### PR TITLE
fix: don't use fake gopath and repopath for generating pkg/client code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ bin/*
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 
 # editor and IDE paraphernalia
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ bin/*
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
+# Dependency directories
 vendor/
 
 # editor and IDE paraphernalia

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ codegen: manifests controller-gen
 ## Generate pkg/client directory
 	./hack/update-codegen.sh
 	rm -rf ./vendor
-#	go mod tidy
+	go mod tidy
 ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..." 
 

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) crd paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd paths="pkg/apis/..." output:crd:artifacts:config=config/crd/bases
 	$(KUBECTL) kustomize config/default > config/install.yaml
 
 .PHONY: codegen
@@ -99,7 +99,7 @@ codegen: manifests controller-gen
 	rm -rf ./vendor
 	go mod tidy
 ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..." 
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="pkg/apis/..." 
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) crd paths="pkg/apis/..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd paths="./..." output:crd:artifacts:config=config/crd/bases
 	$(KUBECTL) kustomize config/default > config/install.yaml
 
 .PHONY: codegen
@@ -99,7 +99,7 @@ codegen: manifests controller-gen
 	rm -rf ./vendor
 	go mod tidy -e
 ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="pkg/apis/..." 
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..." 
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ codegen: manifests controller-gen
 ## Generate pkg/client directory
 	./hack/update-codegen.sh
 	rm -rf ./vendor
-	go mod tidy
+	go mod tidy -e
 ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="pkg/apis/..." 
 

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ codegen: manifests controller-gen
 ## Generate pkg/client directory
 	./hack/update-codegen.sh
 	rm -rf ./vendor
-	go mod tidy -e
+#	go mod tidy
 ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..." 
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -8,14 +8,10 @@ source $(dirname $0)/library.sh
 header "running codegen"
 
 ensure_vendor
-make_fake_paths
 
-export GOPATH="${FAKE_GOPATH}"
 export GO111MODULE="off"
 
-cd "${FAKE_REPOPATH}"
-
-CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${FAKE_REPOPATH}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
+CODEGEN_PKG=${CODEGEN_PKG:-$(ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
 chmod +x ${CODEGEN_PKG}/*.sh
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Motivation

If I run `make codegen` or anything that depends on it, it fails due to the fact that the [update-codegen.sh](https://github.com/numaproj/numaplane/blob/v0.4.0/hack/update-codegen.sh) script at [this](https://github.com/numaproj/numaplane/blob/v0.4.0/hack/library.sh#L32) line fails at the end due to "Permission denied" attempting to delete all of the files (just started happening):
```
rm: /var/folders/3_/nkw952qn66qfwq3kc7mc1jnr0000gq/T/tmp.MqU1r9Fp7s/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.0.darwin-arm64/LICENSE: Permission denied
rm: /var/folders/3_/nkw952qn66qfwq3kc7mc1jnr0000gq/T/tmp.MqU1r9Fp7s/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.0.darwin-arm64/PATENTS: Permission denied
rm: /var/folders/3_/nkw952qn66qfwq3kc7mc1jnr0000gq/T/tmp.MqU1r9Fp7s/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.0.darwin-arm64/bin/go: Permission denied
...
```
It seems to be downloading go in there, and then the permissions of the files in there don't include my user's write access.

### Modifications

The file `update-codegen.sh` was copied over from Numaflow. In there, an optimization was done to create a fake GOPATH and fake repo path. However, this causes the error when deleting the files. Therefore, I'm removing the fake paths so we don't need that `rm` line either. Instead, I am just adding `vendor` back into `.gitignore`.

### Verification

I tried adding a new file in `pkg/apis/numaplane/v1alpha1` and then ran `make codegen` to confirm that the new code for it would be autogenerated in `pkg/client`.