### PR TITLE
fix: avoid error on status update

### DIFF
--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -248,6 +248,16 @@ var _ = Describe("PipelineRollout Controller", func() {
 				return false, nil
 			}, time.Second, interval).Should(BeTrue())
 
+			By("Verifying that the PipelineRollout Status Phase is Running")
+			Consistently(func() (apiv1.Phase, error) {
+				updatedResource := &apiv1.PipelineRollout{}
+				err := k8sClient.Get(ctx, resourceLookupKey, updatedResource)
+				if err != nil {
+					return apiv1.Phase(""), err
+				}
+				return updatedResource.Status.Phase, nil
+			}, duration, interval).Should(Equal(apiv1.PhaseRunning))
+
 			By("Verifying that the same PipelineRollout should not perform and update (no Configuration condition LastTransitionTime change) and the hash spec annotation should not change")
 			Expect(k8sClient.Get(ctx, resourceLookupKey, currentPipelineRollout)).ToNot(HaveOccurred())
 			Expect(k8sClient.Update(ctx, currentPipelineRollout)).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #61 

### Modifications

Implemented `RetryOnConflict` to get the latest version of the resource and update it's status with the status of the in-memory object modified during reconciliation.


### Verification

Running unit tests multiple times will no longer show the error mentioned in the issue.