### PR TITLE
feat: User Strategy in Namespace-level ConfigMap

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -3,4 +3,5 @@ resources:
 - numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
 - numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
 - numaplane.numaproj.io_v1alpha1_isbservicerollout.yaml
+- namespace-level-config.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/namespace-level-config.yaml
+++ b/config/samples/namespace-level-config.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     numaplane.numaproj.io/config: namespace-level-config
 data:
-  # strategy can be either "progressive" or "pause-and-drain"
-  strategy: "progressive"
+  # upgradeStrategy can be either "progressive" or "pause-and-drain"
+  upgradeStrategy: "progressive"

--- a/config/samples/namespace-level-config.yaml
+++ b/config/samples/namespace-level-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+  namespace: example-namespace
+  labels:
+    numaplane.numaproj.io/config: namespace-level-config
+data:
+  # strategy can be either "progressive" or "pause-and-drain"
+  strategy: "progressive"

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -33,7 +33,7 @@ const (
 	// LabelValueUSDEConfig is the label value used to identify the USDE ConfigMap
 	LabelValueUSDEConfig = "usde-config"
 
-	// LabelValueNamespaceConfig is the label value used to identify the namespace-level ConfigMap
+	// LabelValueNamespaceConfig is the label value used to identify the user's namespace-level ConfigMap
 	LabelValueNamespaceConfig = "namespace-level-config"
 
 	// LabelKeyISBServiceNameForPipeline is the label key used to identify the ISBService being used by a Pipeline

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -33,6 +33,9 @@ const (
 	// LabelValueUSDEConfig is the label value used to identify the USDE ConfigMap
 	LabelValueUSDEConfig = "usde-config"
 
+	// LabelValueNamespaceConfig is the label value used to identify the namespace-level ConfigMap
+	LabelValueNamespaceConfig = "namespace-level-config"
+
 	// LabelKeyISBServiceNameForPipeline is the label key used to identify the ISBService being used by a Pipeline
 	// This is useful as a Label to quickly locate all Pipelines of a given ISBService
 	LabelKeyISBServiceNameForPipeline = "numaplane.numaproj.io/isbsvc-name"

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
 
+	"github.com/numaproj/numaplane/internal/usde"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
@@ -39,7 +40,7 @@ type USDEConfig struct {
 }
 
 type NamespaceConfig struct {
-	UpgradeStrategy string `json:"upgradeStrategy,omitempty" yaml:"upgradeStrategy,omitempty"`
+	UpgradeStrategy usde.USDEStrategy `json:"upgradeStrategy,omitempty" yaml:"upgradeStrategy,omitempty"`
 }
 
 var instance *ConfigManager

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -22,6 +22,10 @@ type ConfigManager struct {
 	// USDE Config
 	usdeConfig     USDEConfig
 	usdeConfigLock *sync.RWMutex
+
+	// Namespace-level Config
+	namespaceConfigMap     map[string]NamespaceConfig
+	namespaceConfigMapLock *sync.RWMutex
 }
 
 type NumaflowControllerDefinitionsManager struct {
@@ -32,6 +36,10 @@ type NumaflowControllerDefinitionsManager struct {
 type USDEConfig struct {
 	PipelineSpecExcludedPaths   []string `json:"pipelineSpecExcludedPaths,omitempty" yaml:"pipelineSpecExcludedPaths,omitempty"`
 	ISBServiceSpecExcludedPaths []string `json:"isbServiceSpecExcludedPaths,omitempty" yaml:"isbServiceSpecExcludedPaths,omitempty"`
+}
+
+type NamespaceConfig struct {
+	UpgradeStrategy string `json:"upgradeStrategy,omitempty" yaml:"upgradeStrategy,omitempty"`
 }
 
 var instance *ConfigManager
@@ -47,8 +55,10 @@ func GetConfigManagerInstance() *ConfigManager {
 				rolloutConfig: map[string]string{},
 				lock:          new(sync.RWMutex),
 			},
-			usdeConfig:     USDEConfig{},
-			usdeConfigLock: new(sync.RWMutex),
+			usdeConfig:             USDEConfig{},
+			usdeConfigLock:         new(sync.RWMutex),
+			namespaceConfigMap:     make(map[string]NamespaceConfig),
+			namespaceConfigMapLock: new(sync.RWMutex),
 		}
 	})
 	return instance
@@ -210,4 +220,25 @@ func (cm *ConfigManager) GetUSDEConfig() USDEConfig {
 	defer cm.usdeConfigLock.Unlock()
 
 	return cm.usdeConfig
+}
+
+func (cm *ConfigManager) UpdateNamespaceConfig(namespace string, config NamespaceConfig) {
+	cm.namespaceConfigMapLock.Lock()
+	defer cm.namespaceConfigMapLock.Unlock()
+
+	cm.namespaceConfigMap[namespace] = config
+}
+
+func (cm *ConfigManager) UnsetNamespaceConfig(namespace string) {
+	cm.namespaceConfigMapLock.Lock()
+	defer cm.namespaceConfigMapLock.Unlock()
+
+	delete(cm.namespaceConfigMap, namespace)
+}
+
+func (cm *ConfigManager) GetNamespaceConfig(namespace string) NamespaceConfig {
+	cm.namespaceConfigMapLock.Lock()
+	defer cm.namespaceConfigMapLock.Unlock()
+
+	return cm.namespaceConfigMap[namespace]
 }

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -24,7 +24,7 @@ type ConfigManager struct {
 	usdeConfig     USDEConfig
 	usdeConfigLock *sync.RWMutex
 
-	// Namespace-level Config
+	// User Namespace-level Config
 	namespaceConfigMap     map[string]NamespaceConfig
 	namespaceConfigMapLock *sync.RWMutex
 }

--- a/internal/usde/usde.go
+++ b/internal/usde/usde.go
@@ -1,0 +1,39 @@
+package usde
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	progressiveStrategyID = "progressive"
+	ppndStrategyID        = "pause-and-drain"
+)
+
+type USDEStrategy string
+
+func (s *USDEStrategy) UnmarshalJSON(data []byte) (err error) {
+	// Trim spaces and check length
+	dataStrNoSpaces := strings.TrimSpace(string(data[:]))
+	if len(dataStrNoSpaces) == 0 {
+		return fmt.Errorf("empty strategy (allowed values are: %s or %s)", progressiveStrategyID, ppndStrategyID)
+	}
+
+	// Remove the double quotes around the string
+	strategyStr := string(data[1 : len(data)-1])
+
+	// Make sure the string is one of the possible strategy values
+	if strategyStr != progressiveStrategyID && strategyStr != ppndStrategyID {
+		return fmt.Errorf("invalid strategy %s (allowed values are: %s or %s)", string(data[:]), progressiveStrategyID, ppndStrategyID)
+	}
+
+	var usdeStrategyStr string
+	if err := json.Unmarshal(data, &usdeStrategyStr); err != nil {
+		return err
+	}
+
+	*s = USDEStrategy(usdeStrategyStr)
+
+	return nil
+}

