### PR TITLE
fix: checking Pipeline conditions for PPND, plus don't pause failed pipelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,9 @@ test: codegen fmt vet envtest ## Run tests.
 
 .PHONY: test-e2e
 test-e2e: codegen fmt vet envtest ## Run e2e tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" GOFLAGS="-count=1" go test -v ./tests/e2e/... 
+	GOFLAGS="-count=1" go test -v ./tests/e2e/... 
+
+	
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.58.0

--- a/internal/controller/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout_controller_test.go
@@ -325,6 +325,18 @@ func Test_reconcile_PPND(t *testing.T) {
 			expectedISBSvcSpec: createDefaultISBServiceSpec("2.10.11"),
 		},
 		{
+			name:                   "existing ISBService - new spec - pipelines failed",
+			newISBSvcSpec:          createDefaultISBServiceSpec("2.10.11"),
+			existingISBSvcDef:      createDefaultISBService("2.10.3", numaflowv1.ISBSvcPhaseRunning, true),
+			existingStatefulSetDef: createDefaultISBStatefulSet("2.10.3", true),
+			existingPipelinePhase:  numaflowv1.PipelinePhaseFailed,
+			expectedRolloutPhase:   apiv1.PhaseDeployed,
+			expectedConditionsSet: map[apiv1.ConditionType]metav1.ConditionStatus{
+				apiv1.ConditionChildResourceDeployed: metav1.ConditionTrue,
+			},
+			expectedISBSvcSpec: createDefaultISBServiceSpec("2.10.11"),
+		},
+		{
 			name:                   "existing ISBService - spec already updated - isbsvc reconciling",
 			newISBSvcSpec:          createDefaultISBServiceSpec("2.10.11"),
 			existingISBSvcDef:      createDefaultISBService("2.10.11", numaflowv1.ISBSvcPhaseRunning, false),

--- a/internal/controller/pause_requester.go
+++ b/internal/controller/pause_requester.go
@@ -48,7 +48,7 @@ func processChildObjectWithoutDataLoss(ctx context.Context, rollout client.Objec
 		// Don't do this yet if we just made a request - it's too soon for anything to have happened
 		if !pauseRequestUpdated && resourceNeedsUpdating {
 
-			// check if the pipelines are all paused
+			// check if the pipelines are all paused (or can't be paused)
 			allPaused, err := areAllPipelinesPausedOrUnpausible(ctx, pauseRequester, rolloutNamespace, rolloutName)
 			if err != nil {
 				return false, err

--- a/internal/controller/pause_requester.go
+++ b/internal/controller/pause_requester.go
@@ -49,12 +49,12 @@ func processChildObjectWithoutDataLoss(ctx context.Context, rollout client.Objec
 		if !pauseRequestUpdated && resourceNeedsUpdating {
 
 			// check if the pipelines are all paused
-			allPaused, err := areAllPipelinesPaused(ctx, pauseRequester, rolloutNamespace, rolloutName)
+			allPaused, err := areAllPipelinesPausedOrUnpausible(ctx, pauseRequester, rolloutNamespace, rolloutName)
 			if err != nil {
 				return false, err
 			}
 			if allPaused {
-				numaLogger.Infof("confirmed all Pipelines have paused so %s can safely update", pauseRequester.getChildTypeString())
+				numaLogger.Infof("confirmed all Pipelines have paused (or can't pause) so %s can safely update", pauseRequester.getChildTypeString())
 				err = updateFunc()
 				if err != nil {
 					return false, err
@@ -100,8 +100,8 @@ func requestPipelinesPause(ctx context.Context, pauseRequester PauseRequester, r
 	return updated, err
 }
 
-// check if all Pipelines corresponding to this Rollout have paused
-func areAllPipelinesPaused(ctx context.Context, pauseRequester PauseRequester, rolloutNamespace string, rolloutName string) (bool, error) {
+// check if all Pipelines corresponding to this Rollout have paused or are otherwise not pausible (contract with Numaflow is that this is Pipelines which are "Failed")
+func areAllPipelinesPausedOrUnpausible(ctx context.Context, pauseRequester PauseRequester, rolloutNamespace string, rolloutName string) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
 	pipelines, err := pauseRequester.getPipelineList(ctx, rolloutNamespace, rolloutName)
 	if err != nil {
@@ -112,8 +112,9 @@ func areAllPipelinesPaused(ctx context.Context, pauseRequester PauseRequester, r
 		if err != nil {
 			return false, err
 		}
-		if status.Phase != "Paused" {
+		if status.Phase != "Paused" && status.Phase != "Failed" {
 			numaLogger.Debugf("pipeline %q has status.phase=%q", pipeline.Name, status.Phase)
+
 			return false, nil
 		}
 	}

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -572,6 +572,7 @@ func pipelineIsUpdating(newPipelineDef *kubernetes.GenericObject, existingPipeli
 	// note if Pipeline's children are still being updated
 	unhealthyOrProgressing, _ := checkChildResources(existingPipelineStatus.Conditions, func(c metav1.Condition) bool {
 		// TODO: once we have "inProgressStrategy" we can just look for c.Status == metav1.ConditionFalse while inProgressStrategy==PPND
+		// https://github.com/numaproj/numaplane/issues/239
 		return c.Reason == "Progressing" || c.Reason == "GetDaemonServiceFailed" //return c.Status == metav1.ConditionFalse
 	})
 

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -569,13 +569,9 @@ func pipelineIsUpdating(newPipelineDef *kubernetes.GenericObject, existingPipeli
 		return true, nil
 	}
 
-	/*progressing, _ := checkChildResources(existingPipelineStatus.Conditions, func(c metav1.Condition) bool {
-		return c.Reason == "Progressing"
-	})*/
-
 	// note if Pipeline's children are still being updated
 	unhealthyOrProgressing, _ := checkChildResources(existingPipelineStatus.Conditions, func(c metav1.Condition) bool {
-		// TODO: if we simply always set to "Progressing", we don't need the second case
+		// TODO: once we have "inProgressStrategy" we can just look for c.Status == metav1.ConditionFalse while inProgressStrategy==PPND
 		return c.Reason == "Progressing" || c.Reason == "GetDaemonServiceFailed" //return c.Status == metav1.ConditionFalse
 	})
 

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -575,7 +575,8 @@ func pipelineIsUpdating(newPipelineDef *kubernetes.GenericObject, existingPipeli
 
 	// note if Pipeline's children are still being updated
 	unhealthyOrProgressing, _ := checkChildResources(existingPipelineStatus.Conditions, func(c metav1.Condition) bool {
-		return c.Status == metav1.ConditionFalse
+		// TODO: if we simply always set to "Progressing", we don't need the second case
+		return c.Reason == "Progressing" || c.Reason == "GetDaemonServiceFailed" //return c.Status == metav1.ConditionFalse
 	})
 
 	return unhealthyOrProgressing, nil

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -21,12 +21,13 @@ import (
 )
 
 var (
-	dynamicClient dynamic.DynamicClient
-	testEnv       *envtest.Environment
-	ctx           context.Context
-	cancel        context.CancelFunc
-	suiteTimeout  = 5 * time.Minute
-	testTimeout   = 2 * time.Minute
+	dynamicClient       dynamic.DynamicClient
+	testEnv             *envtest.Environment
+	ctx                 context.Context
+	cancel              context.CancelFunc
+	suiteTimeout        = 30 * time.Minute
+	testTimeout         = 2 * time.Minute
+	testPollingInterval = 1 * time.Second
 
 	pipelineRolloutClient           planepkg.PipelineRolloutInterface
 	isbServiceRolloutClient         planepkg.ISBServiceRolloutInterface

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -25,7 +25,7 @@ var (
 	testEnv             *envtest.Environment
 	ctx                 context.Context
 	cancel              context.CancelFunc
-	suiteTimeout        = 30 * time.Minute
+	suiteTimeout        = 30 * time.Minute // Note: if we start seeing "client rate limiter: context deadline exceeded", we need to increase this value
 	testTimeout         = 2 * time.Minute
 	testPollingInterval = 1 * time.Second
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -47,6 +47,7 @@ var (
 	pipelineSpecSourceDuration = metav1.Duration{
 		Duration: time.Second,
 	}
+	one          = int32(1)
 	pipelineSpec = numaflowv1.PipelineSpec{
 		InterStepBufferServiceName: isbServiceRolloutName,
 		Vertices: []numaflowv1.AbstractVertex{
@@ -58,6 +59,10 @@ var (
 						Duration: &pipelineSpecSourceDuration,
 					},
 				},
+				Scale: numaflowv1.Scale{
+					Min: &one,
+					Max: &one,
+				},
 			},
 			{
 				Name: "out",
@@ -65,6 +70,10 @@ var (
 					AbstractSink: numaflowv1.AbstractSink{
 						Log: &numaflowv1.Log{},
 					},
+				},
+				Scale: numaflowv1.Scale{
+					Min: &one,
+					Max: &one,
 				},
 			},
 		},
@@ -259,7 +268,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		// new NumaflowController spec
 		updatedNumaflowControllerSpec := apiv1.NumaflowControllerRolloutSpec{
-			Controller: apiv1.Controller{Version: "0.0.6"},
+			Controller: apiv1.Controller{Version: "0.0.9"},
 		}
 
 		updateNumaflowControllerRolloutInK8S(func(rollout apiv1.NumaflowControllerRollout) (apiv1.NumaflowControllerRollout, error) {
@@ -270,7 +279,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		// TODO: update this controller image when Numaflow v1.3.1 is released
 		//       versions prior to v1.3.0 do not reconcile MonoVertex
 		verifyNumaflowControllerDeployment(Namespace, func(d appsv1.Deployment) bool {
-			return d.Spec.Template.Spec.Containers[0].Image == "quay.io/numaio/numaflow-rc:v0.0.6"
+			return d.Spec.Template.Spec.Containers[0].Image == "quay.io/numaio/numaflow-rc:v0.0.9"
 		})
 
 		verifyNumaflowControllerReady(Namespace)
@@ -500,7 +509,7 @@ func createNumaflowControllerRolloutSpec(name, namespace string) *apiv1.Numaflow
 			Namespace: namespace,
 		},
 		Spec: apiv1.NumaflowControllerRolloutSpec{
-			Controller: apiv1.Controller{Version: "1.3.0"},
+			Controller: apiv1.Controller{Version: "0.0.8"},
 		},
 	}
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -48,7 +48,7 @@ var (
 		Duration: time.Second,
 	}
 	numVertices         = int32(1)
-	zeroReplicaSleepSec = uint32(15)
+	zeroReplicaSleepSec = uint32(15) // if for some reason the Vertex has 0 replicas, this will cause Numaflow to address it
 	pipelineSpec        = numaflowv1.PipelineSpec{
 		InterStepBufferServiceName: isbServiceRolloutName,
 		Vertices: []numaflowv1.AbstractVertex{

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -48,7 +48,7 @@ var (
 		Duration: time.Second,
 	}
 	numVertices         = int32(1)
-	zeroReplicaSleepSec = uint32(15) // if for some reason the Vertex has 0 replicas, this will cause Numaflow to address it
+	zeroReplicaSleepSec = uint32(15) // if for some reason the Vertex has 0 replicas, this will cause Numaflow to scale it back up
 	pipelineSpec        = numaflowv1.PipelineSpec{
 		InterStepBufferServiceName: isbServiceRolloutName,
 		Vertices: []numaflowv1.AbstractVertex{

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -48,8 +48,9 @@ var (
 	pipelineSpecSourceDuration = metav1.Duration{
 		Duration: time.Second,
 	}
-	one          = int32(1)
-	pipelineSpec = numaflowv1.PipelineSpec{
+	numVertices         = int32(1)
+	zeroReplicaSleepSec = uint32(15)
+	pipelineSpec        = numaflowv1.PipelineSpec{
 		InterStepBufferServiceName: isbServiceRolloutName,
 		Vertices: []numaflowv1.AbstractVertex{
 			{
@@ -60,10 +61,7 @@ var (
 						Duration: &pipelineSpecSourceDuration,
 					},
 				},
-				Scale: numaflowv1.Scale{
-					Min: &one,
-					Max: &one,
-				},
+				Scale: numaflowv1.Scale{Min: &numVertices, Max: &numVertices, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
 			},
 			{
 				Name: "out",
@@ -72,10 +70,7 @@ var (
 						Log: &numaflowv1.Log{},
 					},
 				},
-				Scale: numaflowv1.Scale{
-					Min: &one,
-					Max: &one,
-				},
+				Scale: numaflowv1.Scale{Min: &numVertices, Max: &numVertices, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
 			},
 		},
 		Edges: []numaflowv1.Edge{
@@ -269,7 +264,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		// new NumaflowController spec
 		updatedNumaflowControllerSpec := apiv1.NumaflowControllerRolloutSpec{
-			Controller: apiv1.Controller{Version: "0.0.9"},
+			Controller: apiv1.Controller{Version: "0.0.13"},
 		}
 
 		updateNumaflowControllerRolloutInK8S(func(rollout apiv1.NumaflowControllerRollout) (apiv1.NumaflowControllerRollout, error) {
@@ -280,7 +275,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		// TODO: update this controller image when Numaflow v1.3.1 is released
 		//       versions prior to v1.3.0 do not reconcile MonoVertex
 		verifyNumaflowControllerDeployment(Namespace, func(d appsv1.Deployment) bool {
-			return d.Spec.Template.Spec.Containers[0].Image == "quay.io/numaio/numaflow-rc:v0.0.9"
+			return d.Spec.Template.Spec.Containers[0].Image == "quay.io/numaio/numaflow-rc:v0.0.13"
 		})
 
 		verifyNumaflowControllerReady(Namespace)
@@ -528,7 +523,7 @@ func createNumaflowControllerRolloutSpec(name, namespace string) *apiv1.Numaflow
 			Namespace: namespace,
 		},
 		Spec: apiv1.NumaflowControllerRolloutSpec{
-			Controller: apiv1.Controller{Version: "0.0.8"},
+			Controller: apiv1.Controller{Version: "0.0.12"},
 		},
 	}
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -138,7 +137,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() error {
 			_, err := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 			return err
-		}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(Succeed())
+		}, testTimeout, testPollingInterval).Should(Succeed())
 
 		verifyNumaflowControllerReady(Namespace)
 	})
@@ -153,7 +152,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() error {
 			_, err := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 			return err
-		}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(Succeed())
+		}, testTimeout, testPollingInterval).Should(Succeed())
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 
@@ -169,7 +168,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() error {
 			_, err := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 			return err
-		}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(Succeed())
+		}, testTimeout, testPollingInterval).Should(Succeed())
 
 		document("Verifying that the Pipeline was created")
 		verifyPipelineSpec(Namespace, pipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
@@ -191,7 +190,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() error {
 			_, err := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
 			return err
-		}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(Succeed())
+		}, testTimeout, testPollingInterval).Should(Succeed())
 
 		document("Verifying that the MonoVertex was created")
 		// verifyMonoVertexSpec(Namespace, monoVertexRolloutName, func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec) bool {
@@ -300,24 +299,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 		verifyISBServiceSpec(Namespace, isbServiceRolloutName, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream.Version == "2.9.8"
 		})
-
-		time.Sleep(90 * time.Second)
-
-		statefulSet, err := kubeClient.AppsV1().StatefulSets(Namespace).Get(ctx, fmt.Sprintf("isbsvc-%s-js", isbServiceRolloutName), metav1.GetOptions{})
-		fmt.Printf("err = %v, statefulSet: %+v\n", err, statefulSet)
-		if statefulSet == nil {
-			fmt.Println("statefulset nil")
-			By("statefulset nil")
-		} else if statefulSet.Status.ObservedGeneration != 2 {
-			fmt.Printf("statefulset observedGeneration=%d\n", statefulSet.Status.ObservedGeneration)
-			By(fmt.Sprintf("statefulset observedGeneration=%d\n", statefulSet.Status.ObservedGeneration))
-		} else if statefulSet.Status.UpdatedReplicas != int32(3) {
-			fmt.Printf("statefulset UpdatedReplicas=%d\n", statefulSet.Status.UpdatedReplicas)
-			By(fmt.Sprintf("statefulset UpdatedReplicas=%d\n", statefulSet.Status.UpdatedReplicas))
-		} else {
-			fmt.Println("statefulset passed all")
-			By("statefulset passed all")
-		}
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -48,7 +48,7 @@ func verifyISBServiceSpec(namespace string, name string, f func(numaflowv1.Inter
 		}
 
 		return f(retrievedISBServiceSpec)
-	}).WithTimeout(testTimeout).Should(BeTrue())
+	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
 }
 
 func verifyISBSvcReady(namespace string, isbsvcName string, nodeSize int) {
@@ -56,14 +56,15 @@ func verifyISBSvcReady(namespace string, isbsvcName string, nodeSize int) {
 	Eventually(func() error {
 		_, err := dynamicClient.Resource(getGVRForISBService()).Namespace(namespace).Get(ctx, isbsvcName, metav1.GetOptions{})
 		return err
-	}).WithTimeout(testTimeout).Should(Succeed())
+	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(Succeed())
 
 	// TODO: eventually we can use ISBServiceRollout.Status.Conditions(ChildResourcesHealthy) to get this instead
+
 	document("Verifying that the StatefulSet exists and is ready")
 	Eventually(func() bool {
 		statefulSet, _ := kubeClient.AppsV1().StatefulSets(namespace).Get(ctx, fmt.Sprintf("isbsvc-%s-js", isbsvcName), metav1.GetOptions{})
 		return statefulSet != nil && statefulSet.Generation == statefulSet.Status.ObservedGeneration && statefulSet.Status.UpdatedReplicas == int32(nodeSize)
-	}).WithTimeout(5 * time.Minute).Should(BeTrue())
+	}).WithTimeout(testTimeout).WithPolling(10 * time.Second).Should(BeTrue())
 
 	document("Verifying that the StatefulSet Pods are in Running phase")
 	Eventually(func() bool {
@@ -77,7 +78,7 @@ func verifyISBSvcReady(namespace string, isbsvcName string, nodeSize int) {
 			}
 		}
 		return podsInRunning == nodeSize
-	}).WithTimeout(testTimeout).Should(BeTrue())
+	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
 }
 
 func updateISBServiceRolloutInK8S(name string, f func(apiv1.ISBServiceRollout) (apiv1.ISBServiceRollout, error)) {

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +47,7 @@ func verifyISBServiceSpec(namespace string, name string, f func(numaflowv1.Inter
 		}
 
 		return f(retrievedISBServiceSpec)
-	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
+	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
 func verifyISBSvcReady(namespace string, isbsvcName string, nodeSize int) {
@@ -56,7 +55,7 @@ func verifyISBSvcReady(namespace string, isbsvcName string, nodeSize int) {
 	Eventually(func() error {
 		_, err := dynamicClient.Resource(getGVRForISBService()).Namespace(namespace).Get(ctx, isbsvcName, metav1.GetOptions{})
 		return err
-	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(Succeed())
+	}, testTimeout, testPollingInterval).Should(Succeed())
 
 	// TODO: eventually we can use ISBServiceRollout.Status.Conditions(ChildResourcesHealthy) to get this instead
 
@@ -64,7 +63,7 @@ func verifyISBSvcReady(namespace string, isbsvcName string, nodeSize int) {
 	Eventually(func() bool {
 		statefulSet, _ := kubeClient.AppsV1().StatefulSets(namespace).Get(ctx, fmt.Sprintf("isbsvc-%s-js", isbsvcName), metav1.GetOptions{})
 		return statefulSet != nil && statefulSet.Generation == statefulSet.Status.ObservedGeneration && statefulSet.Status.UpdatedReplicas == int32(nodeSize)
-	}).WithTimeout(testTimeout).WithPolling(10 * time.Second).Should(BeTrue())
+	}, testTimeout, testPollingInterval).Should(BeTrue())
 
 	document("Verifying that the StatefulSet Pods are in Running phase")
 	Eventually(func() bool {
@@ -78,7 +77,7 @@ func verifyISBSvcReady(namespace string, isbsvcName string, nodeSize int) {
 			}
 		}
 		return podsInRunning == nodeSize
-	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
+	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
 func updateISBServiceRolloutInK8S(name string, f func(apiv1.ISBServiceRollout) (apiv1.ISBServiceRollout, error)) {

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -62,7 +63,7 @@ func verifyISBSvcReady(namespace string, isbsvcName string, nodeSize int) {
 	Eventually(func() bool {
 		statefulSet, _ := kubeClient.AppsV1().StatefulSets(namespace).Get(ctx, fmt.Sprintf("isbsvc-%s-js", isbsvcName), metav1.GetOptions{})
 		return statefulSet != nil && statefulSet.Generation == statefulSet.Status.ObservedGeneration && statefulSet.Status.UpdatedReplicas == int32(nodeSize)
-	}).WithTimeout(testTimeout).Should(BeTrue())
+	}).WithTimeout(5 * time.Minute).Should(BeTrue())
 
 	document("Verifying that the StatefulSet Pods are in Running phase")
 	Eventually(func() bool {

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +45,7 @@ func verifyMonoVertexSpec(namespace, name string, f func(numaflowv1.MonoVertexSp
 			return false
 		}
 		return f(retrievedMonoVertexSpec)
-	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
+	}, testTimeout, testPollingInterval).Should(BeTrue())
 
 }
 
@@ -84,7 +83,7 @@ func verifyMonoVertexStatus(namespace, monoVertexName string, f func(numaflowv1.
 			return false
 		}
 		return f(retrievedMonoVertexSpec, retrievedMonoVertexStatus)
-	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
+	}, testTimeout, testPollingInterval).Should(BeTrue())
 
 }
 

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +46,7 @@ func verifyMonoVertexSpec(namespace, name string, f func(numaflowv1.MonoVertexSp
 			return false
 		}
 		return f(retrievedMonoVertexSpec)
-	}).WithTimeout(testTimeout).Should(BeTrue())
+	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
 
 }
 
@@ -83,7 +84,7 @@ func verifyMonoVertexStatus(namespace, monoVertexName string, f func(numaflowv1.
 			return false
 		}
 		return f(retrievedMonoVertexSpec, retrievedMonoVertexStatus)
-	}).WithTimeout(testTimeout).Should(BeTrue())
+	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
 
 }
 

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -1,8 +1,6 @@
 package e2e
 
 import (
-	"time"
-
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -25,7 +23,7 @@ func verifyNumaflowControllerDeployment(namespace string, f func(appsv1.Deployme
 			return false
 		}
 		return f(*deployment)
-	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
+	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
 func verifyNumaflowControllerReady(namespace string) {
@@ -33,7 +31,7 @@ func verifyNumaflowControllerReady(namespace string) {
 	Eventually(func() error {
 		_, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 		return err
-	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(Succeed())
+	}, testTimeout, testPollingInterval).Should(Succeed())
 
 	document("Verifying that the Numaflow ControllerRollout is ready")
 	Eventually(func() bool {
@@ -47,7 +45,7 @@ func verifyNumaflowControllerReady(namespace string) {
 		}
 		return childResourcesHealthyCondition.Status == metav1.ConditionTrue
 
-	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
+	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
 func updateNumaflowControllerRolloutInK8S(f func(apiv1.NumaflowControllerRollout) (apiv1.NumaflowControllerRollout, error)) {

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"time"
+
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -23,7 +25,7 @@ func verifyNumaflowControllerDeployment(namespace string, f func(appsv1.Deployme
 			return false
 		}
 		return f(*deployment)
-	}).WithTimeout(testTimeout).Should(BeTrue())
+	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
 }
 
 func verifyNumaflowControllerReady(namespace string) {
@@ -31,7 +33,7 @@ func verifyNumaflowControllerReady(namespace string) {
 	Eventually(func() error {
 		_, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 		return err
-	}).WithTimeout(testTimeout).Should(Succeed())
+	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(Succeed())
 
 	document("Verifying that the Numaflow ControllerRollout is ready")
 	Eventually(func() bool {
@@ -45,7 +47,7 @@ func verifyNumaflowControllerReady(namespace string) {
 		}
 		return childResourcesHealthyCondition.Status == metav1.ConditionTrue
 
-	}).WithTimeout(testTimeout).Should(BeTrue())
+	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
 }
 
 func updateNumaflowControllerRolloutInK8S(f func(apiv1.NumaflowControllerRollout) (apiv1.NumaflowControllerRollout, error)) {

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -32,7 +31,7 @@ func verifyPipelineSpec(namespace string, pipelineName string, f func(numaflowv1
 		}
 
 		return f(retrievedPipelineSpec)
-	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
+	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
 func verifyPipelineStatus(namespace string, pipelineName string, f func(numaflowv1.PipelineSpec, kubernetes.GenericStatus) bool) {
@@ -53,7 +52,7 @@ func verifyPipelineStatus(namespace string, pipelineName string, f func(numaflow
 		}
 
 		return f(retrievedPipelineSpec, retrievedPipelineStatus)
-	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
+	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
 func verifyPipelineReady(namespace string, pipelineName string, numVertices int) {

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -31,7 +32,7 @@ func verifyPipelineSpec(namespace string, pipelineName string, f func(numaflowv1
 		}
 
 		return f(retrievedPipelineSpec)
-	}).WithTimeout(testTimeout).Should(BeTrue())
+	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
 }
 
 func verifyPipelineStatus(namespace string, pipelineName string, f func(numaflowv1.PipelineSpec, kubernetes.GenericStatus) bool) {
@@ -52,7 +53,7 @@ func verifyPipelineStatus(namespace string, pipelineName string, f func(numaflow
 		}
 
 		return f(retrievedPipelineSpec, retrievedPipelineStatus)
-	}).WithTimeout(testTimeout).Should(BeTrue())
+	}).WithTimeout(testTimeout).WithPolling(1 * time.Second).Should(BeTrue())
 }
 
 func verifyPipelineReady(namespace string, pipelineName string, numVertices int) {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -61,6 +61,8 @@ var _ = BeforeSuite(func() {
 	}
 
 	cfg, err := testEnv.Start()
+	cfg.QPS = 10000
+	cfg.Burst = 1000
 	Expect(cfg).NotTo(BeNil())
 	Expect(err).NotTo(HaveOccurred())
 

--- a/tests/manifests/default/controller_definitions.yaml
+++ b/tests/manifests/default/controller_definitions.yaml
@@ -397,7 +397,7 @@ controllerDefinitions:
             name: controller-config-volume
 
 
-- version: "1.3.1"
+- version: "1.3.0"
   fullSpec: |
     apiVersion: v1
     kind: ServiceAccount
@@ -716,7 +716,7 @@ controllerDefinitions:
             - controller
             env:
             - name: NUMAFLOW_IMAGE
-              value: quay.io/numaproj/numaflow:v1.3.1
+              value: quay.io/numaproj/numaflow:v1.3.0
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -757,7 +757,7 @@ controllerDefinitions:
                   key: controller.leader.election.lease.renew.period
                   name: numaflow-cmd-params-config
                   optional: true
-            image: quay.io/numaproj/numaflow:v1.3.1
+            image: quay.io/numaproj/numaflow:v1.3.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/tests/manifests/default/controller_definitions.yaml
+++ b/tests/manifests/default/controller_definitions.yaml
@@ -1,5 +1,5 @@
 controllerDefinitions:
-- version: "1.3.0"
+- version: "0.0.8"
   fullSpec: |
     apiVersion: v1
     kind: ServiceAccount
@@ -318,7 +318,7 @@ controllerDefinitions:
             - controller
             env:
             - name: NUMAFLOW_IMAGE
-              value: quay.io/numaproj/numaflow:v1.3.0
+              value: quay.io/numaio/numaflow-rc:v0.0.8
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -359,8 +359,803 @@ controllerDefinitions:
                   key: controller.leader.election.lease.renew.period
                   name: numaflow-cmd-params-config
                   optional: true
-            image: quay.io/numaproj/numaflow:v1.3.0
-            imagePullPolicy: Always
+            image: quay.io/numaio/numaflow-rc:v0.0.8
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: 8081
+              initialDelaySeconds: 3
+              periodSeconds: 3
+            name: controller-manager
+            ports:
+            - containerPort: 9090
+              name: metrics
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: 8081
+              initialDelaySeconds: 3
+              periodSeconds: 3
+            resources:
+              limits:
+                cpu: 500m
+                memory: 1024Mi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+            volumeMounts:
+            - mountPath: /etc/numaflow
+              name: controller-config-volume
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 9737
+          serviceAccountName: numaflow-sa
+          volumes:
+          - configMap:
+              name: numaflow-controller-config
+            name: controller-config-volume
+
+
+- version: "1.3.1"
+  fullSpec: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: numaflow-sa
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller-manager
+        app.kubernetes.io/name: numaflow-controller-manager
+        app.kubernetes.io/part-of: numaflow
+      name: numaflow-role
+    rules:
+    - apiGroups:
+      - numaflow.numaproj.io
+      resources:
+      - interstepbufferservices
+      - interstepbufferservices/finalizers
+      - interstepbufferservices/status
+      - pipelines
+      - pipelines/finalizers
+      - pipelines/status
+      - vertices
+      - vertices/finalizers
+      - vertices/status
+      - vertices/scale
+      - monovertices
+      - monovertices/finalizers
+      - monovertices/status
+      - monovertices/scale
+      verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - pods/exec
+      - configmaps
+      - services
+      - persistentvolumeclaims
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      - statefulsets
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - batch
+      resources:
+      - jobs
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller-manager
+        app.kubernetes.io/name: numaflow-controller-manager
+        app.kubernetes.io/part-of: numaflow
+      name: numaflow-role-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: numaflow-role
+    subjects:
+    - kind: ServiceAccount
+      name: numaflow-sa
+    ---
+    apiVersion: v1
+    data:
+      namespaced: "true"
+      server.disable.auth: "true"
+    kind: ConfigMap
+    metadata:
+      name: numaflow-cmd-params-config
+    ---
+    apiVersion: v1
+    data:
+      controller-config.yaml: |
+        defaults:
+          containerResources: |
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+        isbsvc:
+          redis:
+            # Default Redis settings, could be overridden by InterStepBufferService specs
+            settings:
+              # Redis config shared by both master and replicas
+              redis: |
+                min-replicas-to-write 1
+                # Disable RDB persistence, AOF persistence already enabled.
+                save ""
+                # Enable AOF https://redis.io/topics/persistence#append-only-file
+                appendonly yes
+                auto-aof-rewrite-percentage 100
+                auto-aof-rewrite-min-size 64mb
+                maxmemory 512mb
+                maxmemory-policy allkeys-lru
+              # Special config only used by master
+              master: ""
+              # Special config only used by replicas
+              replica: ""
+              # Sentinel config
+              sentinel: |
+                sentinel down-after-milliseconds mymaster 10000
+                sentinel failover-timeout mymaster 2000
+                sentinel parallel-syncs mymaster 1
+            versions:
+            - version: 7.0.11
+              redisImage: bitnami/redis:7.0.11-debian-11-r3
+              sentinelImage: bitnami/redis-sentinel:7.0.11-debian-11-r3
+              redisExporterImage: bitnami/redis-exporter:1.50.0-debian-11-r4
+              initContainerImage: debian:latest
+            - version: 7.0.15
+              redisImage: bitnami/redis:7.0.15-debian-11-r2
+              sentinelImage: bitnami/redis-sentinel:7.0.15-debian-11-r2
+              redisExporterImage: bitnami/redis-exporter:1.56.0-debian-11-r2
+              initContainerImage: debian:latest
+          jetstream:
+            # Default JetStream settings, could be overridden by InterStepBufferService specs
+            settings: |
+              # https://docs.nats.io/running-a-nats-service/configuration#limits
+              # Only support to configure "max_payload".
+              # Max payload size in bytes, defaults to 1 MB. It is not recommended to use values over 8MB but max_payload can be set up to 64MB.
+              max_payload: 1048576
+              # https://docs.nats.io/running-a-nats-service/configuration#jetstream
+              # Only configure "max_memory_store" or "max_file_store", do not set "store_dir" as it has been hardcoded.
+              # e.g. 1G. -1 means no limit, up to 75% of available memory. This only take effect for streams created using memory storage.
+              max_memory_store: -1
+              # e.g. 20G. -1 means no limit, Up to 1TB if available
+              max_file_store: 1TB
+            bufferConfig: |
+              # The default properties of the buffers (streams) to be created in this JetStream service
+              stream:
+                # 0: Limits, 1: Interest, 2: WorkQueue
+                retention: 0
+                maxMsgs: 100000
+                maxAge: 72h
+                maxBytes: -1
+                # 0: File, 1: Memory
+                storage: 0
+                replicas: 3
+                duplicates: 60s
+              # The default consumer properties for the created streams
+              consumer:
+                ackWait: 60s
+                maxAckPending: 25000
+              otBucket:
+                maxValueSize: 0
+                history: 1
+                ttl: 3h
+                maxBytes: 0
+                # 0: File, 1: Memory
+                storage: 0
+                replicas: 3
+              procBucket:
+                maxValueSize: 0
+                history: 1
+                ttl: 72h
+                maxBytes: 0
+                # 0: File, 1: Memory
+                storage: 0
+                replicas: 3
+            versions:
+            - version: latest
+              natsImage: nats:2.10.17
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.8.1
+              natsImage: nats:2.8.1
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.8.1-alpine
+              natsImage: nats:2.8.1-alpine
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: nats-server
+            - version: 2.8.3
+              natsImage: nats:2.8.3
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.8.3-alpine
+              natsImage: nats:2.8.3-alpine
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: nats-server
+            - version: 2.9.0
+              natsImage: nats:2.9.0
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.9.0-alpine
+              natsImage: nats:2.9.0-alpine
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: nats-server
+            - version: 2.9.6
+              natsImage: nats:2.9.6
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.9.8
+              natsImage: nats:2.9.8
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.9.15
+              natsImage: nats:2.9.15
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.10.3
+              natsImage: nats:2.10.3
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.10.11
+              natsImage: nats:2.10.11
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.10.17
+              natsImage: nats:2.10.17
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+    kind: ConfigMap
+    metadata:
+      name: numaflow-controller-config
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: numaflow-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: controller-manager
+          app.kubernetes.io/name: controller-manager
+          app.kubernetes.io/part-of: numaflow
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: controller-manager
+            app.kubernetes.io/name: controller-manager
+            app.kubernetes.io/part-of: numaflow
+        spec:
+          containers:
+          - args:
+            - controller
+            env:
+            - name: NUMAFLOW_IMAGE
+              value: quay.io/numaproj/numaflow:v1.3.1
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NUMAFLOW_CONTROLLER_NAMESPACED
+              valueFrom:
+                configMapKeyRef:
+                  key: namespaced
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  key: managed.namespace
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_DISABLED
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.disabled
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.duration
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.renew.deadline
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.renew.period
+                  name: numaflow-cmd-params-config
+                  optional: true
+            image: quay.io/numaproj/numaflow:v1.3.1
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: 8081
+              initialDelaySeconds: 3
+              periodSeconds: 3
+            name: controller-manager
+            ports:
+            - containerPort: 9090
+              name: metrics
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: 8081
+              initialDelaySeconds: 3
+              periodSeconds: 3
+            resources:
+              limits:
+                cpu: 500m
+                memory: 1024Mi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+            volumeMounts:
+            - mountPath: /etc/numaflow
+              name: controller-config-volume
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 9737
+          serviceAccountName: numaflow-sa
+          volumes:
+          - configMap:
+              name: numaflow-controller-config
+            name: controller-config-volume
+
+- version: "0.0.9"
+  fullSpec: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: numaflow-sa
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller-manager
+        app.kubernetes.io/name: numaflow-controller-manager
+        app.kubernetes.io/part-of: numaflow
+      name: numaflow-role
+    rules:
+    - apiGroups:
+      - numaflow.numaproj.io
+      resources:
+      - interstepbufferservices
+      - interstepbufferservices/finalizers
+      - interstepbufferservices/status
+      - pipelines
+      - pipelines/finalizers
+      - pipelines/status
+      - vertices
+      - vertices/finalizers
+      - vertices/status
+      - vertices/scale
+      - monovertices
+      - monovertices/finalizers
+      - monovertices/status
+      - monovertices/scale
+      verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - pods/exec
+      - configmaps
+      - services
+      - persistentvolumeclaims
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - create
+      - get
+      - list
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      - statefulsets
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - batch
+      resources:
+      - jobs
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller-manager
+        app.kubernetes.io/name: numaflow-controller-manager
+        app.kubernetes.io/part-of: numaflow
+      name: numaflow-role-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: numaflow-role
+    subjects:
+    - kind: ServiceAccount
+      name: numaflow-sa
+    ---
+    apiVersion: v1
+    data:
+      namespaced: "true"
+      server.disable.auth: "true"
+    kind: ConfigMap
+    metadata:
+      name: numaflow-cmd-params-config
+    ---
+    apiVersion: v1
+    data:
+      controller-config.yaml: |
+        defaults:
+          containerResources: |
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+        isbsvc:
+          redis:
+            # Default Redis settings, could be overridden by InterStepBufferService specs
+            settings:
+              # Redis config shared by both master and replicas
+              redis: |
+                min-replicas-to-write 1
+                # Disable RDB persistence, AOF persistence already enabled.
+                save ""
+                # Enable AOF https://redis.io/topics/persistence#append-only-file
+                appendonly yes
+                auto-aof-rewrite-percentage 100
+                auto-aof-rewrite-min-size 64mb
+                maxmemory 512mb
+                maxmemory-policy allkeys-lru
+              # Special config only used by master
+              master: ""
+              # Special config only used by replicas
+              replica: ""
+              # Sentinel config
+              sentinel: |
+                sentinel down-after-milliseconds mymaster 10000
+                sentinel failover-timeout mymaster 2000
+                sentinel parallel-syncs mymaster 1
+            versions:
+            - version: 7.0.11
+              redisImage: bitnami/redis:7.0.11-debian-11-r3
+              sentinelImage: bitnami/redis-sentinel:7.0.11-debian-11-r3
+              redisExporterImage: bitnami/redis-exporter:1.50.0-debian-11-r4
+              initContainerImage: debian:latest
+            - version: 7.0.15
+              redisImage: bitnami/redis:7.0.15-debian-11-r2
+              sentinelImage: bitnami/redis-sentinel:7.0.15-debian-11-r2
+              redisExporterImage: bitnami/redis-exporter:1.56.0-debian-11-r2
+              initContainerImage: debian:latest
+          jetstream:
+            # Default JetStream settings, could be overridden by InterStepBufferService specs
+            settings: |
+              # https://docs.nats.io/running-a-nats-service/configuration#limits
+              # Only support to configure "max_payload".
+              # Max payload size in bytes, defaults to 1 MB. It is not recommended to use values over 8MB but max_payload can be set up to 64MB.
+              max_payload: 1048576
+              # https://docs.nats.io/running-a-nats-service/configuration#jetstream
+              # Only configure "max_memory_store" or "max_file_store", do not set "store_dir" as it has been hardcoded.
+              # e.g. 1G. -1 means no limit, up to 75% of available memory. This only take effect for streams created using memory storage.
+              max_memory_store: -1
+              # e.g. 20G. -1 means no limit, Up to 1TB if available
+              max_file_store: 1TB
+            bufferConfig: |
+              # The default properties of the buffers (streams) to be created in this JetStream service
+              stream:
+                # 0: Limits, 1: Interest, 2: WorkQueue
+                retention: 0
+                maxMsgs: 100000
+                maxAge: 72h
+                maxBytes: -1
+                # 0: File, 1: Memory
+                storage: 0
+                replicas: 3
+                duplicates: 60s
+              # The default consumer properties for the created streams
+              consumer:
+                ackWait: 60s
+                maxAckPending: 25000
+              otBucket:
+                maxValueSize: 0
+                history: 1
+                ttl: 3h
+                maxBytes: 0
+                # 0: File, 1: Memory
+                storage: 0
+                replicas: 3
+              procBucket:
+                maxValueSize: 0
+                history: 1
+                ttl: 72h
+                maxBytes: 0
+                # 0: File, 1: Memory
+                storage: 0
+                replicas: 3
+            versions:
+            - version: latest
+              natsImage: nats:2.10.17
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.8.1
+              natsImage: nats:2.8.1
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.8.1-alpine
+              natsImage: nats:2.8.1-alpine
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: nats-server
+            - version: 2.8.3
+              natsImage: nats:2.8.3
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.8.3-alpine
+              natsImage: nats:2.8.3-alpine
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: nats-server
+            - version: 2.9.0
+              natsImage: nats:2.9.0
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.9.0-alpine
+              natsImage: nats:2.9.0-alpine
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: nats-server
+            - version: 2.9.6
+              natsImage: nats:2.9.6
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.9.8
+              natsImage: nats:2.9.8
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.9.15
+              natsImage: nats:2.9.15
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.10.3
+              natsImage: nats:2.10.3
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.10.11
+              natsImage: nats:2.10.11
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+            - version: 2.10.17
+              natsImage: nats:2.10.17
+              metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+              configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+              startCommand: /nats-server
+    kind: ConfigMap
+    metadata:
+      name: numaflow-controller-config
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: numaflow-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: controller-manager
+          app.kubernetes.io/name: controller-manager
+          app.kubernetes.io/part-of: numaflow
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: controller-manager
+            app.kubernetes.io/name: controller-manager
+            app.kubernetes.io/part-of: numaflow
+        spec:
+          containers:
+          - args:
+            - controller
+            env:
+            - name: NUMAFLOW_IMAGE
+              value: quay.io/numaio/numaflow-rc:v0.0.9
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NUMAFLOW_CONTROLLER_NAMESPACED
+              valueFrom:
+                configMapKeyRef:
+                  key: namespaced
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  key: managed.namespace
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_DISABLED
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.disabled
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.duration
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.renew.deadline
+                  name: numaflow-cmd-params-config
+                  optional: true
+            - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.leader.election.lease.renew.period
+                  name: numaflow-cmd-params-config
+                  optional: true
+            image: quay.io/numaio/numaflow-rc:v0.0.9
+            imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:
                 path: /healthz

--- a/tests/manifests/default/controller_definitions.yaml
+++ b/tests/manifests/default/controller_definitions.yaml
@@ -1,5 +1,5 @@
 controllerDefinitions:
-- version: "0.0.8"
+- version: "0.0.12"
   fullSpec: |
     apiVersion: v1
     kind: ServiceAccount
@@ -318,7 +318,7 @@ controllerDefinitions:
             - controller
             env:
             - name: NUMAFLOW_IMAGE
-              value: quay.io/numaio/numaflow-rc:v0.0.8
+              value: quay.io/numaio/numaflow-rc:v0.0.12
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -359,7 +359,7 @@ controllerDefinitions:
                   key: controller.leader.election.lease.renew.period
                   name: numaflow-cmd-params-config
                   optional: true
-            image: quay.io/numaio/numaflow-rc:v0.0.8
+            image: quay.io/numaio/numaflow-rc:v0.0.12
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:
@@ -794,7 +794,7 @@ controllerDefinitions:
               name: numaflow-controller-config
             name: controller-config-volume
 
-- version: "0.0.9"
+- version: "0.0.13"
   fullSpec: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1113,7 +1113,7 @@ controllerDefinitions:
             - controller
             env:
             - name: NUMAFLOW_IMAGE
-              value: quay.io/numaio/numaflow-rc:v0.0.9
+              value: quay.io/numaio/numaflow-rc:v0.0.13
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -1154,7 +1154,7 @@ controllerDefinitions:
                   key: controller.leader.election.lease.renew.period
                   name: numaflow-cmd-params-config
                   optional: true
-            image: quay.io/numaio/numaflow-rc:v0.0.9
+            image: quay.io/numaio/numaflow-rc:v0.0.13
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #230 

### Modifications

#### Modification 1: Don't pause "Failed" pipelines:

1. I don't pause pipelines if they're "Failed"
2. I can update the pipeline spec without waiting for a "Failed" pipeline to be "Paused"
3. I can update NumaflowController and ISBService specs if Pipelines are either "Paused" or "Failed"

##### Verification

1. unit test checks ISBService (same code is used for Numaflow Controller so presumably that is being verified at the same time)
2. manually tested this sequence: create bad pipeline which failed validation; attempted to update failed pipeline with a change which didn't fix the problem; updated failed pipeline by fixing the validation error
3. manually tested updating ISBServiceRO and NCRO while pipeline was failed 

#### Modification 2: Fix Pipeline Condition checking for PPND

Was accidentally checking the `PipelineRollout.Conditions` rather than `Pipeline.Conditions` when waiting for the Pipeline to be fully reconciled. 

##### Verification

I observed in the log that at the time we resumed the Pipeline all of the Child Conditions were in a healthy state. I also observed that the daemon was up and running.

#### Modification 3: e2e test

Have incorporated latest Numaflow release into e2e test.
Have increased suite timeout and added a comment in case we need to increase further in the future.
Have fixed the Makefile which was setting environment variable for the test related to bringing up a separate kubernetes environment, which we aren't using. 

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->