### PR TITLE
USDE Config

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1056,6 +1056,21 @@ metadata:
   name: numaplane-controller-config
   namespace: numaplane-system
 ---
+apiVersion: v1
+data:
+  isbServiceSpecExcludedPaths: |
+    - "invalid"
+  pipelineSpecExcludedPaths: |
+    - "lifecycle"
+    - "limits"
+    - "watermark"
+kind: ConfigMap
+metadata:
+  labels:
+    numaplane.numaproj.io/config: usde-config
+  name: numaplane-controller-usde-config
+  namespace: numaplane-system
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1058,8 +1058,6 @@ metadata:
 ---
 apiVersion: v1
 data:
-  isbServiceSpecExcludedPaths: |
-    - "invalid"
   pipelineSpecExcludedPaths: |
     - "lifecycle"
     - "limits"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - controller-manager.yaml
   - controller-config.yaml
+  - usde-config.yaml
 
 images:
   - name: quay.io/numaproj/numaplane-controller

--- a/config/manager/usde-config.yaml
+++ b/config/manager/usde-config.yaml
@@ -11,14 +11,3 @@ data:
     - "watermark"
   isbServiceSpecExcludedPaths: |
     - "invalid"
----
-# TTODO: REMOVE BELOW BUT USE IT IN UNIT TESTS
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: numaplane-controller-notsupported-config
-  labels:
-    numaplane.numaproj.io/config: not-supported
-data:
-  x: "123"

--- a/config/manager/usde-config.yaml
+++ b/config/manager/usde-config.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: numaplane-controller-usde-config
+  labels:
+    numaplane.numaproj.io/config: usde-config
+data:
+  pipelineSpecExcludedPaths: |
+    - "lifecycle"
+    - "limits"
+    - "watermark"
+  isbServiceSpecExcludedPaths: |
+    - "invalid"
+---
+# TTODO: REMOVE BELOW BUT USE IT IN UNIT TESTS
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: numaplane-controller-notsupported-config
+  labels:
+    numaplane.numaproj.io/config: not-supported
+data:
+  x: "123"

--- a/config/manager/usde-config.yaml
+++ b/config/manager/usde-config.yaml
@@ -9,5 +9,3 @@ data:
     - "lifecycle"
     - "limits"
     - "watermark"
-  isbServiceSpecExcludedPaths: |
-    - "invalid"

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -24,10 +24,14 @@ const (
 	// LabelKeyNumaplaneInstance Resource metadata labels (keys and values) used for tracking
 	LabelKeyNumaplaneInstance = "numaplane.numaproj.io/tracking-id"
 
-	// LabelKeyNumaplaneControllerConfig is the label key used to identify the configmap for the controller definitions
+	// LabelKeyNumaplaneControllerConfig is the label key used to identify additional Numaplane ConfigMaps (ex: Numaflow Controller definitions, USDE, etc.)
 	LabelKeyNumaplaneControllerConfig = "numaplane.numaproj.io/config"
-	// LabelValueNumaplaneControllerConfig is the label value used to identify the configmap for the controller definitions
-	LabelValueNumaplaneControllerConfig = "numaflow-controller-definitions"
+
+	// LabelValueNumaflowControllerDefinitions is the label value used to identify the Numaplane ConfigMap for the Numaflow Controller definitions
+	LabelValueNumaflowControllerDefinitions = "numaflow-controller-definitions"
+
+	// LabelValueNumaflowControllerDefinitions is the label value used to identify the Numaplane ConfigMap for the Numaflow Controller definitions
+	LabelValueUSDEConfig = "usde-config"
 
 	// LabelKeyISBServiceNameForPipeline is the label key used to identify the ISBService being used by a Pipeline
 	// This is useful as a Label to quickly locate all Pipelines of a given ISBService

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -30,7 +30,7 @@ const (
 	// LabelValueNumaflowControllerDefinitions is the label value used to identify the Numaplane ConfigMap for the Numaflow Controller definitions
 	LabelValueNumaflowControllerDefinitions = "numaflow-controller-definitions"
 
-	// LabelValueNumaflowControllerDefinitions is the label value used to identify the Numaplane ConfigMap for the Numaflow Controller definitions
+	// LabelValueUSDEConfig is the label value used to identify the USDE ConfigMap
 	LabelValueUSDEConfig = "usde-config"
 
 	// LabelKeyISBServiceNameForPipeline is the label key used to identify the ISBService being used by a Pipeline

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -205,9 +205,14 @@ func (cm *ConfigManager) UnsetUSDEConfig() {
 	cm.usdeConfig = &USDEConfig{}
 }
 
-func (cm *ConfigManager) GetUSDEConfig() *USDEConfig {
+func (cm *ConfigManager) GetUSDEConfig() (USDEConfig, error) {
 	cm.usdeConfigLock.Lock()
 	defer cm.usdeConfigLock.Unlock()
 
-	return cm.usdeConfig
+	usdeConfig, err := CloneWithSerialization(cm.usdeConfig)
+	if err != nil {
+		return USDEConfig{}, err
+	}
+
+	return *usdeConfig, nil
 }

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -20,7 +20,7 @@ type ConfigManager struct {
 	numaflowControllerDefMgr NumaflowControllerDefinitionsManager
 
 	// USDE Config
-	usdeConfig     *USDEConfig
+	usdeConfig     USDEConfig
 	usdeConfigLock *sync.RWMutex
 }
 
@@ -47,7 +47,7 @@ func GetConfigManagerInstance() *ConfigManager {
 				rolloutConfig: map[string]string{},
 				lock:          new(sync.RWMutex),
 			},
-			usdeConfig:     &USDEConfig{},
+			usdeConfig:     USDEConfig{},
 			usdeConfigLock: new(sync.RWMutex),
 		}
 	})
