### PR TITLE
fix: watch with EnqueueRequestForOwner to avoid multiple reconcile calls

### DIFF
--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -226,10 +226,11 @@ func (r *ISBServiceRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Watch InterStepBufferServices
-	if err := controller.Watch(source.Kind(mgr.GetCache(), &numaflowv1.InterStepBufferService{}), &handler.EnqueueRequestForObject{}, predicate.ResourceVersionChangedPredicate{}); err != nil {
+	if err := controller.Watch(source.Kind(mgr.GetCache(), &numaflowv1.InterStepBufferService{}),
+		handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &apiv1.ISBServiceRollout{}, handler.OnlyControllerOwner()),
+		predicate.ResourceVersionChangedPredicate{}); err != nil {
 		return err
 	}
 
 	return nil
-
 }

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -287,7 +287,9 @@ func (r *PipelineRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Watch Pipelines
-	if err := controller.Watch(source.Kind(mgr.GetCache(), &numaflowv1.Pipeline{}), &handler.EnqueueRequestForObject{}, predicate.ResourceVersionChangedPredicate{}); err != nil {
+	if err := controller.Watch(source.Kind(mgr.GetCache(), &numaflowv1.Pipeline{}),
+		handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &apiv1.PipelineRollout{}, handler.OnlyControllerOwner()),
+		predicate.ResourceVersionChangedPredicate{}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #5 

### Modifications

Using events handler `EnqueueRequestForOwner` with the controller watch when watching for events on the child resources (Pipeline and ISBService). This reduces the number of Reconcile calls to only handle changes related to the owned resource.

### Verification

Manually tested changes and observed that the number of Reconcile calls is reduced for the same operations.