### PR TITLE
Phases

### DIFF
--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -125,7 +125,7 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Update the Status subresource
 	if isbServiceRollout.DeletionTimestamp.IsZero() { // would've already been deleted
-		statusUpdateErr := r.updateISBServiceRolloutStatusToFailed(ctx, isbServiceRollout, err)
+		statusUpdateErr := r.updateISBServiceRolloutStatus(ctx, isbServiceRollout)
 		if statusUpdateErr != nil {
 			return ctrl.Result{}, statusUpdateErr
 		}
@@ -306,7 +306,7 @@ func (r *ISBServiceRolloutReconciler) updateISBServiceRolloutStatus(ctx context.
 		Status:     rawStatus,
 	}
 
-	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "ISBServiceRollouts")
+	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "isbservicerollouts")
 }
 
 func (r *ISBServiceRolloutReconciler) updateISBServiceRolloutStatusToFailed(ctx context.Context, isbServiceRollout *apiv1.ISBServiceRollout, err error) error {

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	runtimecontroller "sigs.k8s.io/controller-runtime/pkg/controller"
@@ -36,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
@@ -98,6 +98,11 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	err := r.reconcile(ctx, isbServiceRollout)
 	if err != nil {
+		statusUpdateErr := r.updateISBServiceRolloutStatusToFailed(ctx, isbServiceRollout, err)
+		if statusUpdateErr != nil {
+			return ctrl.Result{}, statusUpdateErr
+		}
+
 		return ctrl.Result{}, err
 	}
 
@@ -106,6 +111,12 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		isbServiceRolloutStatus := isbServiceRollout.Status
 		if err := r.client.Update(ctx, isbServiceRollout); err != nil {
 			numaLogger.Error(err, "Error Updating ISBServiceRollout", "ISBServiceRollout", isbServiceRollout)
+
+			statusUpdateErr := r.updateISBServiceRolloutStatusToFailed(ctx, isbServiceRollout, err)
+			if statusUpdateErr != nil {
+				return ctrl.Result{}, statusUpdateErr
+			}
+
 			return ctrl.Result{}, err
 		}
 		// restore the original status, which would've been wiped in the previous call to Update()
@@ -114,18 +125,9 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Update the Status subresource
 	if isbServiceRollout.DeletionTimestamp.IsZero() { // would've already been deleted
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			latestISBServiceRollout := &apiv1.ISBServiceRollout{}
-			if err := r.client.Get(ctx, req.NamespacedName, latestISBServiceRollout); err != nil {
-				return err
-			}
-
-			latestISBServiceRollout.Status = isbServiceRollout.Status
-			return r.client.Status().Update(ctx, latestISBServiceRollout)
-		})
-		if err != nil {
-			numaLogger.Error(err, "Error Updating isbServiceRollout Status", "isbServiceRollout", isbServiceRollout)
-			return ctrl.Result{}, err
+		statusUpdateErr := r.updateISBServiceRolloutStatusToFailed(ctx, isbServiceRollout, err)
+		if statusUpdateErr != nil {
+			return ctrl.Result{}, statusUpdateErr
 		}
 	}
 
@@ -169,7 +171,6 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 	err := kubernetes.ApplyCRSpec(ctx, r.restConfig, &obj, "interstepbufferservices")
 	if err != nil {
 		numaLogger.Errorf(err, "failed to apply CR: %v", err)
-		isbServiceRollout.Status.MarkFailed("ApplyISBServiceFailure", err.Error())
 		return err
 	}
 
@@ -181,7 +182,6 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 	}
 
 	if err = r.applyPodDisruptionBudget(ctx, isbServiceRollout); err != nil {
-		isbServiceRollout.Status.MarkFailed("ApplyISBServiceFailure", err.Error())
 		return fmt.Errorf("failed to apply PodDisruptionBudget for ISBServiceRollout %s, err: %v", isbServiceRollout.Name, err)
 	}
 
