### PR TITLE
Pause feature - address remaining comments and more

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: example-namespace
 spec:
   controller:
-    version: "0.0.2" #numaio-rc-0.0.2
+    version: "0.0.7" #numaio-rc-0.0.7

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -239,7 +239,7 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 	return ctrl.Result{}, nil
 }
 
-func (r *ISBServiceRolloutReconciler) getChildType() string {
+func (r *ISBServiceRolloutReconciler) getChildTypeString() string {
 	return "interstepbufferservice"
 }
 
@@ -282,7 +282,9 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 	}
 
 	if common.DataLossPrevention {
-		return processChildObjectWithoutDataLoss(ctx, isbServiceRollout.Namespace, isbServiceRollout.Name, r, newISBServiceDef, isbServiceNeedsUpdating, isbServiceIsUpdating)
+		return processChildObjectWithoutDataLoss(ctx, isbServiceRollout.Namespace, isbServiceRollout.Name, r, isbServiceNeedsUpdating, isbServiceIsUpdating, func() error {
+			return kubernetes.UpdateCR(ctx, r.restConfig, newISBServiceDef, "interstepbufferservices")
+		})
 	} else {
 		// update ISBService
 		err = kubernetes.UpdateCR(ctx, r.restConfig, newISBServiceDef, "interstepbufferservices")
@@ -296,9 +298,10 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 	return false, nil
 }
 
+/*
 func (r *ISBServiceRolloutReconciler) updateResource(ctx context.Context, rolloutNamespace string, rolloutName string, resourceDefinition *kubernetes.GenericObject) error {
 	return kubernetes.UpdateCR(ctx, r.restConfig, resourceDefinition, "interstepbufferservices")
-}
+}*/
 
 func (r *ISBServiceRolloutReconciler) markRolloutPaused(ctx context.Context, rolloutNamespace string, rolloutName string, paused bool) error {
 	isbServiceRollout := &apiv1.ISBServiceRollout{}

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -238,6 +238,7 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 	return ctrl.Result{}, nil
 }
 
+// for the purpose of logging
 func (r *ISBServiceRolloutReconciler) getChildTypeString() string {
 	return "interstepbufferservice"
 }
@@ -326,7 +327,7 @@ func (r *ISBServiceRolloutReconciler) markRolloutPaused(ctx context.Context, rol
 	return nil
 }
 
-func (r *ISBServiceRolloutReconciler) getPauseModuleKey(rolloutNamespace string, rolloutName string) string {
+func (r *ISBServiceRolloutReconciler) getRolloutKey(rolloutNamespace string, rolloutName string) string {
 	return GetPauseModule().getISBServiceKey(rolloutNamespace, rolloutName)
 }
 

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -159,12 +159,15 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 	startTime := time.Now()
 	numaLogger := logger.FromContext(ctx)
 
+	pm := GetPauseModule()
+	pauseModuleKey := pm.getISBServiceKey(isbServiceRollout.Namespace, isbServiceRollout.Name)
+
 	// is isbServiceRollout being deleted? need to remove the finalizer so it can
 	// (OwnerReference will delete the underlying ISBService through Cascading deletion)
 	if !isbServiceRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting ISBServiceRollout")
 		if controllerutil.ContainsFinalizer(isbServiceRollout, finalizerName) {
-			GetPauseModule().deleteISBServicePauseRequest(isbServiceRollout.Namespace, isbServiceRollout.Name)
+			pm.deletePauseRequest(pm.getISBServiceKey(isbServiceRollout.Namespace, isbServiceRollout.Name))
 			controllerutil.RemoveFinalizer(isbServiceRollout, finalizerName)
 		}
 		// generate metrics for ISB Service deletion.
@@ -178,10 +181,10 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 		controllerutil.AddFinalizer(isbServiceRollout, finalizerName)
 	}
 
