### PR TITLE
remove rate limiting from initial PipelineRollout.Reconcile() call

### DIFF
--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -117,7 +117,7 @@ func (r *PipelineRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	numaLogger := logger.GetBaseLogger().WithName(loggerName).WithValues("pipelinerollout", req.NamespacedName)
 
 	namespacedName := namespacedNameToKey(req.NamespacedName)
-	r.queue.AddRateLimited(namespacedName)
+	r.queue.Add(namespacedName)
 	numaLogger.Debugf("added PipelineRollout %v to queue", namespacedName)
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #115 

### Modifications

`PipelineRollout.Reconcile()` is using a queue with a [default Controller Rate Limiter](https://github.com/numaproj/numaplane/blob/main/internal/util/queue.go#L20) which does exponential backoff. `Reconcile()` was adding to this queue calling `queue.AddRateLimited()`. If `Reconcile()` is called too many times in a row, the PipelineRollout gets delayed further and further.

After thinking about it, I don't think we need to add any delays for the initial reconciliation. 

### Verification

Removing this seems to resolve the issue, based on @afugazzotto's testing.