### PR TITLE
feat: add numaflow controller definition for v1.3.0

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -20,12 +20,12 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .status.message
-      name: Message
-      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.message
+      name: Message
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -372,6 +372,62 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: monovertices.numaflow.numaproj.io
+spec:
+  group: numaflow.numaproj.io
+  names:
+    kind: MonoVertex
+    listKind: MonoVertexList
+    plural: monovertices
+    shortNames:
+    - mvtx
+    singular: monovertex
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.reason
+      name: Reason
+      type: string
+    - jsonPath: .status.message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
   name: numaflowcontrollerrollouts.numaplane.numaproj.io
@@ -708,9 +764,6 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .status.message
-      name: Message
-      type: string
     - jsonPath: .status.vertexCount
       name: Vertices
       type: integer
@@ -726,9 +779,20 @@ spec:
       name: UDFs
       priority: 10
       type: integer
+    - jsonPath: .status.mapUDFCount
+      name: Map UDFs
+      priority: 10
+      type: integer
+    - jsonPath: .status.reduceUDFCount
+      name: Reduce UDFs
+      priority: 10
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.message
+      name: Message
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -772,17 +836,20 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .status.reason
-      name: Reason
-      type: string
-    - jsonPath: .status.message
-      name: Message
-      type: string
     - jsonPath: .spec.replicas
       name: Desired
       type: string
     - jsonPath: .status.replicas
       name: Current
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.reason
+      name: Reason
+      type: string
+    - jsonPath: .status.message
+      name: Message
       type: string
     name: v1alpha1
     schema:

--- a/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: example-namespace
 spec:
   controller:
-    version: "1.3.0-rc1" #numaflow-1.3.0-rc1
+    version: "1.3.0" #numaflow-1.3.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/argoproj/gitops-engine v0.7.1-0.20240718175351-6b2984ebc470
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-logr/logr v1.4.1
-	github.com/numaproj/numaflow v1.3.0-rc1
+	github.com/numaproj/numaflow v1.3.0
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
 	github.com/rs/zerolog v1.29.0

--- a/go.sum
+++ b/go.sum
@@ -980,8 +980,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/numaproj/numaflow v1.3.0-rc1 h1:ckxra5OMMSARsl6zZwPI1J3+knyFkmPt5qjjHck3LgY=
-github.com/numaproj/numaflow v1.3.0-rc1/go.mod h1:7ou66HLIFo+zqU8T0zVXzGqTM8D/qDJqqPqbcq0Yc70=
+github.com/numaproj/numaflow v1.3.0 h1:uNpwmXhcfODBGkOwqY+AA9VXmTKH6bIqFnsdQYUd0Jo=
+github.com/numaproj/numaflow v1.3.0/go.mod h1:dWTidSrhA9bGGt4ExVIGst1mM3xL2ZMwfPXQrCnbRaQ=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852/go.mod h1:eqOVx5Vwu4gd2mmMZvVZsgIqNSaW3xxRThUJ0k/TPk4=

--- a/tests/manifests/default/controller_definitions.yaml
+++ b/tests/manifests/default/controller_definitions.yaml
@@ -1,5 +1,5 @@
 controllerDefinitions:
-- version: "1.3.0-rc1"
+- version: "1.3.0"
   fullSpec: |
     apiVersion: v1
     kind: ServiceAccount
@@ -318,7 +318,7 @@ controllerDefinitions:
             - controller
             env:
             - name: NUMAFLOW_IMAGE
-              value: quay.io/numaproj/numaflow:1.3.0-rc1
+              value: quay.io/numaproj/numaflow:v1.3.0
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -359,7 +359,7 @@ controllerDefinitions:
                   key: controller.leader.election.lease.renew.period
                   name: numaflow-cmd-params-config
                   optional: true
-            image: quay.io/numaproj/numaflow:1.3.0-rc1
+            image: quay.io/numaproj/numaflow:v1.3.0
             imagePullPolicy: Always
             livenessProbe:
               httpGet:

--- a/tests/manifests/default/controller_definitions.yaml
+++ b/tests/manifests/default/controller_definitions.yaml
@@ -1,103 +1,141 @@
 controllerDefinitions:
 - version: "1.3.0-rc1"
   fullSpec: |
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: v1
+    kind: ServiceAccount
     metadata:
-      name: numaflow-controller
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
-          app.kubernetes.io/component: controller-manager
-          app.kubernetes.io/name: controller-manager
-          app.kubernetes.io/part-of: numaflow
-      template:
-        metadata:
-          labels:
-            app.kubernetes.io/component: controller-manager
-            app.kubernetes.io/name: controller-manager
-            app.kubernetes.io/part-of: numaflow
-        spec:
-          containers:
-            - args:
-                - controller
-              env:
-                - name: NUMAFLOW_IMAGE
-                  value: quay.io/numaproj/numaflow:v1.3.0-rc1
-                - name: NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: NUMAFLOW_CONTROLLER_NAMESPACED
-                  valueFrom:
-                    configMapKeyRef:
-                      key: namespaced
-                      name: numaflow-cmd-params-config
-                      optional: true
-                - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
-                  valueFrom:
-                    configMapKeyRef:
-                      key: managed.namespace
-                      name: numaflow-cmd-params-config
-                      optional: true
-                - name: NUMAFLOW_LEADER_ELECTION_DISABLED
-                  valueFrom:
-                    configMapKeyRef:
-                      key: controller.leader.election.disabled
-                      name: numaflow-cmd-params-config
-                      optional: true
-                - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
-                  valueFrom:
-                    configMapKeyRef:
-                      key: controller.leader.election.lease.duration
-                      name: numaflow-cmd-params-config
-                      optional: true
-                - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
-                  valueFrom:
-                    configMapKeyRef:
-                      key: controller.leader.election.lease.renew.deadline
-                      name: numaflow-cmd-params-config
-                      optional: true
-                - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
-                  valueFrom:
-                    configMapKeyRef:
-                      key: controller.leader.election.lease.renew.period
-                      name: numaflow-cmd-params-config
-                      optional: true
-              image: quay.io/numaproj/numaflow:v1.3.0-rc1
-              imagePullPolicy: Always
-              livenessProbe:
-                httpGet:
-                  path: /healthz
-                  port: 8081
-                initialDelaySeconds: 3
-                periodSeconds: 3
-              name: controller-manager
-              readinessProbe:
-                httpGet:
-                  path: /readyz
-                  port: 8081
-                initialDelaySeconds: 3
-                periodSeconds: 3
-              resources:
-                limits:
-                  cpu: 500m
-                  memory: 1024Mi
-                requests:
-                  cpu: 100m
-                  memory: 200Mi
-              volumeMounts:
-                - mountPath: /etc/numaflow
-                  name: controller-config-volume
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 9737
-          serviceAccountName: numaflow-sa
-          volumes:
-            - configMap:
-                name: numaflow-controller-config
-              name: controller-config-volume
+      name: numaflow-sa
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller-manager
+        app.kubernetes.io/name: numaflow-controller-manager
+        app.kubernetes.io/part-of: numaflow
+      name: numaflow-role
+    rules:
+    - apiGroups:
+      - numaflow.numaproj.io
+      resources:
+      - interstepbufferservices
+      - interstepbufferservices/finalizers
+      - interstepbufferservices/status
+      - pipelines
+      - pipelines/finalizers
+      - pipelines/status
+      - vertices
+      - vertices/finalizers
+      - vertices/status
+      - vertices/scale
+      - monovertices
+      - monovertices/finalizers
+      - monovertices/status
+      - monovertices/scale
+      verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - pods/exec
+      - configmaps
+      - services
+      - persistentvolumeclaims
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      - statefulsets
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - batch
+      resources:
+      - jobs
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller-manager
+        app.kubernetes.io/name: numaflow-controller-manager
+        app.kubernetes.io/part-of: numaflow
+      name: numaflow-role-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: numaflow-role
+    subjects:
+    - kind: ServiceAccount
+      name: numaflow-sa
+    ---
+    apiVersion: v1
+    data:
+      namespaced: "true"
+      server.disable.auth: "true"
+    kind: ConfigMap
+    metadata:
+      name: numaflow-cmd-params-config
     ---
     apiVersion: v1
     data:
@@ -189,7 +227,7 @@ controllerDefinitions:
                 replicas: 3
             versions:
             - version: latest
-              natsImage: nats:2.10.3
+              natsImage: nats:2.10.17
               metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
               configReloaderImage: natsio/nats-server-config-reloader:0.7.0
               startCommand: /nats-server
@@ -248,141 +286,115 @@ controllerDefinitions:
               metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
               configReloaderImage: natsio/nats-server-config-reloader:0.7.0
               startCommand: /nats-server