@@ -284,4 +284,40 @@ func (r *ISBServiceRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return nil
+}
+
+func (r *ISBServiceRolloutReconciler) updateISBServiceRolloutStatus(ctx context.Context, isbServiceRollout *apiv1.ISBServiceRollout) error {
+	rawSpec := runtime.RawExtension{}
+	err := util.StructToStruct(&isbServiceRollout.Spec, &rawSpec)
+	if err != nil {
+		return fmt.Errorf("unable to convert ISBServiceRollout Spec to GenericObject Spec: %v", err)
+	}
+
+	rawStatus := runtime.RawExtension{}
+	err = util.StructToStruct(&isbServiceRollout.Status, &rawStatus)
+	if err != nil {
+		return fmt.Errorf("unable to convert ISBServiceRollout Status to GenericObject Status: %v", err)
+	}
+
+	obj := kubernetes.GenericObject{
+		TypeMeta:   isbServiceRollout.TypeMeta,
+		ObjectMeta: isbServiceRollout.ObjectMeta,
+		Spec:       rawSpec,
+		Status:     rawStatus,
+	}
+
+	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "ISBServiceRollouts")
+}
+
+func (r *ISBServiceRolloutReconciler) updateISBServiceRolloutStatusToFailed(ctx context.Context, isbServiceRollout *apiv1.ISBServiceRollout, err error) error {
+	numaLogger := logger.FromContext(ctx)
+
+	isbServiceRollout.Status.MarkFailed(isbServiceRollout.Generation, err.Error())
+
+	statusUpdateErr := r.updateISBServiceRolloutStatus(ctx, isbServiceRollout)
+	if statusUpdateErr != nil {
+		numaLogger.Error(statusUpdateErr, "Error updating ISBServiceRollout status", "namespace", isbServiceRollout.Namespace, "name", isbServiceRollout.Name)
+	}
+
+	return statusUpdateErr
 }

--- a/internal/controller/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout_controller_test.go
@@ -96,15 +96,8 @@ var _ = Describe("ISBServiceRollout Controller", Ordered, func() {
 			Expect(createdISBResource.Spec).Should(Equal(isbsSpec))
 		})
 
