### PR TITLE
Status Update Error Requeue and Bug Fix

### DIFF
--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -104,7 +104,7 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if err != nil {
 		statusUpdateErr := r.updateISBServiceRolloutStatusToFailed(ctx, isbServiceRollout, err)
 		if statusUpdateErr != nil {
-			return ctrl.Result{}, statusUpdateErr
+			return ctrl.Result{RequeueAfter: statusUpdateErrorRequeueAfterDuration}, statusUpdateErr
 		}
 
 		return ctrl.Result{}, err
@@ -118,7 +118,7 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 			statusUpdateErr := r.updateISBServiceRolloutStatusToFailed(ctx, isbServiceRollout, err)
 			if statusUpdateErr != nil {
-				return ctrl.Result{}, statusUpdateErr
+				return ctrl.Result{RequeueAfter: statusUpdateErrorRequeueAfterDuration}, statusUpdateErr
 			}
 
 			return ctrl.Result{}, err
@@ -131,7 +131,7 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if isbServiceRollout.DeletionTimestamp.IsZero() { // would've already been deleted
 		statusUpdateErr := r.updateISBServiceRolloutStatus(ctx, isbServiceRollout)
 		if statusUpdateErr != nil {
-			return ctrl.Result{}, statusUpdateErr
+			return ctrl.Result{RequeueAfter: statusUpdateErrorRequeueAfterDuration}, statusUpdateErr
 		}
 	}
 

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -135,7 +135,7 @@ func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req
 	if err != nil {
 		statusUpdateErr := r.updateNumaflowControllerRolloutStatusToFailed(ctx, numaflowControllerRollout, err)
 		if statusUpdateErr != nil {
-			return ctrl.Result{}, statusUpdateErr
+			return ctrl.Result{RequeueAfter: statusUpdateErrorRequeueAfterDuration}, statusUpdateErr
 		}
 
 		return ctrl.Result{}, err
@@ -149,7 +149,7 @@ func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req
 
 			statusUpdateErr := r.updateNumaflowControllerRolloutStatusToFailed(ctx, numaflowControllerRollout, err)
 			if statusUpdateErr != nil {
-				return ctrl.Result{}, statusUpdateErr
+				return ctrl.Result{RequeueAfter: statusUpdateErrorRequeueAfterDuration}, statusUpdateErr
 			}
 
 			return ctrl.Result{}, err
@@ -162,7 +162,7 @@ func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req
 	if numaflowControllerRollout.DeletionTimestamp.IsZero() { // would've already been deleted
 		statusUpdateErr := r.updateNumaflowControllerRolloutStatus(ctx, numaflowControllerRollout)
 		if statusUpdateErr != nil {
-			return ctrl.Result{}, statusUpdateErr
+			return ctrl.Result{RequeueAfter: statusUpdateErrorRequeueAfterDuration}, statusUpdateErr
 		}
 	}
 

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -148,7 +148,7 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 	if err != nil {
 		statusUpdateErr := r.updatePipelineRolloutStatusToFailed(ctx, pipelineRollout, err)
 		if statusUpdateErr != nil {
-			return ctrl.Result{}, statusUpdateErr
+			return ctrl.Result{RequeueAfter: statusUpdateErrorRequeueAfterDuration}, statusUpdateErr
 		}
 
 		return ctrl.Result{}, err
@@ -159,7 +159,7 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 	if err != nil {
 		statusUpdateErr := r.updatePipelineRolloutStatusToFailed(ctx, pipelineRollout, err)
 		if statusUpdateErr != nil {
-			return ctrl.Result{}, statusUpdateErr
+			return ctrl.Result{RequeueAfter: statusUpdateErrorRequeueAfterDuration}, statusUpdateErr
 		}
 
 		return ctrl.Result{}, err
@@ -173,7 +173,7 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 
 			statusUpdateErr := r.updatePipelineRolloutStatusToFailed(ctx, pipelineRollout, err)
 			if statusUpdateErr != nil {
-				return ctrl.Result{}, statusUpdateErr
+				return ctrl.Result{RequeueAfter: statusUpdateErrorRequeueAfterDuration}, statusUpdateErr
 			}
 
 			return ctrl.Result{}, err
@@ -186,7 +186,7 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 	if pipelineRollout.DeletionTimestamp.IsZero() { // would've already been deleted
 		statusUpdateErr := r.updatePipelineRolloutStatus(ctx, pipelineRollout)
 		if statusUpdateErr != nil {
-			return ctrl.Result{}, statusUpdateErr
+			return ctrl.Result{RequeueAfter: statusUpdateErrorRequeueAfterDuration}, statusUpdateErr
 		}
 	}
 

--- a/internal/controller/shared.go
+++ b/internal/controller/shared.go
@@ -1,0 +1,5 @@
+package controller
+
+import "time"
+
+const statusUpdateErrorRequeueAfterDuration = 3 * time.Second

--- a/tests/manifests/kustomization.yaml
+++ b/tests/manifests/kustomization.yaml
@@ -23,6 +23,5 @@ configMapGenerator:
   namespace: numaplane-system
   files:
     - controller_definitions.yaml
-  behavior: merge  # Optional, defaults to "create"
   options:
     immutable: true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

- On status update error, requeue the reconcile key to retry.
- BugFix on kustomization file for following error:
```
> kubectl kustomize tests/manifests | sed 's@quay.io/numaproj/@quay.io/numaproj/@' | sed 's/numaplane-controller:latest/numaplane-controller:latest/' | kubectl apply -f -

error: merging from generator &{0xc0013029c0 <nil>}: id resid.ResId{Gvk:resid.Gvk{Group:"", Version:"v1", Kind:"ConfigMap", isClusterScoped:false}, Name:"numaflow-controller-definitions-config", Namespace:"numaplane-system"} does not exist; cannot merge or replace
```