+            - version: 2.10.17
+              natsImage: nats:2.10.17
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
     kind: ConfigMap
     metadata:
       name: numaflow-controller-config
     ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
+    apiVersion: apps/v1
+    kind: Deployment
     metadata:
-      labels:
-        app.kubernetes.io/component: controller-manager
-        app.kubernetes.io/name: numaflow-controller-manager
-        app.kubernetes.io/part-of: numaflow
-      name: numaflow-role
-    rules:
-      - apiGroups:
-          - numaflow.numaproj.io
-        resources:
-          - interstepbufferservices
-          - interstepbufferservices/finalizers
-          - interstepbufferservices/status
-          - pipelines
-          - pipelines/finalizers
-          - pipelines/status
-          - vertices
-          - vertices/finalizers
-          - vertices/status
-          - vertices/scale
-        verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-      - apiGroups:
-          - coordination.k8s.io
-        resources:
-          - leases
-        verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-      - apiGroups:
-          - ""
-        resources:
-          - events
-        verbs:
-          - create
-          - patch
-      - apiGroups:
-          - ""
-        resources:
-          - pods
-          - pods/exec
-          - configmaps
-          - services
-          - persistentvolumeclaims
-        verbs:
-          - create
-          - get
-          - list
-          - watch
-          - update
-          - patch
-          - delete
-      - apiGroups:
-          - ""
-        resources:
-          - secrets
-        verbs:
-          - create
-          - get
-          - list
-          - update
-          - patch
-          - delete
-      - apiGroups:
-          - apps
-        resources:
-          - deployments
-          - statefulsets
-        verbs:
-          - create
-          - get
-          - list
-          - watch
-          - update
-          - patch
-          - delete
-      - apiGroups:
-          - batch
-        resources:
-          - jobs
-        verbs:
-          - create
-          - get
-          - list
-          - watch
-          - update
-          - patch
-          - delete
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-      labels:
-        app.kubernetes.io/component: controller-manager
-        app.kubernetes.io/name: numaflow-controller-manager
-        app.kubernetes.io/part-of: numaflow
-      name: numaflow-role-binding
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: Role
-      name: numaflow-role
-    subjects:
-      - kind: ServiceAccount
-        name: numaflow-sa
-    ---
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: numaflow-sa
-    ---
-    apiVersion: v1
-    data:
-      namespaced: "true"
-      server.disable.auth: "true"
-    kind: ConfigMap
-    metadata:
-      name: numaflow-cmd-params-config
+      name: numaflow-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: controller-manager
+          app.kubernetes.io/name: controller-manager
+          app.kubernetes.io/part-of: numaflow
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: controller-manager
+            app.kubernetes.io/name: controller-manager
+            app.kubernetes.io/part-of: numaflow
+        spec:
+          containers:
+          - args:
+            - controller
+            env:
+            - name: NUMAFLOW_IMAGE
+              value: quay.io/numaproj/numaflow:1.3.0-rc1
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NUMAFLOW_CONTROLLER_NAMESPACED
+              valueFrom:
+                configMapKeyRef:
+                  key: namespaced
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  key: managed.namespace
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_DISABLED
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.disabled
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.duration
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.renew.deadline
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.renew.period
+                  name: numaflow-cmd-params-config
+                  optional: true
+            image: quay.io/numaproj/numaflow:1.3.0-rc1
+            imagePullPolicy: Always
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: 8081
+              initialDelaySeconds: 3
+              periodSeconds: 3
+            name: controller-manager
+            ports:
+            - containerPort: 9090
+              name: metrics
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: 8081
+              initialDelaySeconds: 3
+              periodSeconds: 3
+            resources:
+              limits:
+                cpu: 500m
+                memory: 1024Mi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+            volumeMounts:
+            - mountPath: /etc/numaflow
+              name: controller-config-volume
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 9737
+          serviceAccountName: numaflow-sa
+          volumes:
+          - configMap:
+              name: numaflow-controller-config
+            name: controller-config-volume
 - version: "1.2.1"
   fullSpec: |
     apiVersion: apps/v1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

Adding the controller definition for `v1.3.0` which is the most recent Numaflow version that includes monovertices.

### Verification

Ran `make start` to update local cm and `make test` to verify tests still work using this definition.

Created sample rollouts to see that the resources were created and functioned properly using this new definition.