### PR TITLE
fix: comparison of 2 JSON-derived maps requires ignoring keys with empty string, int, and bool values

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -34,12 +34,16 @@ func CompareMapsIgnoringNulls(a map[string]interface{}, b map[string]interface{}
 	return reflect.DeepEqual(aNoNulls, bNoNulls)
 }
 
-// recursively remove any nulls, empty maps, and empty arrays from the map
+// recursively remove any nulls, empty strings, empty maps, and empty arrays from the map
 func removeNullValuesFromMap(m map[string]interface{}) bool {
 
 	for k, v := range m {
 		if v == nil {
 			delete(m, k)
+		} else if stringValue, ok := v.(string); ok {
+			if stringValue == "" {
+				delete(m, k)
+			}
 		} else if nestedMap, ok := v.(map[string]interface{}); ok {
 			removeNullValuesFromMap(nestedMap)
 			if len(nestedMap) == 0 {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -34,8 +34,9 @@ func CompareMapsIgnoringNulls(a map[string]interface{}, b map[string]interface{}
 	return reflect.DeepEqual(aNoNulls, bNoNulls)
 }
 
-// recursively remove any nulls, empty strings, empty maps, and empty arrays from the map
-// the types that we look for are the ones that json.Unmarshal() uses
+// recursively remove any zero values from the map including null references, empty strings, numbers that are zero,
+// empty maps, and empty arrays from the map
+// (the types that we look for are the ones that json.Unmarshal() uses)
 func removeNullValuesFromJSONMap(m map[string]interface{}) bool {
 
 	for k, v := range m {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -44,6 +44,30 @@ func removeNullValuesFromMap(m map[string]interface{}) bool {
 			if stringValue == "" {
 				delete(m, k)
 			}
+		} else if intValue, ok := v.(int); ok {
+			if intValue == 0 {
+				delete(m, k)
+			}
+		} else if intValue, ok := v.(int32); ok {
+			if intValue == 0 {
+				delete(m, k)
+			}
+		} else if intValue, ok := v.(int64); ok {
+			if intValue == 0 {
+				delete(m, k)
+			}
+		} else if floatValue, ok := v.(float32); ok {
+			if floatValue == 0 {
+				delete(m, k)
+			}
+		} else if floatValue, ok := v.(float64); ok {
+			if floatValue == 0 {
+				delete(m, k)
+			}
+		} else if boolValue, ok := v.(bool); ok {
+			if !boolValue {
+				delete(m, k)
+			}
 		} else if nestedMap, ok := v.(map[string]interface{}); ok {
 			removeNullValuesFromMap(nestedMap)
 			if len(nestedMap) == 0 {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -78,9 +77,7 @@ var outputJson string = `
 func Test_removeNullValuesFromMap(t *testing.T) {
 	inputMap := make(map[string]interface{})
 	_ = json.Unmarshal([]byte(inputJson), &inputMap)
-	fmt.Printf("before removing nulls: %v", inputMap)
-	removeNullValuesFromMap(inputMap)
-	fmt.Printf("after removing nulls: %v", inputMap)
+	removeNullValuesFromJSONMap(inputMap)
 
 	outputMap := make(map[string]interface{})
 	_ = json.Unmarshal([]byte(outputJson), &outputMap)

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -43,7 +43,8 @@ var inputJson string = `
 		"nestedMapDelete":
 		{
 			"innerMapDelete": {}
-		}
+		},
+		"keyWithEmptyValue": ""
 	}
 
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -44,7 +44,9 @@ var inputJson string = `
 		{
 			"innerMapDelete": {}
 		},
-		"keyWithEmptyValue": ""
+		"stringKeyWithEmptyValue": "",
+		"intKeyWithZeroValue": 0,
+		"boolKeyWithZeroValue": false
 	}
 
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

In order to test whether we need to update our Pipeline or ISBService based on the Rollout spec, we need to compare it with the one we get back from Kubernetes API Get() call. After the Pipeline or ISBService is created and reconciled, this value is the one that Numaflow Controller would have written back [when it did an Update()](https://github.com/numaproj/numaflow/blob/v1.3.0/pkg/reconciler/pipeline/controller.go#L90) as part of adding the Finalizer. Since Numaflow Controller would Unmarshal the JSON into a `Pipeline`struct and then Marshal it back into JSON to do the Update, this means that empty values can get written in. 

Previously, I was only ignoring these empty values:
- reference=nil
- map=empty 
- slice=empty

But I also need to ignore empty string, numeric = 0, and bool=false.

(This issue was noticed while testing)

### Verification

unit test