@@ -171,7 +171,7 @@ func (cm *ConfigManager) loadGlobalConfig(
 	return nil
 }
 
-func CloneWithSerialization[T NumaflowControllerDefinitionConfig | GlobalConfig | USDEConfig](orig *T) (*T, error) {
+func CloneWithSerialization[T NumaflowControllerDefinitionConfig | GlobalConfig](orig *T) (*T, error) {
 	origJSON, err := json.Marshal(orig)
 	if err != nil {
 		return nil, err
@@ -191,7 +191,7 @@ func (cm *ConfigManager) RegisterCallback(f func(config GlobalConfig)) {
 	cm.callbacks = append(cm.callbacks, f)
 }
 
-func (cm *ConfigManager) UpdateUSDEConfig(config *USDEConfig) {
+func (cm *ConfigManager) UpdateUSDEConfig(config USDEConfig) {
 	cm.usdeConfigLock.Lock()
 	defer cm.usdeConfigLock.Unlock()
 
@@ -202,17 +202,12 @@ func (cm *ConfigManager) UnsetUSDEConfig() {
 	cm.usdeConfigLock.Lock()
 	defer cm.usdeConfigLock.Unlock()
 
-	cm.usdeConfig = &USDEConfig{}
+	cm.usdeConfig = USDEConfig{}
 }
 
-func (cm *ConfigManager) GetUSDEConfig() (USDEConfig, error) {
+func (cm *ConfigManager) GetUSDEConfig() USDEConfig {
 	cm.usdeConfigLock.Lock()
 	defer cm.usdeConfigLock.Unlock()
 
-	usdeConfig, err := CloneWithSerialization(cm.usdeConfig)
-	if err != nil {
-		return USDEConfig{}, err
-	}
-
-	return *usdeConfig, nil
+	return cm.usdeConfig
 }

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -17,12 +17,21 @@ type ConfigManager struct {
 	// if the configmap changes, these callbacks will be called
 	callbacks []func(config GlobalConfig)
 
-	controllerDefMgr ControllerDefinitionsManager
+	numaflowControllerDefMgr NumaflowControllerDefinitionsManager
+
+	// USDE Config
+	usdeConfig     *USDEConfig
+	usdeConfigLock *sync.RWMutex
 }
 
-type ControllerDefinitionsManager struct {
+type NumaflowControllerDefinitionsManager struct {
 	rolloutConfig map[string]string
 	lock          *sync.RWMutex
+}
+
+type USDEConfig struct {
+	ExcludedPipelineSpecPaths   []string `json:"excludedPipelineSpecPaths" yaml:"excludedPipelineSpecPaths"`
+	ExcludedISBServiceSpecPaths []string `json:"excludedISBServiceSpecPaths" yaml:"excludedISBServiceSpecPaths"`
 }
 
 var instance *ConfigManager
@@ -34,17 +43,19 @@ func GetConfigManagerInstance() *ConfigManager {
 		instance = &ConfigManager{
 			config: &GlobalConfig{},
 			lock:   new(sync.RWMutex),
-			controllerDefMgr: ControllerDefinitionsManager{
+			numaflowControllerDefMgr: NumaflowControllerDefinitionsManager{
 				rolloutConfig: map[string]string{},
 				lock:          new(sync.RWMutex),
 			},
+			usdeConfig:     &USDEConfig{},
+			usdeConfigLock: new(sync.RWMutex),
 		}
 	})
 	return instance
 }
 
-func (*ConfigManager) GetControllerDefinitionsMgr() *ControllerDefinitionsManager {
-	return &instance.controllerDefMgr
+func (*ConfigManager) GetControllerDefinitionsMgr() *NumaflowControllerDefinitionsManager {
+	return &instance.numaflowControllerDefMgr
 }
 
 // GlobalConfig is the configuration for the controllers, it is
@@ -74,7 +85,7 @@ func (cm *ConfigManager) GetConfig() (GlobalConfig, error) {
 	return *config, nil
 }
 
-func (cm *ControllerDefinitionsManager) UpdateControllerDefinitionConfig(config NumaflowControllerDefinitionConfig) {
+func (cm *NumaflowControllerDefinitionsManager) UpdateNumaflowControllerDefinitionConfig(config NumaflowControllerDefinitionConfig) {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
 
@@ -84,7 +95,7 @@ func (cm *ControllerDefinitionsManager) UpdateControllerDefinitionConfig(config 
 	}
 }
 
-func (cm *ControllerDefinitionsManager) RemoveControllerDefinitionConfig(config NumaflowControllerDefinitionConfig) {
+func (cm *NumaflowControllerDefinitionsManager) RemoveNumaflowControllerDefinitionConfig(config NumaflowControllerDefinitionConfig) {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
 
@@ -93,7 +104,7 @@ func (cm *ControllerDefinitionsManager) RemoveControllerDefinitionConfig(config 
 	}
 }
 
-func (cm *ControllerDefinitionsManager) GetControllerDefinitionsConfig() map[string]string {
+func (cm *NumaflowControllerDefinitionsManager) GetNumaflowControllerDefinitionsConfig() map[string]string {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
 
@@ -160,7 +171,7 @@ func (cm *ConfigManager) loadGlobalConfig(
 	return nil
 }
 
-func CloneWithSerialization[T NumaflowControllerDefinitionConfig | GlobalConfig](orig *T) (*T, error) {
+func CloneWithSerialization[T NumaflowControllerDefinitionConfig | GlobalConfig | USDEConfig](orig *T) (*T, error) {
 	origJSON, err := json.Marshal(orig)
 	if err != nil {
 		return nil, err
@@ -178,4 +189,18 @@ func (cm *ConfigManager) RegisterCallback(f func(config GlobalConfig)) {
 	defer cm.lock.Unlock()
 
 	cm.callbacks = append(cm.callbacks, f)
+}
+
+func (cm *ConfigManager) UpdateUSDEConfig(config *USDEConfig) {
+	cm.usdeConfigLock.Lock()
+	defer cm.usdeConfigLock.Unlock()
+
+	cm.usdeConfig = config
+}
+
+func (cm *ConfigManager) GetUSDEConfig() *USDEConfig {
+	cm.usdeConfigLock.Lock()
+	defer cm.usdeConfigLock.Unlock()
+
+	return cm.usdeConfig
 }

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -30,8 +30,8 @@ type NumaflowControllerDefinitionsManager struct {
 }
 
 type USDEConfig struct {
-	ExcludedPipelineSpecPaths   []string `json:"excludedPipelineSpecPaths" yaml:"excludedPipelineSpecPaths"`
-	ExcludedISBServiceSpecPaths []string `json:"excludedISBServiceSpecPaths" yaml:"excludedISBServiceSpecPaths"`
+	PipelineSpecExcludedPaths   []string `json:"pipelineSpecExcludedPaths,omitempty" yaml:"pipelineSpecExcludedPaths,omitempty"`
+	ISBServiceSpecExcludedPaths []string `json:"isbServiceSpecExcludedPaths,omitempty" yaml:"isbServiceSpecExcludedPaths,omitempty"`
 }
 
 var instance *ConfigManager
@@ -196,6 +196,13 @@ func (cm *ConfigManager) UpdateUSDEConfig(config *USDEConfig) {
 	defer cm.usdeConfigLock.Unlock()
 
 	cm.usdeConfig = config
+}
+
+func (cm *ConfigManager) UnsetUSDEConfig() {
+	cm.usdeConfigLock.Lock()
+	defer cm.usdeConfigLock.Unlock()
+
+	cm.usdeConfig = &USDEConfig{}
 }
 
 func (cm *ConfigManager) GetUSDEConfig() *USDEConfig {

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -436,7 +436,7 @@ func (r *NumaflowControllerRolloutReconciler) sync(
 
 	// Get the target manifests based on the version of the controller and throw an error if the definition not for a version.
 	version := rollout.Spec.Controller.Version
-	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetControllerDefinitionsConfig()
+	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetNumaflowControllerDefinitionsConfig()
 	manifest := definition[version]
 	if len(manifest) == 0 {
 		return gitopsSyncCommon.OperationError, fmt.Errorf("no controller definition found for version %s", version)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -158,7 +158,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 	Expect(err).ToNot(HaveOccurred())
-	config.GetConfigManagerInstance().GetControllerDefinitionsMgr().UpdateControllerDefinitionConfig(getNumaflowControllerDefinitions())
+	config.GetConfigManagerInstance().GetControllerDefinitionsMgr().UpdateNumaflowControllerDefinitionConfig(getNumaflowControllerDefinitions())
 
 	numaflowControllerReconciler, err := NewNumaflowControllerRolloutReconciler(k8sManager.GetClient(),
 		k8sManager.GetScheme(), cfg, kubernetes.NewKubectl(), customMetrics)

--- a/internal/util/kubernetes/config_watcher.go
+++ b/internal/util/kubernetes/config_watcher.go
@@ -114,7 +114,7 @@ func handleUSDEConfigMapEvent(configMap *corev1.ConfigMap, event watch.Event) er
 			return fmt.Errorf("error unmarshalling USDE ISBServiceSpecExcludedPaths: %v", err)
 		}
 
-		config.GetConfigManagerInstance().UpdateUSDEConfig(&usdeConfig)
+		config.GetConfigManagerInstance().UpdateUSDEConfig(usdeConfig)
 	} else if event.Type == watch.Deleted {
 		config.GetConfigManagerInstance().UnsetUSDEConfig()
 	}

--- a/internal/util/kubernetes/config_watcher.go
+++ b/internal/util/kubernetes/config_watcher.go
@@ -96,20 +96,24 @@ func handleNumaflowControllerDefinitionsConfigMapEvent(ctx context.Context, conf
 }
 
 func handleUSDEConfigMapEvent(configMap *corev1.ConfigMap, event watch.Event) error {
-	usdeConfig := config.USDEConfig{}
-
-	err := yaml.Unmarshal([]byte(configMap.Data["pipelineSpecExcludedPaths"]), &usdeConfig.PipelineSpecExcludedPaths)
-	if err != nil {
-		return fmt.Errorf("error unmarshalling USDE PipelineSpecExcludedPaths: %v", err)
-
-	}
-
-	err = yaml.Unmarshal([]byte(configMap.Data["isbServiceSpecExcludedPaths"]), &usdeConfig.ISBServiceSpecExcludedPaths)
-	if err != nil {
-		return fmt.Errorf("error unmarshalling USDE ISBServiceSpecExcludedPaths: %v", err)
-	}
-
 	if event.Type == watch.Added || event.Type == watch.Modified {
+		usdeConfig := config.USDEConfig{}
+
+		if configMap == nil || configMap.Data == nil {
+			return fmt.Errorf("no ConfigMap or data field available")
+		}
+
+		err := yaml.Unmarshal([]byte(configMap.Data["pipelineSpecExcludedPaths"]), &usdeConfig.PipelineSpecExcludedPaths)
+		if err != nil {
+			return fmt.Errorf("error unmarshalling USDE PipelineSpecExcludedPaths: %v", err)
+
+		}
+
+		err = yaml.Unmarshal([]byte(configMap.Data["isbServiceSpecExcludedPaths"]), &usdeConfig.ISBServiceSpecExcludedPaths)
+		if err != nil {
+			return fmt.Errorf("error unmarshalling USDE ISBServiceSpecExcludedPaths: %v", err)
+		}
+
 		config.GetConfigManagerInstance().UpdateUSDEConfig(&usdeConfig)
 	} else if event.Type == watch.Deleted {
 		config.GetConfigManagerInstance().UnsetUSDEConfig()

--- a/internal/util/kubernetes/config_watcher_test.go
+++ b/internal/util/kubernetes/config_watcher_test.go
@@ -49,7 +49,7 @@ func Test_watchConfigMaps(t *testing.T) {
 	// Wait for the controller to process the ConfigMap
 	time.Sleep(5 * time.Second)
 	// Validate the controller definition config is set correctly
-	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetControllerDefinitionsConfig()
+	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetNumaflowControllerDefinitionsConfig()
 	assert.Len(t, definition, 2)
 
 	// Create the ConfigMap object in the fake clientset
@@ -59,6 +59,6 @@ func Test_watchConfigMaps(t *testing.T) {
 	// Wait for the controller to process the ConfigMap
 	time.Sleep(5 * time.Second)
 	// Validate the controller definition config is updated correctly
-	definition = config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetControllerDefinitionsConfig()
+	definition = config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetNumaflowControllerDefinitionsConfig()
 	assert.Len(t, definition, 0)
 }

--- a/internal/util/kubernetes/config_watcher_test.go
+++ b/internal/util/kubernetes/config_watcher_test.go
@@ -28,6 +28,7 @@ func Test_watchConfigMaps(t *testing.T) {
 
 	data, err := os.ReadFile("../../../tests/config/controller-definitions-config.yaml")
 	assert.NoError(t, err)
+
 	// Create a new ConfigMap object
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -48,17 +49,62 @@ func Test_watchConfigMaps(t *testing.T) {
 
 	// Wait for the controller to process the ConfigMap
 	time.Sleep(5 * time.Second)
+
 	// Validate the controller definition config is set correctly
 	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetNumaflowControllerDefinitionsConfig()
 	assert.Len(t, definition, 2)
 
-	// Create the ConfigMap object in the fake clientset
+	// Delete the ConfigMap object from the fake clientset
 	err = clientSet.CoreV1().ConfigMaps("default").Delete(ctx, configMap.Name, metav1.DeleteOptions{})
 	assert.NoError(t, err)
 
 	// Wait for the controller to process the ConfigMap
 	time.Sleep(5 * time.Second)
-	// Validate the controller definition config is updated correctly
+
+	// Validate the controller definition config has been removed
 	definition = config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetNumaflowControllerDefinitionsConfig()
 	assert.Len(t, definition, 0)
+
+	// === USDE Config Test =====================================
+
+	configMap = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "numaplane-controller-usde-config",
+			Namespace: "default",
+			Labels: map[string]string{
+				common.LabelKeyNumaplaneControllerConfig: "usde-config",
+			},
+		},
+		Data: map[string]string{
+			"pipelineSpecExcludedPaths": `
+        - "abc"
+        - "abcde/xyz"
+        - "path/array/sample"
+      `,
+			"isbServiceSpecExcludedPaths": `
+        - "invalid"
+      `,
+		},
+	}
+
+	_, err = clientSet.CoreV1().ConfigMaps("default").Create(ctx, configMap, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	expectedUSDEConfig := config.USDEConfig{
+		PipelineSpecExcludedPaths:   []string{"abc", "abcde/xyz", "path/array/sample"},
+		ISBServiceSpecExcludedPaths: []string{"invalid"},
+	}
+
+	actualUSDEConfig := config.GetConfigManagerInstance().GetUSDEConfig()
+	assert.Equal(t, expectedUSDEConfig, *actualUSDEConfig)
+
+	err = clientSet.CoreV1().ConfigMaps("default").Delete(ctx, configMap.Name, metav1.DeleteOptions{})
+	assert.NoError(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	actualUSDEConfig = config.GetConfigManagerInstance().GetUSDEConfig()
+	assert.Equal(t, config.USDEConfig{}, *actualUSDEConfig)
 }

--- a/internal/util/kubernetes/config_watcher_test.go
+++ b/internal/util/kubernetes/config_watcher_test.go
@@ -97,8 +97,7 @@ func Test_watchConfigMaps(t *testing.T) {
 		ISBServiceSpecExcludedPaths: []string{"invalid"},
 	}
 
-	actualUSDEConfig, err := config.GetConfigManagerInstance().GetUSDEConfig()
-	assert.NoError(t, err)
+	actualUSDEConfig := config.GetConfigManagerInstance().GetUSDEConfig()
 	assert.Equal(t, expectedUSDEConfig, actualUSDEConfig)
 
 	err = clientSet.CoreV1().ConfigMaps("default").Delete(ctx, configMap.Name, metav1.DeleteOptions{})
@@ -106,7 +105,6 @@ func Test_watchConfigMaps(t *testing.T) {
 
 	time.Sleep(5 * time.Second)
 
-	actualUSDEConfig, err = config.GetConfigManagerInstance().GetUSDEConfig()
-	assert.NoError(t, err)
+	actualUSDEConfig = config.GetConfigManagerInstance().GetUSDEConfig()
 	assert.Equal(t, config.USDEConfig{}, actualUSDEConfig)
 }

--- a/internal/util/kubernetes/config_watcher_test.go
+++ b/internal/util/kubernetes/config_watcher_test.go
@@ -97,14 +97,16 @@ func Test_watchConfigMaps(t *testing.T) {
 		ISBServiceSpecExcludedPaths: []string{"invalid"},
 	}
 
-	actualUSDEConfig := config.GetConfigManagerInstance().GetUSDEConfig()
-	assert.Equal(t, expectedUSDEConfig, *actualUSDEConfig)
+	actualUSDEConfig, err := config.GetConfigManagerInstance().GetUSDEConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedUSDEConfig, actualUSDEConfig)
 
 	err = clientSet.CoreV1().ConfigMaps("default").Delete(ctx, configMap.Name, metav1.DeleteOptions{})
 	assert.NoError(t, err)
 
 	time.Sleep(5 * time.Second)
 
-	actualUSDEConfig = config.GetConfigManagerInstance().GetUSDEConfig()
-	assert.Equal(t, config.USDEConfig{}, *actualUSDEConfig)
+	actualUSDEConfig, err = config.GetConfigManagerInstance().GetUSDEConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, config.USDEConfig{}, actualUSDEConfig)
 }

--- a/internal/util/kubernetes/config_watcher_test.go
+++ b/internal/util/kubernetes/config_watcher_test.go
@@ -34,7 +34,7 @@ func Test_watchConfigMaps(t *testing.T) {
 			Name:      "numaflow-controller-definitions-config",
 			Namespace: "default",
 			Labels: map[string]string{
-				common.LabelKeyNumaplaneControllerConfig: common.LabelValueNumaplaneControllerConfig,
+				common.LabelKeyNumaplaneControllerConfig: common.LabelValueNumaflowControllerDefinitions,
 			},
 		},
 		Data: map[string]string{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #175 

### Modifications

Added ConfigMap for USDE Milestone 1. The ConfigMap is watched using the config watcher and the `numaplane.numaproj.io/config` label.

### Verification

Added unit tests to ensure correct config loading.