### PR TITLE
feat: updating DataLossPrevention feature flag to be read periodically

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
-	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/controller"
 	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
@@ -238,8 +237,5 @@ func loadConfigs() {
 	numaLogger.SetLevel(config.LogLevel)
 	logger.SetBaseLogger(numaLogger)
 	clog.SetLogger(*numaLogger.LogrLogger)
-
-	// feature flag
-	common.DataLossPrevention = config.DataLossPrevention
 
 }

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -52,7 +52,4 @@ var (
 
 	// default requeue time used by Reconcilers
 	DefaultDelayedRequeue = ctrl.Result{RequeueAfter: 20 * time.Second}
-
-	// DataLossPrevention is a feature flag used to turn on/off the automatic pause feature for pipelines based on how it's set in the Config
-	DataLossPrevention bool
 )

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -44,6 +44,7 @@ import (
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaplane/internal/common"
+	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
@@ -284,7 +285,12 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 		isbServiceRollout.Status.MarkDeployed(isbServiceRollout.Generation)
 	}
 
-	if common.DataLossPrevention {
+	config, err := config.GetConfigManagerInstance().GetConfig()
+	if err != nil {
+		return false, err
+	}
+
+	if config.DataLossPrevention { // feature flag
 		return processChildObjectWithoutDataLoss(ctx, isbServiceRollout.Namespace, isbServiceRollout.Name, r, isbServiceNeedsUpdating, isbServiceIsUpdating, func() error {
 			r.recorder.Eventf(isbServiceRollout, corev1.EventTypeNormal, "PipelinesPaused", "All Pipelines have paused for ISBService update")
 			err = r.updateISBService(ctx, isbServiceRollout, newISBServiceDef)

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -256,7 +256,12 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 		return ctrl.Result{}, err
 	}
 
-	if deploymentExists && common.DataLossPrevention {
+	config, err := config.GetConfigManagerInstance().GetConfig()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if deploymentExists && config.DataLossPrevention {
 		numaLogger.Debugf("found existing numaflow-controller Deployment")
 
 		// if I need to update or am in the middle of an update of the Controller Deployment, then I need to make sure all the Pipelines are pausing

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -45,6 +45,7 @@ import (
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaplane/internal/common"
+	"github.com/numaproj/numaplane/internal/controller/config"
 
 	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
@@ -424,7 +425,12 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 		pipelineRollout.Status.MarkDeployed(pipelineRollout.Generation)
 	}
 
-	if common.DataLossPrevention { // feature flag
+	config, err := config.GetConfigManagerInstance().GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if config.DataLossPrevention { // feature flag
 		if err = r.processExistingPipelineWithoutDataLoss(ctx, pipelineRollout, existingPipelineDef, newPipelineDef, pipelineNeedsToUpdate); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #155 

### Modifications

Instead of storing DataLossPrevention feature flag as a variable that only gets read on start up, each Reconciler, when performing the reconciliation checks the value.


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->