### PR TITLE
Added Callback to the StateCache For Post Global Config Change

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -181,7 +181,6 @@ func main() {
 		kubectl,
 		customMetrics,
 	)
-
 	if err != nil {
 		numaLogger.Fatal(err, "Unable to create NumaflowControllerRollout controller")
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+
 	"github.com/numaproj/numaplane/internal/controller"
 	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
@@ -180,6 +181,7 @@ func main() {
 		kubectl,
 		customMetrics,
 	)
+
 	if err != nil {
 		numaLogger.Fatal(err, "Unable to create NumaflowControllerRollout controller")
 	}

--- a/internal/sync/cache.go
+++ b/internal/sync/cache.go
@@ -361,6 +361,10 @@ func (c *liveStateCache) Init(numaLogger *logger.NumaLogger) error {
 		return fmt.Errorf("error on init live state cache: %w", err)
 	}
 	c.cacheSettings = *setting
+	// Register the callback for configuration changes
+	controllerConfig.GetConfigManagerInstance().RegisterCallback(func(config controllerConfig.GlobalConfig) {
+		c.getCluster()
+	})
 	return nil
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->
Yes

Fixes (https://github.com/numaproj/numaplane/issues/10)

### Modifications

While initializing the LiveState Cache in the `Init` method, a callback is registered that calls the `getCluster` method to update the cache. This ensures that changes in configuration, such as `includedResources` and `logLevel`, are dynamically applied, keeping the cache current.

### Verification

Todo