### PR TITLE
Fixing security vulnerabilities Present in Quay.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.21 as builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG KUSTOMIZE_VERSION="v5.3.0"
-ARG HELM_VERSION="v3.13.2"
+ARG HELM_VERSION="v3.15.3"
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Yes

Fixes https://github.com/numaproj/numaplane/issues/82

### Modifications

According to the quay.io scan, the vulnerability was caused by the layer that was copying Helm into the Docker image. I have upgraded the Helm version to the recent v3.15.3 in the Dockerfile, which seems to have fixed the issue.

### Verification

The Quay.io scanner does not show the security vulnerability anymore. There are two unknown security issues that I still need to work on.
<img width="1277" alt="Screenshot 2024-07-22 at 5 24 42 PM" src="https://github.com/user-attachments/assets/3dce6cb7-2991-473c-975a-bacc088a4193">