-	_, pauseRequestExists := GetPauseModule().getISBSvcPauseRequest(isbServiceRollout.Namespace, isbServiceRollout.Name)
+	_, pauseRequestExists := pm.getPauseRequest(pauseModuleKey)
 	if !pauseRequestExists {
 		// this is just creating an entry in the map if it doesn't already exist
-		GetPauseModule().newISBServicePauseRequest(isbServiceRollout.Namespace, isbServiceRollout.Name)
+		pm.newPauseRequest(pauseModuleKey)
 	}
 
 	newISBServiceDef := &kubernetes.GenericObject{
@@ -236,6 +239,10 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 	return ctrl.Result{}, nil
 }
 
+func (r *ISBServiceRolloutReconciler) getChildType() string {
+	return "interstepbufferservice"
+}
+
 // take the existing ISBService and merge anything needed from the new ISBService definition
 func mergeISBService(existingISBService *kubernetes.GenericObject, newISBService *kubernetes.GenericObject) *kubernetes.GenericObject {
 	resultISBService := existingISBService.DeepCopy()
@@ -275,49 +282,7 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 	}
 
 	if common.DataLossPrevention {
-
-		if isbServiceNeedsUpdating || isbServiceIsUpdating {
-			numaLogger.Info("ISBService either needs to or is in the process of updating")
-			// TODO: maybe only pause if the update requires pausing
-
-			// request pause if we haven't already
-			pauseRequestUpdated, err := r.requestPipelinesPause(ctx, isbServiceRollout, existingISBServiceDef, true)
-			if err != nil {
-				return false, err
-			}
-			// If we need to update the ISBService, pause the pipelines
-			// Don't do this yet if we just made a request - it's too soon for anything to have happened
-			if !pauseRequestUpdated && isbServiceNeedsUpdating {
-
-				// check if the pipelines are all paused and we're trying to update the spec
-				allPaused, err := r.allPipelinesPaused(ctx, existingISBServiceDef)
-				if err != nil {
-					return false, err
-				}
-				if allPaused {
-					numaLogger.Infof("confirmed all Pipelines have paused so ISBService can safely update")
-					// update ISBService
-					err = kubernetes.UpdateCR(ctx, r.restConfig, newISBServiceDef, "interstepbufferservices")
-					if err != nil {
-						return false, err
-					}
-
-					isbServiceRollout.Status.MarkDeployed(isbServiceRollout.Generation)
-					r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerISBSVCRollout, "update").Observe(time.Since(syncStartTime).Seconds())
-				} else {
-					numaLogger.Debugf("not all Pipelines have paused")
-				}
-
-			}
-			return true, nil
-
-		} else {
-			// remove any pause requirement if necessary
-			_, err := r.requestPipelinesPause(ctx, isbServiceRollout, existingISBServiceDef, false)
-			if err != nil {
-				return false, err
-			}
-		}
+		return processChildObjectWithoutDataLoss(ctx, isbServiceRollout.Namespace, isbServiceRollout.Name, r, newISBServiceDef, isbServiceNeedsUpdating, isbServiceIsUpdating)
 	} else {
 		// update ISBService
 		err = kubernetes.UpdateCR(ctx, r.restConfig, newISBServiceDef, "interstepbufferservices")
@@ -329,6 +294,29 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 	}
 
 	return false, nil
+}
+
+func (r *ISBServiceRolloutReconciler) updateResource(ctx context.Context, rolloutNamespace string, rolloutName string, resourceDefinition *kubernetes.GenericObject) error {
+	return kubernetes.UpdateCR(ctx, r.restConfig, resourceDefinition, "interstepbufferservices")
+}
+
+func (r *ISBServiceRolloutReconciler) markRolloutPaused(ctx context.Context, rolloutNamespace string, rolloutName string, paused bool) error {
+	isbServiceRollout := &apiv1.ISBServiceRollout{}
+	if err := r.client.Get(ctx, k8stypes.NamespacedName{Namespace: rolloutNamespace, Name: rolloutName}, isbServiceRollout); err != nil {
+		return err
+	}
+
+	if paused {
+		isbServiceRollout.Status.MarkPausingPipelines(isbServiceRollout.Generation)
+	} else {
+		isbServiceRollout.Status.MarkUnpausingPipelines(isbServiceRollout.Generation)
+	}
+
+	return nil
+}
+
+func (r *ISBServiceRolloutReconciler) getPauseModuleKey(rolloutNamespace string, rolloutName string) string {
+	return GetPauseModule().getISBServiceKey(rolloutNamespace, rolloutName)
 }
 
 // return:
@@ -358,52 +346,8 @@ func (r *ISBServiceRolloutReconciler) isISBServiceUpdating(ctx context.Context, 
 	return isbServiceNeedsToUpdate, !isbServiceReconciled, nil
 }
 
-// request that Pipelines pause
-// return whether an update was made
-func (r *ISBServiceRolloutReconciler) requestPipelinesPause(ctx context.Context, isbServiceRollout *apiv1.ISBServiceRollout, isbService *kubernetes.GenericObject, pause bool) (bool, error) {
-	numaLogger := logger.FromContext(ctx)
-
-	updated := GetPauseModule().updateISBServicePauseRequest(isbService.Namespace, isbService.Name, pause)
-	if updated { // if the value is different from what it was then make sure we queue the pipelines to be processed
-		numaLogger.Infof("updated pause request = %t", pause)
-		pipelines, err := r.getPipelines(ctx, isbService)
-		if err != nil {
-			return false, err
-		}
-		for _, pipeline := range pipelines {
-			pipelineROReconciler.enqueuePipeline(k8stypes.NamespacedName{Namespace: pipeline.Namespace, Name: pipeline.Name})
-		}
-	}
-
-	if pause {
-		isbServiceRollout.Status.MarkPausingPipelines(isbServiceRollout.Generation)
-	} else {
-		isbServiceRollout.Status.MarkUnpausingPipelines(isbServiceRollout.Generation)
-	}
-	return updated, nil
-}
-
-func (r *ISBServiceRolloutReconciler) getPipelines(ctx context.Context, isbService *kubernetes.GenericObject) ([]*kubernetes.GenericObject, error) {
-	return kubernetes.ListCR(ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", isbService.Namespace, fmt.Sprintf("%s=%s", common.LabelKeyISBServiceNameForPipeline, isbService.Name), "")
-}
-
-func (r *ISBServiceRolloutReconciler) allPipelinesPaused(ctx context.Context, isbService *kubernetes.GenericObject) (bool, error) {
-	numaLogger := logger.FromContext(ctx)
-	pipelines, err := r.getPipelines(ctx, isbService)
-	if err != nil {
-		return false, err
-	}
-	for _, pipeline := range pipelines {
-		status, err := kubernetes.ParseStatus(pipeline)
-		if err != nil {
-			return false, err
-		}
-		if status.Phase != "Paused" {
-			numaLogger.Debugf("pipeline %q has status.phase=%q", pipeline.Name, status.Phase)
-			return false, nil
-		}
-	}
-	return true, nil
+func (r *ISBServiceRolloutReconciler) getPipelineList(ctx context.Context, rolloutNamespace string, rolloutName string) ([]*kubernetes.GenericObject, error) {
+	return kubernetes.ListCR(ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", rolloutNamespace, fmt.Sprintf("%s=%s", common.LabelKeyISBServiceNameForPipeline, rolloutName), "")
 }
 
 // Apply pod disruption budget for the ISBService

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -733,7 +733,7 @@ func (r *NumaflowControllerRolloutReconciler) processNumaflowControllerStatus(ct
 	if healthy {
 		controllerRollout.Status.MarkChildResourcesHealthy(controllerRollout.Generation)
 	} else {
-		controllerRollout.Status.MarkChildResourcesUnhealthy(conditionReason, conditionMsg, deployment.Generation)
+		controllerRollout.Status.MarkChildResourcesUnhealthy(conditionReason, conditionMsg, controllerRollout.Generation)
 	}
 
 	return nil

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -317,6 +317,7 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 	return ctrl.Result{}, nil
 }
 
+// for the purpose of logging
 func (r *NumaflowControllerRolloutReconciler) getChildTypeString() string {
 	return "Numaflow Controller"
 }
@@ -325,7 +326,7 @@ func (r *NumaflowControllerRolloutReconciler) getPipelineList(ctx context.Contex
 	return kubernetes.ListCR(ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", rolloutNamespace, "", "")
 }
 
-func (r *NumaflowControllerRolloutReconciler) getPauseModuleKey(rolloutNamespace string, rolloutName string) string {
+func (r *NumaflowControllerRolloutReconciler) getRolloutKey(rolloutNamespace string, rolloutName string) string {
 	return GetPauseModule().getNumaflowControllerKey(rolloutNamespace)
 }
 

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -221,13 +221,12 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 ) (ctrl.Result, error) {
 	numaLogger := logger.FromContext(ctx)
 
-	pm := GetPauseModule()
-	pauseModuleKey := pm.getNumaflowControllerKey(namespace)
+	controllerKey := GetPauseModule().getNumaflowControllerKey(namespace)
 
 	if !controllerRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting NumaflowControllerRollout")
 		if controllerutil.ContainsFinalizer(controllerRollout, finalizerName) {
-			GetPauseModule().deletePauseRequest(pauseModuleKey)
+			GetPauseModule().deletePauseRequest(controllerKey)
 			controllerutil.RemoveFinalizer(controllerRollout, finalizerName)
 		}
 		// generate the metrics for the numaflow controller deletion based on a numaflow version.
@@ -241,10 +240,10 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 		controllerutil.AddFinalizer(controllerRollout, finalizerName)
 	}
 
-	_, pauseRequestExists := GetPauseModule().getPauseRequest(pauseModuleKey)
+	_, pauseRequestExists := GetPauseModule().getPauseRequest(controllerKey)
 	if !pauseRequestExists {
 		// this is just creating an entry in the map if it doesn't already exist
-		GetPauseModule().newPauseRequest(pauseModuleKey)
+		GetPauseModule().newPauseRequest(controllerKey)
 	}
 
 	deployment, deploymentExists, err := r.getNumaflowControllerDeployment(ctx, controllerRollout)

--- a/internal/controller/pause.go
+++ b/internal/controller/pause.go
@@ -19,108 +19,57 @@ var (
 
 func GetPauseModule() *PauseModule {
 	once.Do(func() {
-		pauseModuleInstance = &PauseModule{
-			controllerRequestedPause: make(map[string]*bool),
-			isbSvcRequestedPause:     make(map[string]*bool),
-		}
+		pauseModuleInstance = &PauseModule{pauseRequests: make(map[string]*bool)}
 	})
 
 	return pauseModuleInstance
 }
 
 type PauseModule struct {
-	// map of namespace (where Numaflow Controller lives) to Pause Request
-	controllerRequestedPause     map[string]*bool // having *bool gives us 3 states: [true=pause-required, false=pause-not-required, nil=unknown]
-	controllerRequestedPauseLock sync.RWMutex
-	// map of ISBService namespaced name to Pause Request
-	isbSvcRequestedPause     map[string]*bool // having *bool gives us 3 states: [true=pause-required, false=pause-not-required, nil=unknown]
-	isbSvcRequestedPauseLock sync.RWMutex
+	lock sync.RWMutex
+	// map of pause requester to Pause Request
+	pauseRequests map[string]*bool // having *bool gives us 3 states: [true=pause-required, false=pause-not-required, nil=unknown]
 }
 
-func (pm *PauseModule) newControllerPauseRequest(namespace string) {
-	pm.controllerRequestedPauseLock.Lock()
-	defer pm.controllerRequestedPauseLock.Unlock()
-	_, alreadyThere := pm.controllerRequestedPause[namespace]
+func (pm *PauseModule) newPauseRequest(requester string) {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	_, alreadyThere := pm.pauseRequests[requester]
 	if !alreadyThere {
-		pm.controllerRequestedPause[namespace] = nil
+		pm.pauseRequests[requester] = nil
 	}
 }
 
-func (pm *PauseModule) deleteControllerPauseRequest(namespace string) {
-	pm.controllerRequestedPauseLock.Lock()
-	defer pm.controllerRequestedPauseLock.Unlock()
-	delete(pm.controllerRequestedPause, namespace)
-}
-
-func (pm *PauseModule) getControllerPauseRequest(namespace string) (*bool, bool) {
-	pm.controllerRequestedPauseLock.RLock()
-	defer pm.controllerRequestedPauseLock.RUnlock()
-	entry, exists := pm.controllerRequestedPause[namespace]
-	return entry, exists
+func (pm *PauseModule) deletePauseRequest(requester string) {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	delete(pm.pauseRequests, requester)
 }
 
 // update and return whether the value changed
-func (pm *PauseModule) updateControllerPauseRequest(namespace string, pause bool) bool {
+func (pm *PauseModule) updatePauseRequest(requester string, pause bool) bool {
 	// first check to see if the same using read lock
-	pm.controllerRequestedPauseLock.RLock()
-	entry := pm.controllerRequestedPause[namespace]
+	pm.lock.RLock()
+	entry := pm.pauseRequests[requester]
 	if entry != nil && *entry == pause {
 		// nothing to do
-		pm.controllerRequestedPauseLock.RUnlock()
+		pm.lock.RUnlock()
 		return false
 	}
-	pm.controllerRequestedPauseLock.RUnlock()
+	pm.lock.RUnlock()
 
 	// if not the same, use write lock to modify
-	pm.controllerRequestedPauseLock.Lock()
-	defer pm.controllerRequestedPauseLock.Unlock()
-	pm.controllerRequestedPause[namespace] = &pause
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	pm.pauseRequests[requester] = &pause
 	return true
 }
 
-func (pm *PauseModule) newISBServicePauseRequest(namespace string, isbsvcName string) {
-	namespacedName := namespaceName(namespace, isbsvcName)
-	pm.isbSvcRequestedPauseLock.Lock()
-	defer pm.isbSvcRequestedPauseLock.Unlock()
-	_, alreadyThere := pm.isbSvcRequestedPause[namespacedName]
-	if !alreadyThere {
-		pm.isbSvcRequestedPause[namespacedName] = nil
-	}
-}
-
-func (pm *PauseModule) deleteISBServicePauseRequest(namespace string, isbsvcName string) {
-	namespacedName := namespaceName(namespace, isbsvcName)
-	pm.isbSvcRequestedPauseLock.Lock()
-	defer pm.isbSvcRequestedPauseLock.Unlock()
-	delete(pm.isbSvcRequestedPause, namespacedName)
-}
-
-func (pm *PauseModule) getISBSvcPauseRequest(namespace string, isbsvcName string) (*bool, bool) {
-	pm.isbSvcRequestedPauseLock.RLock()
-	defer pm.isbSvcRequestedPauseLock.RUnlock()
-	entry, exists := pm.isbSvcRequestedPause[namespaceName(namespace, isbsvcName)]
+func (pm *PauseModule) getPauseRequest(requester string) (*bool, bool) {
+	pm.lock.RLock()
+	defer pm.lock.RUnlock()
+	entry, exists := pm.pauseRequests[requester]
 	return entry, exists
-}
-
-// update and return whether the value changed
-func (pm *PauseModule) updateISBServicePauseRequest(namespace string, isbsvcName string, pause bool) bool {
-	namespacedName := namespaceName(namespace, isbsvcName)
-	// first check to see if the same using read lock
-	pm.isbSvcRequestedPauseLock.RLock()
-	entry := pm.isbSvcRequestedPause[namespacedName]
-	if entry != nil && *entry == pause {
-		// nothing to do
-		pm.isbSvcRequestedPauseLock.RUnlock()
-		return false
-	}
-	pm.isbSvcRequestedPauseLock.RUnlock()
-
-	// if not the same, use write lock to modify
-	pm.isbSvcRequestedPauseLock.Lock()
-	defer pm.isbSvcRequestedPauseLock.Unlock()
-	pm.isbSvcRequestedPause[namespacedName] = &pause
-	return true
-
 }
 
 // pause pipeline
@@ -137,18 +86,17 @@ func (pm *PauseModule) pausePipeline(ctx context.Context, restConfig *rest.Confi
 // lock the maps while we change pipeline lifecycle so nobody changes their pause request
 // while we run; otherwise, they may think they are pausing the pipeline while it's running
 func (pm *PauseModule) runPipelineIfSafe(ctx context.Context, restConfig *rest.Config, pipeline *kubernetes.GenericObject) (bool, error) {
-	pm.controllerRequestedPauseLock.RLock()
-	defer pm.controllerRequestedPauseLock.RUnlock()
-	pm.isbSvcRequestedPauseLock.RLock()
-	defer pm.isbSvcRequestedPauseLock.RUnlock()
+	pm.lock.RLock()
+	defer pm.lock.RUnlock()
 
 	// verify that all requests are still to pause, if not we can't run right now
-	controllerPauseRequest := pm.controllerRequestedPause[pipeline.Namespace]
+	controllerPauseRequest := pm.pauseRequests[pm.getNumaflowControllerKey(pipeline.Namespace)]
 	var existingPipelineSpec PipelineSpec
 	if err := json.Unmarshal(pipeline.Spec.Raw, &existingPipelineSpec); err != nil {
 		return false, err
 	}
-	isbsvcPauseRequest := pm.isbSvcRequestedPause[getISBSvcName(existingPipelineSpec)]
+	isbsvcName := getISBSvcName(existingPipelineSpec)
+	isbsvcPauseRequest := pm.pauseRequests[pm.getISBServiceKey(pipeline.Namespace, isbsvcName)]
 	if (controllerPauseRequest != nil && *controllerPauseRequest) || (isbsvcPauseRequest != nil && *isbsvcPauseRequest) {
 		// somebody is requesting to pause - can't run
 		return false, nil
@@ -175,6 +123,10 @@ func (pm *PauseModule) updatePipelineLifecycle(ctx context.Context, restConfig *
 	return kubernetes.UpdateUnstructuredCR(ctx, restConfig, unstruc, common.PipelineGVR, pipeline.Namespace, pipeline.Name)
 }
 
-func namespaceName(namespace, name string) string {
-	return fmt.Sprintf("%s/%s", namespace, name)
+func (pm *PauseModule) getNumaflowControllerKey(namespace string) string {
+	return fmt.Sprintf("NC:%s", namespace)
+}
+
+func (pm *PauseModule) getISBServiceKey(namespace string, name string) string {
+	return fmt.Sprintf("I:%s/%s", namespace, name)
 }

--- a/internal/controller/pause_requester.go
+++ b/internal/controller/pause_requester.go
@@ -1,0 +1,117 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/numaproj/numaplane/internal/util/kubernetes"
+	"github.com/numaproj/numaplane/internal/util/logger"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+type PauseRequester interface {
+	getPipelineList(ctx context.Context, rolloutNamespace string, rolloutName string) ([]*kubernetes.GenericObject, error)
+
+	updateResource(ctx context.Context, rolloutNamespace string, rolloutName string, resourceDefinition *kubernetes.GenericObject) error
+
+	markRolloutPaused(ctx context.Context, rolloutNamespace string, rolloutName string, paused bool) error
+
+	getPauseModuleKey(rolloutNamespace string, rolloutName string) string
+
+	getChildType() string
+}
+
+// process a child object, pausing pipelines or resuming pipelines if needed
+// return:
+// - true if needs a requeue
+// - error if any (note we'll automatically reuqueue if there's an error anyway)
+func processChildObjectWithoutDataLoss(ctx context.Context, rolloutNamespace string, rolloutName string, pauseRequester PauseRequester, newResourceDefinition *kubernetes.GenericObject,
+	resourceNeedsUpdating bool, resourceIsUpdating bool) (bool, error) {
+	numaLogger := logger.FromContext(ctx)
+	if resourceNeedsUpdating || resourceIsUpdating {
+		numaLogger.Infof("%s either needs to or is in the process of updating", pauseRequester.getChildType())
+		// TODO: maybe only pause if the update requires pausing
+
+		// request pause if we haven't already
+		pauseRequestUpdated, err := requestPipelinesPause(ctx, pauseRequester, rolloutName, rolloutNamespace, true)
+		if err != nil {
+			return false, err
+		}
+		// If we need to update the ISBService, pause the pipelines
+		// Don't do this yet if we just made a request - it's too soon for anything to have happened
+		if !pauseRequestUpdated && resourceNeedsUpdating {
+
+			// check if the pipelines are all paused and we're trying to update the spec
+			allPaused, err := areAllPipelinesPaused(ctx, pauseRequester, rolloutName, rolloutNamespace)
+			if err != nil {
+				return false, err
+			}
+			if allPaused {
+				numaLogger.Infof("confirmed all Pipelines have paused so %s can safely update", pauseRequester.getChildType())
+				pauseRequester.updateResource(ctx, rolloutName, rolloutNamespace, newResourceDefinition)
+				// update ISBService
+				/*err = kubernetes.UpdateCR(ctx, r.restConfig, newISBServiceDef, "interstepbufferservices")
+				if err != nil {
+					return false, err
+				}
+
+				isbServiceRollout.Status.MarkDeployed(isbServiceRollout.Generation)
+				r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerISBSVCRollout, "update").Observe(time.Since(syncStartTime).Seconds())*/
+			} else {
+				numaLogger.Debugf("not all Pipelines have paused")
+			}
+
+		}
+		return true, nil
+
+	} else {
+		// remove any pause requirement if necessary
+		_, err := requestPipelinesPause(ctx, pauseRequester, rolloutName, rolloutNamespace, false)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return false, nil
+}
+
+// request that Pipelines pause
+// return whether an update was made
+func requestPipelinesPause(ctx context.Context, pauseRequester PauseRequester, rolloutNamespace string, rolloutName string, pause bool) (bool, error) {
+	numaLogger := logger.FromContext(ctx)
+
+	pm := GetPauseModule()
+
+	updated := pm.updatePauseRequest(pauseRequester.getPauseModuleKey(rolloutNamespace, rolloutName), pause)
+	if updated { // if the value is different from what it was then make sure we queue the pipelines to be processed
+		numaLogger.Infof("updated pause request = %t", pause)
+		pipelines, err := pauseRequester.getPipelineList(ctx, rolloutNamespace, rolloutName)
+		if err != nil {
+			return false, err
+		}
+		for _, pipeline := range pipelines {
+			pipelineROReconciler.enqueuePipeline(k8stypes.NamespacedName{Namespace: pipeline.Namespace, Name: pipeline.Name})
+		}
+	}
+
+	err := pauseRequester.markRolloutPaused(ctx, rolloutNamespace, rolloutName, pause)
+	return updated, err
+}
+
+func areAllPipelinesPaused(ctx context.Context, pauseRequester PauseRequester, rolloutNamespace string, rolloutName string) (bool, error) {
+	numaLogger := logger.FromContext(ctx)
+	pipelines, err := pauseRequester.getPipelineList(ctx, rolloutNamespace, rolloutName)
+	if err != nil {
+		return false, err
+	}
+	for _, pipeline := range pipelines {
+		status, err := kubernetes.ParseStatus(pipeline)
+		if err != nil {
+			return false, err
+		}
+		if status.Phase != "Paused" {
+			numaLogger.Debugf("pipeline %q has status.phase=%q", pipeline.Name, status.Phase)
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/internal/controller/pause_requester.go
+++ b/internal/controller/pause_requester.go
@@ -17,7 +17,7 @@ type PauseRequester interface {
 	markRolloutPaused(ctx context.Context, rolloutNamespace string, rolloutName string, paused bool) error
 
 	// get the unique key corresponding to this Rollout
-	getPauseModuleKey(rolloutNamespace string, rolloutName string) string
+	getRolloutKey(rolloutNamespace string, rolloutName string) string
 
 	// just a free form string to describe what we're deploying, for logging
 	getChildTypeString() string
@@ -79,7 +79,7 @@ func requestPipelinesPause(ctx context.Context, pauseRequester PauseRequester, r
 
 	pm := GetPauseModule()
 
-	updated := pm.updatePauseRequest(pauseRequester.getPauseModuleKey(rolloutNamespace, rolloutName), pause)
+	updated := pm.updatePauseRequest(pauseRequester.getRolloutKey(rolloutNamespace, rolloutName), pause)
 	if updated { // if the value is different from what it was then make sure we queue the pipelines to be processed
 		numaLogger.Infof("updated pause request = %t", pause)
 		pipelines, err := pauseRequester.getPipelineList(ctx, rolloutNamespace, rolloutName)

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -530,8 +530,11 @@ func (r *PipelineRolloutReconciler) setPipelineLifecycle(ctx context.Context, pa
 // - error if any
 func (r *PipelineRolloutReconciler) checkForPauseRequest(ctx context.Context, pipelineRollout *apiv1.PipelineRollout, isbsvcName string) (bool, bool, error) {
 	numaLogger := logger.FromContext(ctx)
+
+	pm := GetPauseModule()
+
 	// Is either Numaflow Controller or ISBService trying to update (such that we need to pause)?
-	controllerPauseRequest, found := GetPauseModule().getControllerPauseRequest(pipelineRollout.Namespace)
+	controllerPauseRequest, found := pm.getPauseRequest(pm.getNumaflowControllerKey(pipelineRollout.Namespace))
 	if !found {
 		numaLogger.Debugf("No pause request found for numaflow controller on namespace %q", pipelineRollout.Namespace)
 		return false, false, nil
@@ -539,7 +542,7 @@ func (r *PipelineRolloutReconciler) checkForPauseRequest(ctx context.Context, pi
 	}
 	controllerRequestsPause := controllerPauseRequest != nil && *controllerPauseRequest
 
-	isbsvcPauseRequest, found := GetPauseModule().getISBSvcPauseRequest(pipelineRollout.Namespace, isbsvcName)
+	isbsvcPauseRequest, found := pm.getPauseRequest(pm.getISBServiceKey(pipelineRollout.Namespace, isbsvcName))
 	if !found {
 		numaLogger.Debugf("No pause request found for isbsvc %q on namespace %q", isbsvcName, pipelineRollout.Namespace)
 		return false, false, nil


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #163 - Address prior PR comments
Fixes #174 - Use Pipeline's `ChildResourcesHealthy` condition to determine if Pipeline is still being reconciled

### Modifications

This addresses the following comments:
- [mark NumaflowControllerRollout unhealthy if Deployment doesn't exist](https://github.com/numaproj/numaplane/pull/125/files#r1697647636)
- [consolidate ](https://github.com/numaproj/numaplane/pull/125#discussion_r1698820989)`allPipelinesPaused()` function between NumaflowControllerRollout reconciler and ISBServiceRollout reconciler
- [improve readability](https://github.com/numaproj/numaplane/pull/125#discussion_r1698819003) in the NumaflowControllerRollout.reconcile() function

Note that I have decided to go for simplicity as far as the Pause Module. I have condensed the NumaflowController pause request code and the ISBService pause request code into just one thing. 

I have also condensed the common code from ISBServiceRollout reconciler and NumaflowControllerRollout reconciler into a single set of functions through the use of a `PauseRequester` interface. 

### Verification

- has passed e2e test in CI multiple times (which updates pipeline through pausing, and updates Numaflow Controller and ISBService through pausing pipeline)
- ran `watch -n 1 kubectl get pods` and `watch -n 1 kubectl get pipeline` in separate terminals while the test was running to confirm visually what was happening