--- a/internal/util/kubernetes/config_watcher.go
+++ b/internal/util/kubernetes/config_watcher.go
@@ -26,18 +26,18 @@ func StartConfigMapWatcher(ctx context.Context, config *rest.Config) error {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	namespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	numaplaneNamespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return fmt.Errorf("failed to read namespace: %w", err)
 	}
 
-	go watchConfigMaps(ctx, client, string(namespace))
+	go watchConfigMaps(ctx, client, string(numaplaneNamespace))
 
 	return nil
 }
 
 // watchConfigMaps watches for ConfigMaps continuously and updates the in-memory config objects based on the ConfigMaps data
-func watchConfigMaps(ctx context.Context, client kubernetes.Interface, namespace string) {
+func watchConfigMaps(ctx context.Context, client kubernetes.Interface, numaplaneNamespace string) {
 	numaLogger := logger.FromContext(ctx)
 
 	watcher, err := client.CoreV1().ConfigMaps("").Watch(ctx, metav1.ListOptions{
@@ -68,7 +68,7 @@ func watchConfigMaps(ctx context.Context, client kubernetes.Interface, namespace
 
 		case common.LabelValueNumaflowControllerDefinitions:
 			// Only handle this kind of ConfigMap if it is in the Numaplane namespace
-			if configMap.Namespace != namespace {
+			if configMap.Namespace != numaplaneNamespace {
 				break
 			}
 
@@ -76,7 +76,7 @@ func watchConfigMaps(ctx context.Context, client kubernetes.Interface, namespace
 
 		case common.LabelValueUSDEConfig:
 			// Only handle this kind of ConfigMap if it is in the Numaplane namespace
-			if configMap.Namespace != namespace {
+			if configMap.Namespace != numaplaneNamespace {
 				break
 			}
 
@@ -86,7 +86,7 @@ func watchConfigMaps(ctx context.Context, client kubernetes.Interface, namespace
 
 		case common.LabelValueNamespaceConfig:
 			// Only handle this kind of ConfigMap if it is NOT in the Numaplane namespace
-			if configMap.Namespace == namespace {
+			if configMap.Namespace == numaplaneNamespace {
 				break
 			}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #177 

### Modifications

Added a namespace-level ConfigMap users can use to add user-related customization parameters. Modified the config watcher to look for ConfigMaps in all namespaces and handle only those of interest based on labels and the namespace they are in.

### Verification

Manually tested.