### PR TITLE
feat: Create PodDisruptionBudget for each ISBSVC controller

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -824,6 +824,19 @@ rules:
   - deployments
   verbs:
   - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -36,3 +36,6 @@ rules:
       - deployments
     verbs:
       - '*'
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -180,9 +181,34 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 		return err
 	}
 
+	if err = r.applyPodDisruptionBudget(ctx, isbServiceRollout); err != nil {
+		isbServiceRollout.Status.MarkFailed("ApplyISBServiceFailure", err.Error())
+		return fmt.Errorf("failed to apply PodDisruptionBudget for ISBServiceRollout %s, err: %v", isbServiceRollout.Name, err)
+	}
+
 	processISBServiceStatus(ctx, isbsvc, isbServiceRollout)
 
 	isbServiceRollout.Status.MarkRunning()
+
+	return nil
+}
+
+// Apply pod disruption budget for the ISBService
+func (r *ISBServiceRolloutReconciler) applyPodDisruptionBudget(ctx context.Context, isbServiceRollout *apiv1.ISBServiceRollout) error {
+	pdb := kubernetes.NewPodDisruptionBudget(isbServiceRollout.Name, isbServiceRollout.Namespace, 1,
+		[]metav1.OwnerReference{*metav1.NewControllerRef(isbServiceRollout.GetObjectMeta(), apiv1.ISBServiceRolloutGroupVersionKind)},
+	)
+
+	// Create the pdb only if it doesn't exist
+	if err := r.client.Get(ctx, client.ObjectKey{Name: pdb.Name, Namespace: pdb.Namespace}, pdb); err != nil {
+		if apierrors.IsNotFound(err) {
+			if err = r.client.Create(ctx, pdb); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -19,9 +19,11 @@ package controller
 import (
 	"context"
 	"fmt"
+
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
@@ -37,7 +39,6 @@ import (
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #54 

### Modifications

- Create PodDisruptionBudget for each ISBSVC controller

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

Tested in local kind cluster

```bash
$ kubectl get poddisruptionbudgets -A                                                        macos-P9DJ3XY0QL: Tue Jun 25 16:54:47 2024

NAMESPACE           NAME        MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
example-namespace   my-isbsvc   N/A             1                 1                     30m

---------------------------

$ kubectl get po -A                                                                          macos-P9DJ3XY0QL: Tue Jun 25 16:55:00 2024

NAMESPACE            NAME                                            READY   STATUS    RESTARTS        AGE
example-namespace    isbsvc-my-isbsvc-js-0                           3/3     Running   0               30m
example-namespace    isbsvc-my-isbsvc-js-1                           3/3     Running   0               30m
example-namespace    isbsvc-my-isbsvc-js-2                           3/3     Running   0               30m
example-namespace    numaflow-controller-77b5746fc8-474nj            1/1     Running   0               108m
kube-system          coredns-787d4945fb-gxths                        1/1     Running   1 (3h37m ago)   4d3h
kube-system          coredns-787d4945fb-m8298                        1/1     Running   1 (3h37m ago)   4d3h
kube-system          etcd-kind-control-plane                         1/1     Running   1 (3h37m ago)   4d3h
kube-system          kindnet-hcqs4                                   1/1     Running   1 (3h37m ago)   4d3h
kube-system          kube-apiserver-kind-control-plane               1/1     Running   1 (3h37m ago)   4d3h
kube-system          kube-controller-manager-kind-control-plane      1/1     Running   3 (3h37m ago)   4d3h
kube-system          kube-proxy-xxmr9                                1/1     Running   1 (3h37m ago)   4d3h
kube-system          kube-scheduler-kind-control-plane               1/1     Running   3 (3h37m ago)   4d3h
local-path-storage   local-path-provisioner-75f5b54ffd-nzc49         1/1     Running   2 (3h37m ago)   4d3h
numaplane-system     numaplane-controller-manager-5967ccf485-zgh54   1/1     Running   0               38m
```

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->