-		It("Should have the ISBServiceRollout Status Phase as Deployed", func() {
-			Consistently(func() (apiv1.Phase, error) {
-				createdISBResource := &apiv1.ISBServiceRollout{}
-				err := k8sClient.Get(ctx, resourceLookupKey, createdISBResource)
-				if err != nil {
-					return apiv1.Phase(""), err
-				}
-				return createdISBResource.Status.Phase, nil
-			}, timeout, interval).Should(Equal(apiv1.PhaseDeployed))
+		It("Should have the ISBServiceRollout Status Phase as Deployed and ObservedGeneration matching Generation", func() {
+			verifyStatusPhase(ctx, apiv1.ISBServiceRolloutGroupVersionKind, namespace, isbServiceRolloutName, apiv1.PhaseDeployed)
 		})
 
 		It("Should have created an PodDisruptionBudget for ISB ", func() {
@@ -204,15 +197,8 @@ var _ = Describe("ISBServiceRollout Controller", Ordered, func() {
 				return false, nil
 			}, timeout, interval).Should(BeTrue())
 
-			By("Verifying that the ISBServiceRollout Status Phase is Deployed")
-			Consistently(func() (apiv1.Phase, error) {
-				updatedResource := &apiv1.ISBServiceRollout{}
-				err := k8sClient.Get(ctx, resourceLookupKey, updatedResource)
-				if err != nil {
-					return apiv1.Phase(""), err
-				}
-				return updatedResource.Status.Phase, nil
-			}, timeout, interval).Should(Equal(apiv1.PhaseDeployed))
+			By("Verifying that the ISBServiceRollout Status Phase is Deployed and ObservedGeneration matches Generation")
+			verifyStatusPhase(ctx, apiv1.ISBServiceRolloutGroupVersionKind, namespace, isbServiceRolloutName, apiv1.PhaseDeployed)
 
 			By("Verifying that the same ISBServiceRollout should not perform and update (no Configuration condition LastTransitionTime change)")
 			Expect(k8sClient.Get(ctx, resourceLookupKey, currentISBServiceRollout)).ToNot(HaveOccurred())

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -457,7 +457,7 @@ func (r *NumaflowControllerRolloutReconciler) processNumaflowControllerStatus(ct
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "numaflow-controller",
+			Name:      NumaflowControllerDeploymentName,
 			Namespace: controllerRollout.Namespace,
 		},
 	}

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -395,18 +395,12 @@ func processPipelineStatus(ctx context.Context, pipeline *kubernetes.GenericObje
 
 	numaLogger.Debugf("pipeline status: %+v", pipelineStatus)
 
-	// TODO: make string comparison instead of using numaflowv1 import (it defeats the purpose of having RawExtension).
-	// Create a function to convert/parse/check string instead of numaflowv1.Phase
-	// Do this for all 3 controllers
-
 	pipelinePhase := numaflowv1.PipelinePhase(pipelineStatus.Phase)
 	switch pipelinePhase {
 	case numaflowv1.PipelinePhaseFailed:
 		pipelineRollout.Status.MarkChildResourcesUnhealthy("PipelineFailed", "Pipeline Failed", pipelineRollout.Generation)
 	case numaflowv1.PipelinePhasePaused, numaflowv1.PipelinePhasePausing:
-		// TODO: update string(pipelinePhase) when working on strng comparison changes
-		pipelineRollout.Status.MarkPipelinePausingOrPausedWithReason(string(pipelinePhase), pipelineRollout.Generation)
-
+		pipelineRollout.Status.MarkPipelinePausingOrPausedWithReason(fmt.Sprintf("Pipeline%s", string(pipelinePhase)), pipelineRollout.Generation)
 		setPipelineHealthStatus(pipeline, pipelineRollout, pipelineStatus.ObservedGeneration)
 	case numaflowv1.PipelinePhaseUnknown:
 		pipelineRollout.Status.MarkChildResourcesHealthUnknown("PipelineUnknown", "Pipeline Phase Unknown", pipelineRollout.Generation)

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -330,7 +330,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 		}
 		newPipelineDef = *newObj
 
-		err = applyPipelineSpec(ctx, r.restConfig, &newPipelineDef, pipelineRollout)
+		err = applyPipelineSpec(ctx, r.restConfig, &newPipelineDef)
 		if err != nil {
 			return false, err
 		}
@@ -352,7 +352,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 		}
 		newPipelineDef = *newObj
 
-		err = applyPipelineSpec(ctx, r.restConfig, &newPipelineDef, pipelineRollout)
+		err = applyPipelineSpec(ctx, r.restConfig, &newPipelineDef)
 		if err != nil {
 			return false, err
 		}
@@ -360,7 +360,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 	}
 
 	// If no need to pause, just apply the spec
-	err = applyPipelineSpec(ctx, r.restConfig, &newPipelineDef, pipelineRollout)
+	err = applyPipelineSpec(ctx, r.restConfig, &newPipelineDef)
 	if err != nil {
 		return false, err
 	}
@@ -491,7 +491,6 @@ func applyPipelineSpec(
 	ctx context.Context,
 	restConfig *rest.Config,
 	obj *kubernetes.GenericObject,
-	pipelineRollout *apiv1.PipelineRollout,
 ) error {
 	numaLogger := logger.FromContext(ctx)
 

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -166,7 +166,7 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 
 	// Update the Status subresource
 	if pipelineRollout.DeletionTimestamp.IsZero() { // would've already been deleted
-		statusUpdateErr := r.updatePipelineRolloutStatusToFailed(ctx, pipelineRollout, err)
+		statusUpdateErr := r.updatePipelineRolloutStatus(ctx, pipelineRollout)
 		if statusUpdateErr != nil {
 			return ctrl.Result{}, statusUpdateErr
 		}

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -132,15 +132,8 @@ var _ = Describe("PipelineRollout Controller", Ordered, func() {
 			Expect(createdResource.Spec).Should(Equal(pipelineSpec))
 		})
 
-		It("Should have the PipelineRollout Status Phase has Deployed", func() {
-			Consistently(func() (apiv1.Phase, error) {
-				createdResource := &apiv1.PipelineRollout{}
-				err := k8sClient.Get(ctx, resourceLookupKey, createdResource)
-				if err != nil {
-					return apiv1.Phase(""), err
-				}
-				return createdResource.Status.Phase, nil
-			}, duration, interval).Should(Equal(apiv1.PhaseDeployed))
+		It("Should have the PipelineRollout Status Phase has Deployed and ObservedGeneration matching Generation", func() {
+			verifyStatusPhase(ctx, apiv1.PipelineRolloutGroupVersionKind, namespace, pipelineRolloutName, apiv1.PhaseDeployed)
 		})
 
 		It("Should update the PipelineRollout and Numaflow Pipeline", func() {
@@ -218,15 +211,8 @@ var _ = Describe("PipelineRollout Controller", Ordered, func() {
 				return false, nil
 			}, timeout, interval).Should(BeTrue())
 
-			By("Verifying that the PipelineRollout Status Phase is Deployed")
-			Consistently(func() (apiv1.Phase, error) {
-				updatedResource := &apiv1.PipelineRollout{}
-				err := k8sClient.Get(ctx, resourceLookupKey, updatedResource)
-				if err != nil {
-					return apiv1.Phase(""), err
-				}
-				return updatedResource.Status.Phase, nil
-			}, duration, interval).Should(Equal(apiv1.PhaseDeployed))
+			By("Verifying that the PipelineRollout Status Phase is Deployed and ObservedGeneration matches Generation")
+			verifyStatusPhase(ctx, apiv1.PipelineRolloutGroupVersionKind, namespace, pipelineRolloutName, apiv1.PhaseDeployed)
 
 			By("Verifying that the same PipelineRollout should not perform and update (no Configuration condition LastTransitionTime change)")
 			Expect(k8sClient.Get(ctx, resourceLookupKey, currentPipelineRollout)).ToNot(HaveOccurred())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -253,3 +253,42 @@ func verifyAutoHealing(ctx context.Context, gvk schema.GroupVersionKind, namespa
 	e.Should(Equal(originalValue))
 	e.ShouldNot(Equal(newValue))
 }
+
+func verifyStatusPhase(ctx context.Context, gvk schema.GroupVersionKind, namespace string, resourceName string, desiredPhase apiv1.Phase) {
+	lookupKey := types.NamespacedName{Name: resourceName, Namespace: namespace}
+
+	currentResource := unstructured.Unstructured{}
+	currentResource.SetGroupVersionKind(gvk)
+	Consistently(func() (bool, error) {
+		err := k8sClient.Get(ctx, lookupKey, &currentResource)
+		if err != nil {
+			return false, err
+		}
+
+		phase, found, err := unstructured.NestedString(currentResource.Object, "status", "phase")
+		if err != nil {
+			return false, err
+		}
+		if !found {
+			return false, nil
+		}
+
+		observedGeneration, found, err := unstructured.NestedInt64(currentResource.Object, "status", "observedGeneration")
+		if err != nil {
+			return false, err
+		}
+		if !found {
+			return false, nil
+		}
+
+		generation, found, err := unstructured.NestedInt64(currentResource.Object, "metadata", "generation")
+		if err != nil {
+			return false, err
+		}
+		if !found {
+			return false, nil
+		}
+
+		return apiv1.Phase(phase) == desiredPhase && observedGeneration == generation, nil
+	}, duration, interval).Should(BeTrue())
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,17 @@
+package util
+
+import "encoding/json"
+
+func StructToStruct(src any, dest any) error {
+	jsonBytes, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(jsonBytes, dest)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #103 

### Modifications

- Updated controllers to include setting the status phase as Failed in case of reconciliation errors.
- Created reusable functions for: resource status update, struct-to-struct conversion, GroupVersionResource computation.
- Added ObservedGeneration on status when updating phase.

### Verification

Added some extra unit tests. Done manual tests to check ObservedGeneration and Phase. Unable to test failure cases.