### PR TITLE
Numaflow Controller Rollout Auto Healing

### DIFF
--- a/internal/controller/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout_controller_test.go
@@ -253,30 +253,9 @@ var _ = Describe("ISBServiceRollout Controller", Ordered, func() {
 
 		})
 
-		It("Should auto heal the InterStepBufferService with the ISBServiceRollout interstepbufferservice spec when the InterStepBufferService spec is changed", func() {
-			By("updating the InterStepBufferService")
-			currentISBService := &numaflowv1.InterStepBufferService{}
-			Expect(k8sClient.Get(ctx, resourceLookupKey, currentISBService)).To(Succeed())
-
-			originalJetstreamVersion := currentISBService.Spec.JetStream.Version
-			newJetstreamVersion := "1.2.3"
-			currentISBService.Spec.JetStream.Version = newJetstreamVersion
-
-			Expect(k8sClient.Update(ctx, currentISBService)).ToNot(HaveOccurred())
-
-			By("Verifying the changed field of the InterStepBufferService is the same as the original and not the modified version")
-			e := Eventually(func() (string, error) {
-				updatedResource := &numaflowv1.InterStepBufferService{}
-				err := k8sClient.Get(ctx, resourceLookupKey, updatedResource)
-				if err != nil {
-					return "", err
-				}
-
-				return updatedResource.Spec.JetStream.Version, nil
-			}, duration, interval)
-
-			e.Should(Equal(originalJetstreamVersion))
-			e.ShouldNot(Equal(newJetstreamVersion))
+		It("Should auto heal the InterStepBufferService with the ISBServiceRollout pipeline spec when the InterStepBufferService spec is changed", func() {
+			By("updating the InterStepBufferService and verifying the changed field is the same as the original and not the modified version")
+			verifyAutoHealing(ctx, numaflowv1.ISBGroupVersionKind, namespace, isbServiceRolloutName, "spec.jetstream.version", "1.2.3.4.5")
 		})
 
 		It("Should delete the ISBServiceRollout and InterStepBufferService", func() {

--- a/internal/controller/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout_controller_test.go
@@ -33,13 +33,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("ISBServiceRollout Controller", func() {
+var _ = Describe("ISBServiceRollout Controller", Ordered, func() {
 	const (
 		namespace             = "default"
 		isbServiceRolloutName = "isbservicerollout-test"
-		timeout               = 10 * time.Second
-		duration              = 10 * time.Second
-		interval              = 250 * time.Millisecond
 	)
 
 	ctx := context.Background()
@@ -268,7 +265,7 @@ var _ = Describe("ISBServiceRollout Controller", func() {
 			Expect(k8sClient.Update(ctx, currentISBService)).ToNot(HaveOccurred())
 
 			By("Verifying the changed field of the InterStepBufferService is the same as the original and not the modified version")
-			e := Consistently(func() (string, error) {
+			e := Eventually(func() (string, error) {
 				updatedResource := &numaflowv1.InterStepBufferService{}
 				err := k8sClient.Get(ctx, resourceLookupKey, updatedResource)
 				if err != nil {

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -36,13 +36,10 @@ import (
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
-var _ = Describe("PipelineRollout Controller", func() {
+var _ = Describe("PipelineRollout Controller", Ordered, func() {
 	const (
 		namespace           = "default"
 		pipelineRolloutName = "pipelinerollout-test"
-		timeout             = 10 * time.Second
-		duration            = 10 * time.Second
-		interval            = 250 * time.Millisecond
 	)
 
 	ctx := context.Background()
@@ -295,7 +292,7 @@ var _ = Describe("PipelineRollout Controller", func() {
 			Expect(k8sClient.Update(ctx, currentPipeline)).ToNot(HaveOccurred())
 
 			By("Verifying the changed field of the Numaflow Pipeline is the same as the original and not the modified version")
-			e := Consistently(func() (string, error) {
+			e := Eventually(func() (string, error) {
 				updatedResource := &numaflowv1.Pipeline{}
 				err := k8sClient.Get(ctx, resourceLookupKey, updatedResource)
 				if err != nil {

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -281,29 +281,8 @@ var _ = Describe("PipelineRollout Controller", Ordered, func() {
 		})
 
 		It("Should auto heal the Numaflow Pipeline with the PipelineRollout pipeline spec when the Numaflow Pipeline spec is changed", func() {
-			By("updating the Numaflow Pipeline")
-			currentPipeline := &numaflowv1.Pipeline{}
-			Expect(k8sClient.Get(ctx, resourceLookupKey, currentPipeline)).To(Succeed())
-
-			originalISBServiceName := currentPipeline.Spec.InterStepBufferServiceName
-			newISBServiceName := "my-isbsvc-updated-in-child"
-			currentPipeline.Spec.InterStepBufferServiceName = newISBServiceName
-
-			Expect(k8sClient.Update(ctx, currentPipeline)).ToNot(HaveOccurred())
-
-			By("Verifying the changed field of the Numaflow Pipeline is the same as the original and not the modified version")
-			e := Eventually(func() (string, error) {
-				updatedResource := &numaflowv1.Pipeline{}
-				err := k8sClient.Get(ctx, resourceLookupKey, updatedResource)
-				if err != nil {
-					return "", err
-				}
-
-				return updatedResource.Spec.InterStepBufferServiceName, nil
-			}, duration, interval)
-
-			e.Should(Equal(originalISBServiceName))
-			e.ShouldNot(Equal(newISBServiceName))
+			By("updating the Numaflow Pipeline and verifying the changed field is the same as the original and not the modified version")
+			verifyAutoHealing(ctx, numaflowv1.PipelineGroupVersionKind, namespace, pipelineRolloutName, "spec.interStepBufferServiceName", "someotherisbsname")
 		})
 
 		It("Should delete the PipelineRollout and Numaflow Pipeline", func() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #19 

### Modifications

Enabled watching of Deployment resource in Numaflow Controller Rollout controller and updated unit test to test reconciliation logic.

### Verification

Tested manually and via unit tests that making changes to the Deployment resource owned by the NumaflowControllerRollout will auto heal by undoing the changes.