### PR TITLE
test: check rollout conditions in e2e tests

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -26,7 +26,7 @@ var (
 	testEnv       *envtest.Environment
 	ctx           context.Context
 	cancel        context.CancelFunc
-	suiteTimeout  = 15 * time.Minute
+	suiteTimeout  = 30 * time.Minute
 	testTimeout   = 2 * time.Minute
 
 	pipelineRolloutClient           planepkg.PipelineRolloutInterface

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
+	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 	planepkg "github.com/numaproj/numaplane/pkg/client/clientset/versioned/typed/numaplane/v1alpha1"
 )
 
@@ -25,7 +26,7 @@ var (
 	testEnv       *envtest.Environment
 	ctx           context.Context
 	cancel        context.CancelFunc
-	suiteTimeout  = 5 * time.Minute
+	suiteTimeout  = 15 * time.Minute
 	testTimeout   = 2 * time.Minute
 
 	pipelineRolloutClient           planepkg.PipelineRolloutInterface
@@ -72,6 +73,15 @@ func verifyPodsRunning(namespace string, numPods int, labelSelector string) {
 
 	}).WithTimeout(testTimeout).Should(BeTrue())
 
+}
+
+func getRolloutCondition(conditions []metav1.Condition, conditionType apiv1.ConditionType) metav1.ConditionStatus {
+	for _, cond := range conditions {
+		if cond.Type == string(conditionType) {
+			return cond.Status
+		}
+	}
+	return metav1.ConditionUnknown
 }
 
 func getNumaflowResourceStatus(u *unstructured.Unstructured) (kubernetes.GenericStatus, error) {

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -287,6 +287,17 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return *retrievedPipelineSpec.Vertices[0].Source.Generator.RPU == int64(10)
 		})
 
+		document("Verifying that the PipelineRollout conditions are as expected")
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
+
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
+		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionFalse))
+
 		verifyPipelineReady(Namespace, pipelineRolloutName, 2)
 
 	})
@@ -308,6 +319,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 		verifyNumaflowControllerDeployment(Namespace, func(d appsv1.Deployment) bool {
 			return d.Spec.Template.Spec.Containers[0].Image == "quay.io/numaio/numaflow-rc:v0.0.6"
 		})
+
+		document("Verifying that the NumaflowControllerRollout conditions are as expected")
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
 
 		verifyNumaflowControllerReady(Namespace)
 
@@ -332,6 +349,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return retrievedISBServiceSpec.JetStream.Version == "2.9.8"
 		})
 
+		document("Verifying that the ISBServiceRollout conditions are as expected")
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
+
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 
 		verifyPipelineReady(Namespace, pipelineRolloutName, 2)
@@ -354,6 +377,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 		verifyMonoVertexSpec(Namespace, monoVertexRolloutName, func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec) bool {
 			return retrievedMonoVertexSpec.Source.UDSource.Container.Image == "quay.io/numaio/numaflow-java/source-simple-source:v0.6.0"
 		})
+
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
 
 		verifyMonoVertexReady(Namespace, monoVertexRolloutName)
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -145,10 +145,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		// TODO: add test when dataLossPrevention envVar is added
+		// Eventually(func() metav1.ConditionStatus {
+		// 	rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
 
 		verifyNumaflowControllerReady(Namespace)
 	})
@@ -171,10 +172,10 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		// Eventually(func() metav1.ConditionStatus {
+		// 	rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 
@@ -340,10 +341,10 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		// Eventually(func() metav1.ConditionStatus {
+		// 	rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
 
 		verifyNumaflowControllerReady(Namespace)
 
@@ -374,10 +375,10 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		// Eventually(func() metav1.ConditionStatus {
+		// 	rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
 		verifyNumaflowControllerReady(Namespace)
 	})
@@ -164,7 +164,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 
@@ -192,12 +192,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionFalse))
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
 
 		verifyPipelineReady(Namespace, pipelineRolloutName, 2)
 
@@ -223,7 +223,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
 		verifyMonoVertexReady(Namespace, monoVertexRolloutName)
 
@@ -277,7 +277,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		// 	rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRollouName, metav1.GetOptions{})
 		//
 		// return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-		// }).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
+		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
 		// wait for update to reconcile
 		time.Sleep(5 * time.Second)
@@ -295,12 +295,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionFalse))
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
 
 		verifyPipelineReady(Namespace, pipelineRolloutName, 2)
 
@@ -328,7 +328,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
 		verifyNumaflowControllerReady(Namespace)
 
@@ -357,7 +357,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 
@@ -385,7 +385,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}).WithTimeout(testTimeout).Should(Equal(metav1.ConditionTrue))
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
 		verifyMonoVertexReady(Namespace, monoVertexRolloutName)
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -135,11 +135,16 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		document("Verifying that the NumaflowControllerRollout was created")
 		Eventually(func() error {
-			_, err = numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+			_, err := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 			return err
 		}, testTimeout, testPollingInterval).Should(Succeed())
 
 		document("Verifying that the NumaflowControllerRollout conditions are as expected")
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
@@ -167,6 +172,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 		}, testTimeout, testPollingInterval).Should(Succeed())
 
 		document("Verifying that the ISBServiceRollout conditions are as expected")
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
@@ -202,6 +212,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 		document("Verifying that the PipelineRollout conditions are as expected")
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
@@ -230,6 +245,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 		verifyMonoVertexSpec(Namespace, monoVertexRolloutName, func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec) bool {
 			return monoVertexSpec.Source != nil
 		})
+
+		document("Verifying that the MonoVertexRollout conditions are as expected")
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
@@ -305,6 +326,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 		document("Verifying that the PipelineRollout conditions are as expected")
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
@@ -336,6 +362,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 		})
 
 		document("Verifying that the NumaflowControllerRollout conditions are as expected")
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
@@ -372,6 +403,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 		document("Verifying that the ISBServiceRollout conditions are as expected")
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
@@ -402,6 +438,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 		verifyMonoVertexSpec(Namespace, monoVertexRolloutName, func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec) bool {
 			return retrievedMonoVertexSpec.Source.UDSource.Container.Image == "quay.io/numaio/numaflow-java/source-simple-source:v0.6.0"
 		})
+
+		document("Verifying that the MonoVertexRollout conditions are as expected")
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -145,6 +145,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+
 		verifyNumaflowControllerReady(Namespace)
 	})
 
@@ -165,6 +170,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 
@@ -330,6 +340,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+
 		verifyNumaflowControllerReady(Namespace)
 
 		verifyPipelineReady(Namespace, pipelineRolloutName, 2)
@@ -358,6 +373,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #96 

### Modifications

Adds a common function to get a specific condition from a rollout's array of condition to then check the status of it.

For our e2e tests, we are checking the `ChildResourcesHealthyCondition` for all rollouts and extra for PipelineRollout the `PipelinePausedOrPausing` condition to be sure they are true or false in the correct cases.

TODO: We will want to include an env variable to signify when dataLossPrevention is enabled. This way we will appropriately check that pipelines are being paused during rollout updates.

```
func getRolloutCondition(conditions []metav1.Condition, conditionType apiv1.ConditionType) metav1.ConditionStatus {
	for _, cond := range conditions {
		if cond.Type == string(conditionType) {
			return cond.Status
		}
	}
	return metav1.ConditionUnknown
}
```

### Verification

Ran `make test-e2e` and Github CI.