### PR TITLE
feat: introduce aggregate roles

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -808,6 +808,92 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: numaplane-aggregate-to-admin
+rules:
+- apiGroups:
+  - numaplane.numaproj.io
+  resources:
+  - pipelinerollouts
+  - isbservicerollouts
+  - numaflowcontrollerrollouts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - numaplane.numaproj.io
+  resources:
+  - pipelinerollouts/status
+  - isbservicerollouts/status
+  - numaflowcontrollerrollouts/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: numaplane-aggregate-to-edit
+rules:
+- apiGroups:
+  - numaplane.numaproj.io
+  resources:
+  - pipelinerollouts
+  - isbservicerollouts
+  - numaflowcontrollerrollouts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - numaplane.numaproj.io
+  resources:
+  - pipelinerollouts/status
+  - isbservicerollouts/status
+  - numaflowcontrollerrollouts/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: numaplane-aggregate-to-view
+rules:
+- apiGroups:
+  - numaplane.numaproj.io
+  resources:
+  - pipelinerollouts
+  - isbservicerollouts
+  - numaflowcontrollerrollouts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - numaplane.numaproj.io
+  resources:
+  - pipelinerollouts/status
+  - isbservicerollouts/status
+  - numaflowcontrollerrollouts/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: numaplane-role
 rules:
 - apiGroups:

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -13,3 +13,6 @@ resources:
   - numaflowcontrollerrollout_viewer_role.yaml
   - isbservicerollout_editor_role.yaml
   - isbservicerollout_viewer_role.yaml
+  - numaplane-aggregate-to-admin.yaml
+  - numaplane-aggregate-to-edit.yaml
+  - numaplane-aggregate-to-view.yaml

--- a/config/rbac/numaplane-aggregate-to-admin.yaml
+++ b/config/rbac/numaplane-aggregate-to-admin.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: numaplane-aggregate-to-admin
+rules:
+  - apiGroups:
+    - numaplane.numaproj.io
+    resources:
+    - pipelinerollouts
+    - isbservicerollouts
+    - numaflowcontrollerrollouts
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - numaplane.numaproj.io
+    resources:
+    - pipelinerollouts/status
+    - isbservicerollouts/status
+    - numaflowcontrollerrollouts/status
+    verbs:
+    - get
+    
+  

--- a/config/rbac/numaplane-aggregate-to-edit.yaml
+++ b/config/rbac/numaplane-aggregate-to-edit.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: numaplane-aggregate-to-edit
+rules:
+  - apiGroups:
+    - numaplane.numaproj.io
+    resources:
+    - pipelinerollouts
+    - isbservicerollouts
+    - numaflowcontrollerrollouts
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - numaplane.numaproj.io
+    resources:
+    - pipelinerollouts/status
+    - isbservicerollouts/status
+    - numaflowcontrollerrollouts/status
+    verbs:
+    - get

--- a/config/rbac/numaplane-aggregate-to-view.yaml
+++ b/config/rbac/numaplane-aggregate-to-view.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: numaplane-aggregate-to-view
+rules:
+  - apiGroups:
+    - numaplane.numaproj.io
+    resources:
+    - pipelinerollouts
+    - isbservicerollouts
+    - numaflowcontrollerrollouts
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - numaplane.numaproj.io
+    resources:
+    - pipelinerollouts/status
+    - isbservicerollouts/status
+    - numaflowcontrollerrollouts/status
+    verbs:
+    - get


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

Introduces aggregate roles for admin, editor and viewer.

These follow the same formatting as Numaflow's roles defined [here](https://github.com/numaproj/numaflow/tree/main/config/cluster-install/rbac/controller-manager)

### Verification

Ran `make start` to see that roles have been created properly