### PR TITLE
fix: `generate-internal-groups.sh` is deprecated.

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -21,12 +21,12 @@ chmod +x ${CODEGEN_PKG}/*.sh
 
 
 subheader "running codegen"
-bash -x ${CODEGEN_PKG}/generate-groups.sh "deepcopy" \
+bash -x ${CODEGEN_PKG}/kube_codegen.sh "deepcopy" \
   github.com/numaproj/numaplane/pkg/client github.com/numaproj/numaplane/pkg/apis \
   "numaplane:v1alpha1" \
   --go-header-file hack/boilerplate.go.txt
 
-bash -x ${CODEGEN_PKG}/generate-groups.sh "client,informer,lister" \
+bash -x ${CODEGEN_PKG}/kube_codegen.sh "client,informer,lister" \
   github.com/numaproj/numaplane/pkg/client github.com/numaproj/numaplane/pkg/apis \
   "numaplane:v1alpha1" \
   --go-header-file hack/boilerplate.go.txt


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->
`make codegen` seeing the following errrors,
```
rm: cannot remove '/tmp/tmp.xFtU2ZYXQs/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.linux-amd64/pkg/tool/linux_amd64/cover': Permission denied
rm: cannot remove '/tmp/tmp.xFtU2ZYXQs/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.linux-amd64/pkg/tool/linux_amd64/vet': Permission denied
rm: cannot remove '/tmp/tmp.xFtU2ZYXQs/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.linux-amd64/pkg/tool/linux_amd64/covdata': Permission denied
```
This is caused by `generate-internal-groups.sh` is deprecated,
```
github.com/numaproj/numaplane/pkg/client '' github.com/numaproj/numaplane/pkg/apis numaplane:v1alpha1 --go-header-file hack/boilerplate.go.txt
WARNING: generate-internal-groups.sh is deprecated.
WARNING: Please use k8s.io/code-generator/kube_codegen.sh instead.
```

### Modifications

use `kube_codegen.sh` instead


### Verification

`make codegen`