### PR TITLE
Set pipeline pausing condition back to False after resuming a pipeline

### DIFF
--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -416,6 +416,8 @@ func (r *PipelineRolloutReconciler) processPipelineStatus(ctx context.Context, p
 
 	numaLogger.Debugf("pipeline status: %+v", pipelineStatus)
 
+	pipelineRollout.Status.MarkPipelineUnpaused(pipelineDef.Generation)
+
 	pipelinePhase := numaflowv1.PipelinePhase(pipelineStatus.Phase)
 	switch pipelinePhase {
 	case numaflowv1.PipelinePhaseFailed:

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -416,14 +416,14 @@ func (r *PipelineRolloutReconciler) processPipelineStatus(ctx context.Context, p
 
 	numaLogger.Debugf("pipeline status: %+v", pipelineStatus)
 
-	pipelineRollout.Status.MarkPipelineUnpaused(pipelineDef.Generation)
-
 	pipelinePhase := numaflowv1.PipelinePhase(pipelineStatus.Phase)
 	switch pipelinePhase {
 	case numaflowv1.PipelinePhaseFailed:
 		pipelineRollout.Status.MarkChildResourcesUnhealthy("PipelineFailed", "Pipeline Failed", pipelineRollout.Generation)
 	case numaflowv1.PipelinePhasePaused, numaflowv1.PipelinePhasePausing:
-		pipelineRollout.Status.MarkPipelinePausingOrPaused(fmt.Sprintf("Pipeline %s", string(pipelinePhase)), pipelineRollout.Generation)
+		reason := fmt.Sprintf("Pipeline%s", string(pipelinePhase))
+		msg := fmt.Sprintf("Pipeline %s", strings.ToLower(string(pipelinePhase)))
+		pipelineRollout.Status.MarkPipelinePausingOrPaused(reason, msg, pipelineRollout.Generation)
 		setPipelineHealthStatus(existingPipelineDef, pipelineRollout, pipelineStatus.ObservedGeneration)
 	case numaflowv1.PipelinePhaseUnknown:
 		pipelineRollout.Status.MarkChildResourcesHealthUnknown("PipelineUnknown", "Pipeline Phase Unknown", pipelineRollout.Generation)
@@ -431,6 +431,7 @@ func (r *PipelineRolloutReconciler) processPipelineStatus(ctx context.Context, p
 		pipelineRollout.Status.MarkChildResourcesUnhealthy("PipelineDeleting", "Pipeline Deleting", pipelineRollout.Generation)
 	default:
 		setPipelineHealthStatus(existingPipelineDef, pipelineRollout, pipelineStatus.ObservedGeneration)
+		pipelineRollout.Status.MarkPipelineUnpaused(pipelineDef.Generation)
 	}
 
 	return nil

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -423,7 +423,7 @@ func (r *PipelineRolloutReconciler) processPipelineStatus(ctx context.Context, p
 	case numaflowv1.PipelinePhaseFailed:
 		pipelineRollout.Status.MarkChildResourcesUnhealthy("PipelineFailed", "Pipeline Failed", pipelineRollout.Generation)
 	case numaflowv1.PipelinePhasePaused, numaflowv1.PipelinePhasePausing:
-		pipelineRollout.Status.MarkPipelinePausingOrPausedWithReason(fmt.Sprintf("Pipeline%s", string(pipelinePhase)), pipelineRollout.Generation)
+		pipelineRollout.Status.MarkPipelinePausingOrPaused(fmt.Sprintf("Pipeline %s", string(pipelinePhase)), pipelineRollout.Generation)
 		setPipelineHealthStatus(existingPipelineDef, pipelineRollout, pipelineStatus.ObservedGeneration)
 	case numaflowv1.PipelinePhaseUnknown:
 		pipelineRollout.Status.MarkChildResourcesHealthUnknown("PipelineUnknown", "Pipeline Phase Unknown", pipelineRollout.Generation)

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -73,5 +73,5 @@ func (status *PipelineRolloutStatus) MarkPipelinePausingOrPaused(reason, message
 }
 
 func (status *PipelineRolloutStatus) MarkPipelineUnpaused(generation int64) {
-	status.MarkFalse(ConditionPipelinePausingOrPaused, "Unpaused", "Pipeline Unpaused", generation)
+	status.MarkFalse(ConditionPipelinePausingOrPaused, "Unpaused", "Pipeline unpaused", generation)
 }

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -68,12 +68,10 @@ func init() {
 	SchemeBuilder.Register(&PipelineRollout{}, &PipelineRolloutList{})
 }
 
-// NOTE: not setting a reason to avoid changing the LastTransitionTime based on reason change between pausing and unpausing of the pipeline
-func (status *PipelineRolloutStatus) MarkPipelinePausingOrPaused(message string, generation int64) {
-	status.MarkTrueWithReason(ConditionPipelinePausingOrPaused, "", message, generation)
+func (status *PipelineRolloutStatus) MarkPipelinePausingOrPaused(reason, message string, generation int64) {
+	status.MarkTrueWithReason(ConditionPipelinePausingOrPaused, reason, message, generation)
 }
 
-// NOTE: not setting a reason to avoid changing the LastTransitionTime based on reason change between pausing and unpausing of the pipeline
 func (status *PipelineRolloutStatus) MarkPipelineUnpaused(generation int64) {
-	status.MarkFalse(ConditionPipelinePausingOrPaused, "", "", generation)
+	status.MarkFalse(ConditionPipelinePausingOrPaused, "Unpaused", "Pipeline Unpaused", generation)
 }

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -68,14 +68,12 @@ func init() {
 	SchemeBuilder.Register(&PipelineRollout{}, &PipelineRolloutList{})
 }
 
-func (status *PipelineRolloutStatus) MarkPipelinePausingOrPaused(generation int64) {
-	status.MarkTrue(ConditionPipelinePausingOrPaused, generation)
+// NOTE: not setting a reason to avoid changing the LastTransitionTime based on reason change between pausing and unpausing of the pipeline
+func (status *PipelineRolloutStatus) MarkPipelinePausingOrPaused(message string, generation int64) {
+	status.MarkTrueWithReason(ConditionPipelinePausingOrPaused, "", message, generation)
 }
 
-func (status *PipelineRolloutStatus) MarkPipelinePausingOrPausedWithReason(reason string, generation int64) {
-	status.MarkTrueWithReason(ConditionPipelinePausingOrPaused, reason, "", generation)
-}
-
+// NOTE: not setting a reason to avoid changing the LastTransitionTime based on reason change between pausing and unpausing of the pipeline
 func (status *PipelineRolloutStatus) MarkPipelineUnpaused(generation int64) {
 	status.MarkFalse(ConditionPipelinePausingOrPaused, "", "", generation)
 }

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -68,10 +68,14 @@ func init() {
 	SchemeBuilder.Register(&PipelineRollout{}, &PipelineRolloutList{})
 }
 
-func (status *PipelineRolloutStatus) MarkPipelinePausingOrPaused(observedGeneration int64) {
-	status.MarkTrue(ConditionPipelinePausingOrPaused, observedGeneration)
+func (status *PipelineRolloutStatus) MarkPipelinePausingOrPaused(generation int64) {
+	status.MarkTrue(ConditionPipelinePausingOrPaused, generation)
 }
 
-func (status *PipelineRolloutStatus) MarkPipelinePausingOrPausedWithReason(reason string, observedGeneration int64) {
-	status.MarkTrueWithReason(ConditionPipelinePausingOrPaused, reason, "", observedGeneration)
+func (status *PipelineRolloutStatus) MarkPipelinePausingOrPausedWithReason(reason string, generation int64) {
+	status.MarkTrueWithReason(ConditionPipelinePausingOrPaused, reason, "", generation)
+}
+
+func (status *PipelineRolloutStatus) MarkPipelineUnpaused(generation int64) {
+	status.MarkFalse(ConditionPipelinePausingOrPaused, "", "", generation)
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #114 

### Modifications

Mark pipeline rollout status to unpaused if a pipeline is not in pausing state (only on running or succeeded).

### Verification

Unable to fully test at this time due to auto-healing enabled and not excluding changes to the lifecycle field. Was able to test by setting the lifecycle field in the rollout directly and then removing it.