### PR TITLE
Add callback functionality for the numaplane-controller-config ConfigMap

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -146,6 +146,7 @@ func (cm *ConfigManager) loadGlobalConfig(
 		}
 		cm.config = &newConfig
 
+		// call any registered callbacks
 		for _, f := range cm.callbacks {
 			f(*cm.config)
 		}
@@ -167,6 +168,7 @@ func CloneWithSerialization[T NumaflowControllerDefinitionConfig | GlobalConfig]
 	return &clone, nil
 }
 
+// RegisterCallback adds a callback to be called when the config changes
 func (cm *ConfigManager) RegisterCallback(f func(config GlobalConfig)) {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -12,7 +12,15 @@ import (
 )
 
 type ConfigManager struct {
-	config        *GlobalConfig
+	config *GlobalConfig
+	lock   *sync.RWMutex
+	// if the configmap changes, these callbacks will be called
+	callbacks []func(config GlobalConfig)
+
+	controllerDefMgr ControllerDefinitionsManager
+}
+
+type ControllerDefinitionsManager struct {
 	rolloutConfig map[string]string
 	lock          *sync.RWMutex
 }
@@ -24,12 +32,19 @@ var once sync.Once
 func GetConfigManagerInstance() *ConfigManager {
 	once.Do(func() {
 		instance = &ConfigManager{
-			config:        &GlobalConfig{},
-			rolloutConfig: map[string]string{},
-			lock:          new(sync.RWMutex),
+			config: &GlobalConfig{},
+			lock:   new(sync.RWMutex),
+			controllerDefMgr: ControllerDefinitionsManager{
+				rolloutConfig: map[string]string{},
+				lock:          new(sync.RWMutex),
+			},
 		}
 	})
 	return instance
+}
+
+func (*ConfigManager) GetControllerDefinitionsMgr() *ControllerDefinitionsManager {
+	return &instance.controllerDefMgr
 }
 
 // GlobalConfig is the configuration for the controllers, it is
@@ -55,7 +70,7 @@ func (cm *ConfigManager) GetConfig() (GlobalConfig, error) {
 	return *config, nil
 }
 
-func (cm *ConfigManager) UpdateControllerDefinitionConfig(config NumaflowControllerDefinitionConfig) {
+func (cm *ControllerDefinitionsManager) UpdateControllerDefinitionConfig(config NumaflowControllerDefinitionConfig) {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
 
@@ -65,7 +80,7 @@ func (cm *ConfigManager) UpdateControllerDefinitionConfig(config NumaflowControl
 	}
 }
 
-func (cm *ConfigManager) RemoveControllerDefinitionConfig(config NumaflowControllerDefinitionConfig) {
+func (cm *ControllerDefinitionsManager) RemoveControllerDefinitionConfig(config NumaflowControllerDefinitionConfig) {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
 
@@ -74,7 +89,7 @@ func (cm *ConfigManager) RemoveControllerDefinitionConfig(config NumaflowControl
 	}
 }
 
-func (cm *ConfigManager) GetControllerDefinitionsConfig() map[string]string {
+func (cm *ControllerDefinitionsManager) GetControllerDefinitionsConfig() map[string]string {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
 
@@ -92,7 +107,7 @@ func (cm *ConfigManager) LoadAllConfigs(
 		}
 	}
 	if opts.configFileName != "" {
-		err := cm.loadConfig(onErrorReloading, opts.configsPath, opts.configFileName, opts.fileType)
+		err := cm.loadGlobalConfig(onErrorReloading, opts.configsPath, opts.configFileName, opts.fileType)
 		if err != nil {
 			return err
 		}
@@ -100,7 +115,7 @@ func (cm *ConfigManager) LoadAllConfigs(
 	return nil
 }
 
-func (cm *ConfigManager) loadConfig(
+func (cm *ConfigManager) loadGlobalConfig(
 	onErrorReloading func(error),
 	configsPath, configFileName, configFileType string,
 ) error {
@@ -130,6 +145,10 @@ func (cm *ConfigManager) loadConfig(
 			onErrorReloading(err)
 		}
 		cm.config = &newConfig
+
+		for _, f := range cm.callbacks {
+			f(*cm.config)
+		}
 	})
 	v.WatchConfig()
 
@@ -146,4 +165,11 @@ func CloneWithSerialization[T NumaflowControllerDefinitionConfig | GlobalConfig]
 		return nil, err
 	}
 	return &clone, nil
+}
+
+func (cm *ConfigManager) RegisterCallback(f func(config GlobalConfig)) {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+
+	cm.callbacks = append(cm.callbacks, f)
 }

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -79,7 +79,7 @@ func NewISBServiceRolloutReconciler(
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// update the Base Logger's level according to the Numaplane Config
-	logger.RefreshBaseLoggerLevel()
+	//logger.RefreshBaseLoggerLevel()
 	numaLogger := logger.GetBaseLogger().WithName("isbservicerollout-reconciler").WithValues("isbservicerollout", req.NamespacedName)
 
 	isbServiceRollout := &apiv1.ISBServiceRollout{}

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -78,8 +78,6 @@ func NewISBServiceRolloutReconciler(
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// update the Base Logger's level according to the Numaplane Config
-	//logger.RefreshBaseLoggerLevel()
 	numaLogger := logger.GetBaseLogger().WithName("isbservicerollout-reconciler").WithValues("isbservicerollout", req.NamespacedName)
 
 	isbServiceRollout := &apiv1.ISBServiceRollout{}

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -106,8 +106,6 @@ func NewNumaflowControllerRolloutReconciler(
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// update the Base Logger's level according to the Numaplane Config
-	//logger.RefreshBaseLoggerLevel()
 	numaLogger := logger.GetBaseLogger().WithName("numaflowcontrollerrollout-reconciler").WithValues("numaflowcontrollerrollout", req.NamespacedName)
 
 	// TODO: only allow one controllerRollout per namespace.

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -78,7 +78,6 @@ func NewNumaflowControllerRolloutReconciler(
 	kubectl kubeUtil.Kubectl,
 ) (*NumaflowControllerRolloutReconciler, error) {
 	stateCache := sync.NewLiveStateCache(rawConfig)
-	//logger.RefreshBaseLoggerLevel()
 	numaLogger := logger.GetBaseLogger().WithName("state cache").WithValues("numaflowcontrollerrollout")
 	err := stateCache.Init(numaLogger)
 	if err != nil {

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -78,7 +78,7 @@ func NewNumaflowControllerRolloutReconciler(
 	kubectl kubeUtil.Kubectl,
 ) (*NumaflowControllerRolloutReconciler, error) {
 	stateCache := sync.NewLiveStateCache(rawConfig)
-	logger.RefreshBaseLoggerLevel()
+	//logger.RefreshBaseLoggerLevel()
 	numaLogger := logger.GetBaseLogger().WithName("state cache").WithValues("numaflowcontrollerrollout")
 	err := stateCache.Init(numaLogger)
 	if err != nil {
@@ -107,7 +107,7 @@ func NewNumaflowControllerRolloutReconciler(
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// update the Base Logger's level according to the Numaplane Config
-	logger.RefreshBaseLoggerLevel()
+	//logger.RefreshBaseLoggerLevel()
 	numaLogger := logger.GetBaseLogger().WithName("numaflowcontrollerrollout-reconciler").WithValues("numaflowcontrollerrollout", req.NamespacedName)
 
 	// TODO: only allow one controllerRollout per namespace.
@@ -233,7 +233,7 @@ func (r *NumaflowControllerRolloutReconciler) sync(
 
 	// Get the target manifests based on the version of the controller and throw an error if the definition not for a version.
 	version := rollout.Spec.Controller.Version
-	definition := config.GetConfigManagerInstance().GetControllerDefinitionsConfig()
+	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetControllerDefinitionsConfig()
 	manifest := definition[version]
 	if len(manifest) == 0 {
 		return gitopsSyncCommon.OperationError, fmt.Errorf("no controller definition found for version %s", version)

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -79,8 +79,6 @@ func NewPipelineRolloutReconciler(
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *PipelineRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// update the Base Logger's level according to the Numaplane Config
-	//logger.RefreshBaseLoggerLevel()
 	numaLogger := logger.GetBaseLogger().WithName("pipelinerollout-reconciler").WithValues("pipelinerollout", req.NamespacedName)
 	// update the context with this Logger so downstream users can incorporate these values in the logs
 	ctx = logger.WithLogger(ctx, numaLogger)

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -80,7 +80,7 @@ func NewPipelineRolloutReconciler(
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile
 func (r *PipelineRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// update the Base Logger's level according to the Numaplane Config
-	logger.RefreshBaseLoggerLevel()
+	//logger.RefreshBaseLoggerLevel()
 	numaLogger := logger.GetBaseLogger().WithName("pipelinerollout-reconciler").WithValues("pipelinerollout", req.NamespacedName)
 	// update the context with this Logger so downstream users can incorporate these values in the logs
 	ctx = logger.WithLogger(ctx, numaLogger)
@@ -377,5 +377,6 @@ func applyPipelineSpec(
 		pipelineRollout.Status.MarkFailed("ApplyPipelineFailure", err.Error())
 		return err
 	}
+
 	return nil
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -150,7 +150,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 	Expect(err).ToNot(HaveOccurred())
-	config.GetConfigManagerInstance().UpdateControllerDefinitionConfig(getNumaflowControllerDefinitions())
+	config.GetConfigManagerInstance().GetControllerDefinitionsMgr().UpdateControllerDefinitionConfig(getNumaflowControllerDefinitions())
 
 	err = (&NumaflowControllerRolloutReconciler{
 		client:     k8sManager.GetClient(),

--- a/internal/util/kubernetes/config_watcher.go
+++ b/internal/util/kubernetes/config_watcher.go
@@ -68,9 +68,9 @@ func watchConfigMaps(ctx context.Context, client kubernetes.Interface, namespace
 			}
 			// controller config definition is immutable, so no need to update the existing config
 			if event.Type == watch.Added {
-				config.GetConfigManagerInstance().UpdateControllerDefinitionConfig(controllerConfig)
+				config.GetConfigManagerInstance().GetControllerDefinitionsMgr().UpdateControllerDefinitionConfig(controllerConfig)
 			} else if event.Type == watch.Deleted {
-				config.GetConfigManagerInstance().RemoveControllerDefinitionConfig(controllerConfig)
+				config.GetConfigManagerInstance().GetControllerDefinitionsMgr().RemoveControllerDefinitionConfig(controllerConfig)
 			}
 		}
 	}

--- a/internal/util/kubernetes/config_watcher_test.go
+++ b/internal/util/kubernetes/config_watcher_test.go
@@ -49,7 +49,7 @@ func Test_watchConfigMaps(t *testing.T) {
 	// Wait for the controller to process the ConfigMap
 	time.Sleep(5 * time.Second)
 	// Validate the controller definition config is set correctly
-	definition := config.GetConfigManagerInstance().GetControllerDefinitionsConfig()
+	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetControllerDefinitionsConfig()
 	assert.Len(t, definition, 2)
 
 	// Create the ConfigMap object in the fake clientset
@@ -59,6 +59,6 @@ func Test_watchConfigMaps(t *testing.T) {
 	// Wait for the controller to process the ConfigMap
 	time.Sleep(5 * time.Second)
 	// Validate the controller definition config is updated correctly
-	definition = config.GetConfigManagerInstance().GetControllerDefinitionsConfig()
+	definition = config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetControllerDefinitionsConfig()
 	assert.Len(t, definition, 0)
 }

--- a/internal/util/kubernetes/kubernetes.go
+++ b/internal/util/kubernetes/kubernetes.go
@@ -274,7 +274,7 @@ func ApplyCRSpec(ctx context.Context, restConfig *rest.Config, object *GenericOb
 			if err != nil {
 				return fmt.Errorf("failed to create Resource %s/%s, err=%v", object.Namespace, object.Name, err)
 			}
-			numaLogger.Debugf("successfully created resource %s/%s", object.Namespace, object.Name)
+			numaLogger.Infof("successfully created resource %s/%s", object.Namespace, object.Name)
 		} else {
 			return fmt.Errorf("error attempting to Get resources; GVR=%+v err: %v", gvr, err)
 		}
@@ -299,7 +299,7 @@ func ApplyCRSpec(ctx context.Context, restConfig *rest.Config, object *GenericOb
 		if err != nil {
 			return fmt.Errorf("failed to update Resource %s/%s, err=%v", object.Namespace, object.Name, err)
 		}
-		numaLogger.Debugf("successfully updated resource %s/%s", object.Namespace, object.Name)
+		numaLogger.Infof("successfully updated resource %s/%s", object.Namespace, object.Name)
 
 	}
 	return nil

--- a/internal/util/logger/base_logger.go
+++ b/internal/util/logger/base_logger.go
@@ -31,27 +31,6 @@ func GetBaseLogger() *NumaLogger {
 }
 
 // Refresh the Logger's LogLevel based on current config value
-/*func RefreshBaseLoggerLevel() {
-
-	// get the log level from the config
-	globalConfig, err := config.GetConfigManagerInstance().GetConfig()
-	if err != nil {
-		baseLogger.Error(err, "error getting the global config")
-	}
-
-	// if it changed, propagate it to our Base Logger
-	if globalConfig.LogLevel != baseLogger.LogLevel {
-
-		baseLoggerMutex.Lock()
-		defer baseLoggerMutex.Unlock()
-
-		// update the logger with the new log level
-		baseLogger.SetLevel(globalConfig.LogLevel)
-		baseLogger.Infof("log level=%d\n", globalConfig.LogLevel)
-	}
-}*/
-
-// Refresh the Logger's LogLevel based on current config value
 func refreshBaseLoggerLevel(newConfig config.GlobalConfig) {
 
 	// if it changed, propagate it to our Base Logger

--- a/internal/util/logger/base_logger.go
+++ b/internal/util/logger/base_logger.go
@@ -20,6 +20,7 @@ func SetBaseLogger(nl *NumaLogger) {
 	defer baseLoggerMutex.Unlock()
 
 	baseLogger = nl.DeepCopy()
+	config.GetConfigManagerInstance().RegisterCallback(refreshBaseLoggerLevel)
 }
 
 // Get the standard NumaLogger with current Log Level - deep copy it in case user modifies it
@@ -30,7 +31,7 @@ func GetBaseLogger() *NumaLogger {
 }
 
 // Refresh the Logger's LogLevel based on current config value
-func RefreshBaseLoggerLevel() {
+/*func RefreshBaseLoggerLevel() {
 
 	// get the log level from the config
 	globalConfig, err := config.GetConfigManagerInstance().GetConfig()
@@ -47,5 +48,20 @@ func RefreshBaseLoggerLevel() {
 		// update the logger with the new log level
 		baseLogger.SetLevel(globalConfig.LogLevel)
 		baseLogger.Infof("log level=%d\n", globalConfig.LogLevel)
+	}
+}*/
+
+// Refresh the Logger's LogLevel based on current config value
+func refreshBaseLoggerLevel(newConfig config.GlobalConfig) {
+
+	// if it changed, propagate it to our Base Logger
+	if newConfig.LogLevel != baseLogger.LogLevel {
+
+		baseLoggerMutex.Lock()
+		defer baseLoggerMutex.Unlock()
+
+		// update the logger with the new log level
+		baseLogger.SetLevel(newConfig.LogLevel)
+		baseLogger.Infof("log level=%d\n", newConfig.LogLevel)
 	}
 }

--- a/internal/util/logger/base_logger.go
+++ b/internal/util/logger/base_logger.go
@@ -20,6 +20,7 @@ func SetBaseLogger(nl *NumaLogger) {
 	defer baseLoggerMutex.Unlock()
 
 	baseLogger = nl.DeepCopy()
+	// if the Global ConfigMap changes, update the BaseLogger's log level
 	config.GetConfigManagerInstance().RegisterCallback(refreshBaseLoggerLevel)
 }
 

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -147,6 +147,9 @@ func (in *NumaLogger) DeepCopy() *NumaLogger {
 	}
 	out := new(NumaLogger)
 	out.LogLevel = in.LogLevel
+	if out.LogLevel == 0 {
+		out.LogLevel = InfoLevel
+	}
 	out.LogrLogger = new(logr.Logger)
 	*(out.LogrLogger) = *(in.LogrLogger)
 	return out
@@ -246,6 +249,11 @@ func (nl *NumaLogger) Verbosef(msg string, args ...any) {
 
 // SetLevel sets/changes the log level.
 func (nl *NumaLogger) SetLevel(level int) {
+	// default to INFO level if not defined
+	if level == 0 {
+		level = InfoLevel
+	}
+
 	nl.LogLevel = level
 	sink := nl.LogrLogger.GetSink().(*LogSink)
 	zl := setLoggerLevel(sink.l, level)

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -148,7 +148,7 @@ func (in *NumaLogger) DeepCopy() *NumaLogger {
 	out := new(NumaLogger)
 	out.LogLevel = in.LogLevel
 	if out.LogLevel == 0 {
-		out.LogLevel = InfoLevel
+		out.LogLevel = defaultLevel
 	}
 	out.LogrLogger = new(logr.Logger)
 	*(out.LogrLogger) = *(in.LogrLogger)
@@ -249,9 +249,9 @@ func (nl *NumaLogger) Verbosef(msg string, args ...any) {
 
 // SetLevel sets/changes the log level.
 func (nl *NumaLogger) SetLevel(level int) {
-	// default to INFO level if not defined
+	// default if not defined
 	if level == 0 {
-		level = InfoLevel
+		level = defaultLevel
 	}
 
 	nl.LogLevel = level


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

Currently, we can ask the ConfigManager for the latest version of the ConfigMap. This works when we have a goroutine that's running that needs to get the latest and greatest values.

For cases in which we have some persistent state that's created based on value(s) in the ConfigMap, it could be nice to have a callback called to update that state.

This PR takes care of updating the Base Logger used by Numaplane through a callback.

Other remaining cases include:
- updating the `includedResources` passed to gitops-engine
- updating the Log Level that gitops-engine is using


<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

While running, updated LogLevel=4 (debug) and observed that take effect in the log 