### PR TITLE
feat: support consecutive Updates to our dynamic objects; also remove use of dynamic client for Rollouts (not needed)

### DIFF
--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -540,26 +540,7 @@ func (r *ISBServiceRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ISBServiceRolloutReconciler) updateISBServiceRolloutStatus(ctx context.Context, isbServiceRollout *apiv1.ISBServiceRollout) error {
-	rawSpec := runtime.RawExtension{}
-	err := util.StructToStruct(&isbServiceRollout.Spec, &rawSpec)
-	if err != nil {
-		return fmt.Errorf("unable to convert ISBServiceRollout Spec to GenericObject Spec: %v", err)
-	}
-
-	rawStatus := runtime.RawExtension{}
-	err = util.StructToStruct(&isbServiceRollout.Status, &rawStatus)
-	if err != nil {
-		return fmt.Errorf("unable to convert ISBServiceRollout Status to GenericObject Status: %v", err)
-	}
-
-	obj := kubernetes.GenericObject{
-		TypeMeta:   isbServiceRollout.TypeMeta,
-		ObjectMeta: isbServiceRollout.ObjectMeta,
-		Spec:       rawSpec,
-		Status:     rawStatus,
-	}
-
-	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "isbservicerollouts")
+	return r.client.Status().Update(ctx, isbServiceRollout)
 }
 
 func (r *ISBServiceRolloutReconciler) updateISBServiceRolloutStatusToFailed(ctx context.Context, isbServiceRollout *apiv1.ISBServiceRollout, err error) error {

--- a/internal/controller/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout_controller_test.go
@@ -129,9 +129,16 @@ var _ = Describe("ISBServiceRollout Controller", Ordered, func() {
 
 		It("Should have the metrics updated", func() {
 			By("Verifying the ISBService metric")
-			Expect(testutil.ToFloat64(customMetrics.ISBServicesRunning.WithLabelValues())).Should(Equal(float64(1)))
-			Expect(testutil.ToFloat64(customMetrics.ISBServicesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
-			Expect(testutil.ToFloat64(customMetrics.ISBServicesSyncFailed.WithLabelValues())).Should(Equal(float64(0)))
+			Eventually(func() bool {
+				return testutil.ToFloat64(customMetrics.ISBServicesRunning.WithLabelValues()) == 1.0 &&
+					testutil.ToFloat64(customMetrics.ISBServicesSynced.WithLabelValues()) > 1 &&
+					testutil.ToFloat64(customMetrics.ISBServicesSyncFailed.WithLabelValues()) == 0
+
+			}, timeout, interval).Should(BeTrue())
+
+			//Expect(testutil.ToFloat64(customMetrics.ISBServicesRunning.WithLabelValues())).Should(Equal(float64(1)))
+			//Expect(testutil.ToFloat64(customMetrics.ISBServicesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
+			//Expect(testutil.ToFloat64(customMetrics.ISBServicesSyncFailed.WithLabelValues())).Should(Equal(float64(0)))
 		})
 
 		It("Should update the ISBServiceRollout and InterStepBufferService", func() {

--- a/internal/controller/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout_controller_test.go
@@ -42,10 +42,13 @@ import (
 	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/metrics"
+
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
+	commontest "github.com/numaproj/numaplane/tests/common"
 )
 
 var (
+	defaultNamespace         = "default"
 	defaultISBSvcRolloutName = "isbservicerollout-test"
 )
 
@@ -243,7 +246,7 @@ var _ = Describe("ISBServiceRollout Controller", Ordered, func() {
 
 func Test_reconcile_PPND(t *testing.T) {
 
-	restConfig, numaflowClientSet, numaplaneClient, k8sClientSet, err := prepareK8SEnvironment()
+	restConfig, numaflowClientSet, numaplaneClient, k8sClientSet, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
 
 	// Make sure "dataLossPrevention" feature flag is turned on

--- a/internal/controller/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout_controller_test.go
@@ -129,16 +129,8 @@ var _ = Describe("ISBServiceRollout Controller", Ordered, func() {
 
 		It("Should have the metrics updated", func() {
 			By("Verifying the ISBService metric")
-			Eventually(func() bool {
-				return testutil.ToFloat64(customMetrics.ISBServicesRunning.WithLabelValues()) == 1.0 &&
-					testutil.ToFloat64(customMetrics.ISBServicesSynced.WithLabelValues()) > 1 &&
-					testutil.ToFloat64(customMetrics.ISBServicesSyncFailed.WithLabelValues()) == 0
-
-			}, timeout, interval).Should(BeTrue())
-
-			//Expect(testutil.ToFloat64(customMetrics.ISBServicesRunning.WithLabelValues())).Should(Equal(float64(1)))
-			//Expect(testutil.ToFloat64(customMetrics.ISBServicesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
-			//Expect(testutil.ToFloat64(customMetrics.ISBServicesSyncFailed.WithLabelValues())).Should(Equal(float64(0)))
+			Expect(testutil.ToFloat64(customMetrics.ISBServicesRunning.WithLabelValues())).Should(Equal(float64(1)))
+			Expect(testutil.ToFloat64(customMetrics.ISBServicesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
 		})
 
 		It("Should update the ISBServiceRollout and InterStepBufferService", func() {

--- a/internal/controller/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout_controller.go
@@ -291,26 +291,6 @@ func (r *MonoVertexRolloutReconciler) updateMonoVertex(ctx context.Context, mono
 }
 
 func (r *MonoVertexRolloutReconciler) updateMonoVertexRolloutStatus(ctx context.Context, monoVertexRollout *apiv1.MonoVertexRollout) error {
-	/*rawSpec := runtime.RawExtension{}
-	err := util.StructToStruct(&monoVertexRollout.Spec, &rawSpec)
-	if err != nil {
-		return fmt.Errorf("unable to convert MonoVertexRollout Spec to GenericObject Spec: %v", err)
-	}
-
-	rawStatus := runtime.RawExtension{}
-	err = util.StructToStruct(&monoVertexRollout.Status, &rawStatus)
-	if err != nil {
-		return fmt.Errorf("unable to convert MonoVertexRollout Status to GenericObject Status: %v", err)
-	}
-
-	obj := kubernetes.GenericObject{
-		TypeMeta:   monoVertexRollout.TypeMeta,
-		ObjectMeta: monoVertexRollout.ObjectMeta,
-		Spec:       rawSpec,
-		Status:     rawStatus,
-	}
-
-	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "monovertexrollouts")*/
 	return r.client.Status().Update(ctx, monoVertexRollout)
 }
 

--- a/internal/controller/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
-	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
 	"github.com/numaproj/numaplane/internal/util/metrics"
@@ -292,7 +291,7 @@ func (r *MonoVertexRolloutReconciler) updateMonoVertex(ctx context.Context, mono
 }
 
 func (r *MonoVertexRolloutReconciler) updateMonoVertexRolloutStatus(ctx context.Context, monoVertexRollout *apiv1.MonoVertexRollout) error {
-	rawSpec := runtime.RawExtension{}
+	/*rawSpec := runtime.RawExtension{}
 	err := util.StructToStruct(&monoVertexRollout.Spec, &rawSpec)
 	if err != nil {
 		return fmt.Errorf("unable to convert MonoVertexRollout Spec to GenericObject Spec: %v", err)
@@ -311,7 +310,8 @@ func (r *MonoVertexRolloutReconciler) updateMonoVertexRolloutStatus(ctx context.
 		Status:     rawStatus,
 	}
 
-	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "monovertexrollouts")
+	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "monovertexrollouts")*/
+	return r.client.Status().Update(ctx, monoVertexRollout)
 }
 
 func (r *MonoVertexRolloutReconciler) updateMonoVertexRolloutStatusToFailed(ctx context.Context, monoVertexRollout *apiv1.MonoVertexRollout, err error) error {

--- a/internal/controller/monovertexrollout_controller_test.go
+++ b/internal/controller/monovertexrollout_controller_test.go
@@ -121,7 +121,6 @@ var _ = Describe("MonoVertexRollout Controller", Ordered, func() {
 			By("Verifying the MonoVertex metrics")
 			Expect(testutil.ToFloat64(customMetrics.MonoVerticesRunning.WithLabelValues())).Should(Equal(float64(1)))
 			Expect(testutil.ToFloat64(customMetrics.MonoVerticesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
-			Expect(testutil.ToFloat64(customMetrics.MonoVerticesSyncFailed.WithLabelValues())).Should(Equal(float64(0)))
 		})
 
 		It("Should update the MonoVertexRollout and MonoVertex", func() {

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -53,7 +53,6 @@ import (
 	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/sync"
-	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
 	"github.com/numaproj/numaplane/internal/util/metrics"
@@ -790,26 +789,7 @@ func toUnstructuredAndApplyLabel(manifests []string, name string) ([]*unstructur
 }
 
 func (r *NumaflowControllerRolloutReconciler) updateNumaflowControllerRolloutStatus(ctx context.Context, controllerRollout *apiv1.NumaflowControllerRollout) error {
-	rawSpec := runtime.RawExtension{}
-	err := util.StructToStruct(&controllerRollout.Spec, &rawSpec)
-	if err != nil {
-		return fmt.Errorf("unable to convert NumaflowControllerRollout Spec to GenericObject Spec: %v", err)
-	}
-
-	rawStatus := runtime.RawExtension{}
-	err = util.StructToStruct(&controllerRollout.Status, &rawStatus)
-	if err != nil {
-		return fmt.Errorf("unable to convert NumaflowControllerRollout Status to GenericObject Status: %v", err)
-	}
-
-	obj := kubernetes.GenericObject{
-		TypeMeta:   controllerRollout.TypeMeta,
-		ObjectMeta: controllerRollout.ObjectMeta,
-		Spec:       rawSpec,
-		Status:     rawStatus,
-	}
-
-	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "numaflowcontrollerrollouts")
+	return r.client.Status().Update(ctx, controllerRollout)
 }
 
 func (r *NumaflowControllerRolloutReconciler) updateNumaflowControllerRolloutStatusToFailed(ctx context.Context, controllerRollout *apiv1.NumaflowControllerRollout, err error) error {

--- a/internal/controller/numaflowcontrollerrollout_controller_test.go
+++ b/internal/controller/numaflowcontrollerrollout_controller_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -116,17 +115,9 @@ var _ = Describe("NumaflowControllerRollout Controller", Ordered, func() {
 		})
 
 		It("Should have the metrics updated", func() {
-			By(fmt.Sprintf("Verifying the Numaflow Controller metric: %p, %+v", customMetrics, customMetrics))
-
-			Eventually(func() bool {
-				return testutil.ToFloat64(customMetrics.NumaflowControllersSynced.WithLabelValues()) > 1.0 &&
-					testutil.ToFloat64(customMetrics.NumaflowControllersSyncFailed.WithLabelValues()) == 0 &&
-					testutil.ToFloat64(customMetrics.NumaflowControllerKubectlExecutionCounter.WithLabelValues()) > 1
-
-			}, timeout, interval).Should(BeTrue())
-			//Expect(testutil.ToFloat64(customMetrics.NumaflowControllersSynced.WithLabelValues())).Should(BeNumerically(">", 1))
-			//Expect(testutil.ToFloat64(customMetrics.NumaflowControllersSyncFailed.WithLabelValues())).Should(Equal(float64(0)))
-			//Expect(testutil.ToFloat64(customMetrics.NumaflowControllerKubectlExecutionCounter.WithLabelValues())).Should(BeNumerically(">", 1))
+			By("Verifying the Numaflow Controller metric")
+			Expect(testutil.ToFloat64(customMetrics.NumaflowControllersSynced.WithLabelValues())).Should(BeNumerically(">", 1))
+			Expect(testutil.ToFloat64(customMetrics.NumaflowControllerKubectlExecutionCounter.WithLabelValues())).Should(BeNumerically(">", 1))
 		})
 
 		It("Should auto heal the Numaflow Controller Deployment with the spec based on the NumaflowControllerRollout version field value when the Deployment spec is changed", func() {

--- a/internal/controller/numaflowcontrollerrollout_controller_test.go
+++ b/internal/controller/numaflowcontrollerrollout_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -115,10 +116,17 @@ var _ = Describe("NumaflowControllerRollout Controller", Ordered, func() {
 		})
 
 		It("Should have the metrics updated", func() {
-			By("Verifying the Numaflow Controller metric")
-			Expect(testutil.ToFloat64(customMetrics.NumaflowControllersSynced.WithLabelValues())).Should(BeNumerically(">", 1))
-			Expect(testutil.ToFloat64(customMetrics.NumaflowControllersSyncFailed.WithLabelValues())).Should(Equal(float64(0)))
-			Expect(testutil.ToFloat64(customMetrics.NumaflowControllerKubectlExecutionCounter.WithLabelValues())).Should(BeNumerically(">", 1))
+			By(fmt.Sprintf("Verifying the Numaflow Controller metric: %p, %+v", customMetrics, customMetrics))
+
+			Eventually(func() bool {
+				return testutil.ToFloat64(customMetrics.NumaflowControllersSynced.WithLabelValues()) > 1.0 &&
+					testutil.ToFloat64(customMetrics.NumaflowControllersSyncFailed.WithLabelValues()) == 0 &&
+					testutil.ToFloat64(customMetrics.NumaflowControllerKubectlExecutionCounter.WithLabelValues()) > 1
+
+			}, timeout, interval).Should(BeTrue())
+			//Expect(testutil.ToFloat64(customMetrics.NumaflowControllersSynced.WithLabelValues())).Should(BeNumerically(">", 1))
+			//Expect(testutil.ToFloat64(customMetrics.NumaflowControllersSyncFailed.WithLabelValues())).Should(Equal(float64(0)))
+			//Expect(testutil.ToFloat64(customMetrics.NumaflowControllerKubectlExecutionCounter.WithLabelValues())).Should(BeNumerically(">", 1))
 		})
 
 		It("Should auto heal the Numaflow Controller Deployment with the spec based on the NumaflowControllerRollout version field value when the Deployment spec is changed", func() {

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -858,26 +858,7 @@ func pipelineLabels(pipelineRollout *apiv1.PipelineRollout) (map[string]string, 
 	return labelMapping, nil
 }
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatus(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) error {
-	rawSpec := runtime.RawExtension{}
-	err := util.StructToStruct(&pipelineRollout.Spec, &rawSpec)
-	if err != nil {
-		return fmt.Errorf("unable to convert PipelineRollout Spec to GenericObject Spec: %v", err)
-	}
-
-	rawStatus := runtime.RawExtension{}
-	err = util.StructToStruct(&pipelineRollout.Status, &rawStatus)
-	if err != nil {
-		return fmt.Errorf("unable to convert PipelineRollout Status to GenericObject Status: %v", err)
-	}
-
-	obj := kubernetes.GenericObject{
-		TypeMeta:   pipelineRollout.TypeMeta,
-		ObjectMeta: pipelineRollout.ObjectMeta,
-		Spec:       rawSpec,
-		Status:     rawStatus,
-	}
-
-	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "pipelinerollouts")
+	return r.client.Status().Update(ctx, pipelineRollout)
 }
 
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatusToFailed(ctx context.Context, pipelineRollout *apiv1.PipelineRollout, err error) error {

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -147,16 +147,9 @@ var _ = Describe("PipelineRollout Controller", Ordered, func() {
 		})
 
 		It("Should have the metrics updated", func() {
-			By(fmt.Sprintf("Verifying the PipelineRollout metric: customMetrics=%p, customMetrics=%+v, customMetrics.PipelinesRunning=%+v, customMetrics.PipelinesRunning.WithLabelValues()=%+v", customMetrics, customMetrics,
-				customMetrics.PipelinesRunning, customMetrics.PipelinesRunning.WithLabelValues()))
-
-			Eventually(func() bool {
-				return testutil.ToFloat64(customMetrics.PipelinesRunning.WithLabelValues()) == 1.0
-
-			}, timeout, interval).Should(BeTrue())
-			//Expect(testutil.ToFloat64(customMetrics.PipelinesRunning.WithLabelValues())).Should(Equal(float64(1)))
-			//Expect(testutil.ToFloat64(customMetrics.PipelinesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
-			//Expect(testutil.ToFloat64(customMetrics.PipelinesSyncFailed.WithLabelValues())).Should(Equal(float64(0)))
+			By("Verifying the PipelineRollout metric")
+			Expect(testutil.ToFloat64(customMetrics.PipelinesRunning.WithLabelValues())).Should(Equal(float64(1)))
+			Expect(testutil.ToFloat64(customMetrics.PipelinesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
 		})
 
 		It("Should update the PipelineRollout and Numaflow Pipeline", func() {

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -147,10 +147,16 @@ var _ = Describe("PipelineRollout Controller", Ordered, func() {
 		})
 
 		It("Should have the metrics updated", func() {
-			By("Verifying the PipelineRollout metric")
-			Expect(testutil.ToFloat64(customMetrics.PipelinesRunning.WithLabelValues())).Should(Equal(float64(1)))
-			Expect(testutil.ToFloat64(customMetrics.PipelinesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
-			Expect(testutil.ToFloat64(customMetrics.PipelinesSyncFailed.WithLabelValues())).Should(Equal(float64(0)))
+			By(fmt.Sprintf("Verifying the PipelineRollout metric: customMetrics=%p, customMetrics=%+v, customMetrics.PipelinesRunning=%+v, customMetrics.PipelinesRunning.WithLabelValues()=%+v", customMetrics, customMetrics,
+				customMetrics.PipelinesRunning, customMetrics.PipelinesRunning.WithLabelValues()))
+
+			Eventually(func() bool {
+				return testutil.ToFloat64(customMetrics.PipelinesRunning.WithLabelValues()) == 1.0
+
+			}, timeout, interval).Should(BeTrue())
+			//Expect(testutil.ToFloat64(customMetrics.PipelinesRunning.WithLabelValues())).Should(Equal(float64(1)))
+			//Expect(testutil.ToFloat64(customMetrics.PipelinesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
+			//Expect(testutil.ToFloat64(customMetrics.PipelinesSyncFailed.WithLabelValues())).Should(Equal(float64(0)))
 		})
 
 		It("Should update the PipelineRollout and Numaflow Pipeline", func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -145,9 +145,6 @@ var _ = BeforeSuite(func() {
 	// other tests may call this, but it fails if called more than once
 	if customMetrics == nil {
 		customMetrics = metrics.RegisterCustomMetrics()
-		logThis := fmt.Sprintf("customMetrics=%p, %+v", customMetrics, customMetrics)
-		By(logThis)
-		fmt.Println(logThis)
 	}
 
 	err = NewPipelineRolloutReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), cfg, customMetrics,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -79,7 +79,7 @@ func TestControllers(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	//cfg, _, _, _, err := prepareK8SEnvironment()
+	//cfg, _, _, _, err := commontest.PrepareK8SEnvironment()
 	//Expect(err).NotTo(HaveOccurred())
 
 	// Download Numaflow CRDs

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -145,6 +145,9 @@ var _ = BeforeSuite(func() {
 	// other tests may call this, but it fails if called more than once
 	if customMetrics == nil {
 		customMetrics = metrics.RegisterCustomMetrics()
+		logThis := fmt.Sprintf("customMetrics=%p, %+v", customMetrics, customMetrics)
+		By(logThis)
+		fmt.Println(logThis)
 	}
 
 	err = NewPipelineRolloutReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), cfg, customMetrics,

--- a/internal/util/kubernetes/unstructured_util.go
+++ b/internal/util/kubernetes/unstructured_util.go
@@ -235,7 +235,7 @@ func UpdateUnstructuredCR(
 	if err != nil {
 		return fmt.Errorf("failed to update resource %s/%s of type %+v, err=%v", namespace, name, gvr, err)
 	} else {
-		unstruc = result
+		*unstruc = *result
 	}
 
 	numaLogger.Infof("successfully updated resource %s/%s of type %+v", namespace, name, gvr)

--- a/internal/util/kubernetes/unstructured_util.go
+++ b/internal/util/kubernetes/unstructured_util.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -184,6 +185,7 @@ func CreateUnstructuredCR(
 	return nil
 }
 
+// update the CR in Kubernetes, and if successful, set the GenericObject to point to the result (i.e. goal is to have the right resourceVersion)
 func UpdateCR(
 	ctx context.Context,
 	restConfig *rest.Config,
@@ -201,9 +203,18 @@ func UpdateCR(
 		return err
 	}
 
-	return UpdateUnstructuredCR(ctx, restConfig, unstruc, gvr, object.Namespace, object.Name)
+	if err = UpdateUnstructuredCR(ctx, restConfig, unstruc, gvr, object.Namespace, object.Name); err != nil {
+		return err
+	}
+	result, err := UnstructuredToObject(unstruc)
+	if err != nil {
+		return err
+	}
+	*object = *result
+	return nil
 }
 
+// update the CR in Kubernetes, and if successful, set the unstruc to point to the result (i.e. goal is to have the right resourceVersion)
 func UpdateUnstructuredCR(
 	ctx context.Context,
 	restConfig *rest.Config,
@@ -220,9 +231,11 @@ func UpdateUnstructuredCR(
 		return fmt.Errorf("failed to create dynamic client: %v", err)
 	}
 
-	_, err = client.Resource(gvr).Namespace(namespace).Update(ctx, unstruc, metav1.UpdateOptions{})
+	result, err := client.Resource(gvr).Namespace(namespace).Update(ctx, unstruc, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update resource %s/%s of type %+v, err=%v", namespace, name, gvr, err)
+	} else {
+		unstruc = result
 	}
 
 	numaLogger.Infof("successfully updated resource %s/%s of type %+v", namespace, name, gvr)
@@ -262,7 +275,10 @@ func UnstructuredToObject(u *unstructured.Unstructured) (*GenericObject, error) 
 	return &genericObject, err
 }
 
+// Update the Status for the object in Kubernetes and update the object to use the result Status (i.e. goal is to have the right resourceVersion)
 func UpdateStatus(ctx context.Context, restConfig *rest.Config, object *GenericObject, pluralName string) error {
+	numaLogger := logger.FromContext(ctx)
+
 	client, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create dynamic client: %v", err)
@@ -272,34 +288,48 @@ func UpdateStatus(ctx context.Context, restConfig *rest.Config, object *GenericO
 	if err != nil {
 		return err
 	}
+	numaLogger.Debugf("will update status subresource for resource %s/%s of type %+v", object.Namespace, object.Name, gvr)
 
 	// Rationale for commenting this out:
 	// If we get a conflict, it means that the Status we were starting from in this reconciliation was old.
 	// If the new Status is derived from the old Status, then that would've been an invalid state.
-	// TODO: since the primary motivation for this retry logic was to avoid errors showing up in the log, we may be
-	// able to instead conditionally log a warning vs an error for that in the caller
 	//err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 	resource, err := client.Resource(gvr).Namespace(object.Namespace).Get(ctx, object.Name, metav1.GetOptions{})
 	if err != nil {
-		// NOTE: report the error as-is and do not check for resource existance for retry purposes
+		// NOTE: report the error as-is and do not check for resource existence for retry purposes
 		return err
 	}
 
 	resource.Object["status"] = object.Status
 
-	_, err = client.Resource(gvr).Namespace(object.Namespace).UpdateStatus(ctx, resource, metav1.UpdateOptions{})
+	result, err := client.Resource(gvr).Namespace(object.Namespace).UpdateStatus(ctx, resource, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
 
+	// update our original object with the new Status (so it will have latest resourceVersion)
+	resultStatus, found := result.Object["status"]
+	if !found {
+		numaLogger.Errorf(errors.New("failed to get status from result of UpdateStatus"),
+			"Unexpected: updated status for resource %s/%s of type %+v, but result.Object %+v contains no 'status' field", object.Namespace, object.Name, gvr, result.Object)
+		// not sure if there's some way this could happen, will keep the original value for the object if it does
+		return nil
+	}
+	resultMap, ok := resultStatus.(map[string]interface{})
+	if !ok {
+		numaLogger.Errorf(errors.New("unexpected type for result of UpdateStatus"),
+			"Unexpected: updated status for resource %s/%s of type %+v, but result.Object 'status' field is not map[string]interface{}: %+v", object.Namespace, object.Name, gvr, resultStatus)
+		// not sure if there's some way this could happen, will keep the original value for the object if it does
+		return nil
+	}
+	object.Status.Raw, err = json.Marshal(&resultMap)
+	if err != nil {
+		numaLogger.Errorf(err, fmt.Sprintf("Failed to unmarshal json result of UpdateStatus for resource %s/%s of type %+v: %+v", object.Namespace, object.Name, gvr, resultMap))
+		// not sure if there's some way this could happen, will keep the original value for the object if it does
+		return nil
+	}
+
 	return nil
-	//})
-
-	// TODO: we may want to also implement retry.OnError() to retry in case of errors while updating the status.
-	// We should consider to add extra failover logic to avoid this function to not be able to update
-	// the status of the resource and return error.
-
-	//return err
 }
 
 func getGroupVersionResource(object *GenericObject, pluralName string) (schema.GroupVersionResource, error) {

--- a/internal/util/kubernetes/unstructured_util_test.go
+++ b/internal/util/kubernetes/unstructured_util_test.go
@@ -1,21 +1,14 @@
 package kubernetes
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
-	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaplane/internal/common"
-	commontest "github.com/numaproj/numaplane/tests/common"
 )
 
 func TestGetLabel(t *testing.T) {
@@ -44,6 +37,7 @@ func TestGetLabelWithInvalidData(t *testing.T) {
 	assert.Equal(t, "failed to get labels from target object /v1, Kind=Service /my-service: .metadata.labels accessor error: contains non-string value in the map under key \"invalid-label\": <nil> is of the type <nil>, expected string", err.Error())
 }
 
+/*
 func TestCreateUpdateGetListCR(t *testing.T) {
 	restConfig, _, _, _, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
@@ -122,14 +116,5 @@ func TestCreateUpdateGetListCR(t *testing.T) {
 	pipelineList, err := ListCR(context.Background(), restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", namespace, "test=value", "")
 	assert.Nil(t, err)
 	assert.Len(t, pipelineList, 1)
-
-	// Update Status subresource
-	/*rawStatus := runtime.RawExtension{}
-	err = util.StructToStruct(&pipelineRollout.Status, &rawStatus)
-	if err != nil {
-		return fmt.Errorf("unable to convert PipelineRollout Status to GenericObject Status: %v", err)
-	}
-	pipelineObject.Status = rawStatus
-	UpdateStatus(context.Background(), restConfig, pipelineObject, "pipelines")
-	*/
 }
+*/

--- a/internal/util/kubernetes/unstructured_util_test.go
+++ b/internal/util/kubernetes/unstructured_util_test.go
@@ -1,14 +1,21 @@
 package kubernetes
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
+	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaplane/internal/common"
+	commontest "github.com/numaproj/numaplane/tests/common"
 )
 
 func TestGetLabel(t *testing.T) {
@@ -35,4 +42,78 @@ func TestGetLabelWithInvalidData(t *testing.T) {
 	_, err = GetLabel(&obj, "valid-label")
 	assert.Error(t, err)
 	assert.Equal(t, "failed to get labels from target object /v1, Kind=Service /my-service: .metadata.labels accessor error: contains non-string value in the map under key \"invalid-label\": <nil> is of the type <nil>, expected string", err.Error())
+}
+
+func TestCreateUpdateGetListCR(t *testing.T) {
+	restConfig, _, _, _, err := commontest.PrepareK8SEnvironment()
+	assert.Nil(t, err)
+
+	pipelineSpec := numaflowv1.PipelineSpec{
+		Vertices: []numaflowv1.AbstractVertex{
+			{
+				Name: "in",
+				Source: &numaflowv1.Source{
+					Generator: &numaflowv1.GeneratorSource{},
+				},
+			},
+			{
+				Name: "out",
+				Sink: &numaflowv1.Sink{
+					AbstractSink: numaflowv1.AbstractSink{
+						Log: &numaflowv1.Log{},
+					},
+				},
+			},
+		},
+		Edges: []numaflowv1.Edge{
+			{
+				From: "in",
+				To:   "out",
+			},
+		},
+	}
+	pipelineSpecRaw, err := json.Marshal(pipelineSpec)
+	assert.Nil(t, err)
+
+	pipelineObject := &GenericObject{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pipeline",
+			APIVersion: "numaflow.numaproj.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pipeline",
+			Namespace: "default",
+		},
+		Spec: runtime.RawExtension{
+			Raw: pipelineSpecRaw,
+		},
+	}
+	err = CreateCR(context.Background(), restConfig, pipelineObject, "pipelines")
+	assert.Nil(t, err)
+	pipelineObject, err = GetCR(context.Background(), restConfig, pipelineObject, "pipelines")
+	assert.Nil(t, err)
+	version1 := pipelineObject.ResourceVersion
+	fmt.Printf("Created CR, resource version=%s\n", version1)
+
+	// Updating should return the result Pipeline with the updated ResourceVersion
+	pipelineObject.ObjectMeta.Labels = map[string]string{"test": "value"}
+	err = UpdateCR(context.Background(), restConfig, pipelineObject, "pipelines")
+	assert.Nil(t, err)
+	version2 := pipelineObject.ResourceVersion
+
+	fmt.Printf("Updated CR, resource version=%s\n", version2)
+	assert.NotEqual(t, version1, version2)
+
+	// Doing a GET should return the same thing
+	pipelineObject, err = GetCR(context.Background(), restConfig, pipelineObject, "pipelines")
+	assert.Nil(t, err)
+	assert.Equal(t, version2, pipelineObject.ResourceVersion)
+
+	// Do another update
+	pipelineObject.ObjectMeta.Labels["test-2"] = "value-2"
+	err = UpdateCR(context.Background(), restConfig, pipelineObject, "pipelines")
+	assert.Nil(t, err)
+	version3 := pipelineObject.ResourceVersion
+	assert.NotEqual(t, version2, version3)
+
 }

--- a/internal/util/kubernetes/unstructured_util_test.go
+++ b/internal/util/kubernetes/unstructured_util_test.go
@@ -75,6 +75,8 @@ func TestCreateUpdateGetListCR(t *testing.T) {
 	pipelineSpecRaw, err := json.Marshal(pipelineSpec)
 	assert.Nil(t, err)
 
+	namespace := "default"
+
 	pipelineObject := &GenericObject{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pipeline",
@@ -82,7 +84,7 @@ func TestCreateUpdateGetListCR(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-pipeline",
-			Namespace: "default",
+			Namespace: namespace,
 		},
 		Spec: runtime.RawExtension{
 			Raw: pipelineSpecRaw,
@@ -116,4 +118,18 @@ func TestCreateUpdateGetListCR(t *testing.T) {
 	version3 := pipelineObject.ResourceVersion
 	assert.NotEqual(t, version2, version3)
 
+	// List resource
+	pipelineList, err := ListCR(context.Background(), restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", namespace, "test=value", "")
+	assert.Nil(t, err)
+	assert.Len(t, pipelineList, 1)
+
+	// Update Status subresource
+	/*rawStatus := runtime.RawExtension{}
+	err = util.StructToStruct(&pipelineRollout.Status, &rawStatus)
+	if err != nil {
+		return fmt.Errorf("unable to convert PipelineRollout Status to GenericObject Status: %v", err)
+	}
+	pipelineObject.Status = rawStatus
+	UpdateStatus(context.Background(), restConfig, pipelineObject, "pipelines")
+	*/
 }

--- a/internal/util/kubernetes/unstructured_util_test.go
+++ b/internal/util/kubernetes/unstructured_util_test.go
@@ -1,11 +1,18 @@
 package kubernetes
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 
+	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	commontest "github.com/numaproj/numaplane/tests/common"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
 	"github.com/numaproj/numaplane/internal/common"
@@ -37,7 +44,6 @@ func TestGetLabelWithInvalidData(t *testing.T) {
 	assert.Equal(t, "failed to get labels from target object /v1, Kind=Service /my-service: .metadata.labels accessor error: contains non-string value in the map under key \"invalid-label\": <nil> is of the type <nil>, expected string", err.Error())
 }
 
-/*
 func TestCreateUpdateGetListCR(t *testing.T) {
 	restConfig, _, _, _, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
@@ -117,4 +123,3 @@ func TestCreateUpdateGetListCR(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, pipelineList, 1)
 }
-*/

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -279,9 +278,6 @@ func (m *CustomMetrics) IncPipelinesRunningMetrics(name, namespace string) {
 	defer pipelineLock.Unlock()
 	m.PipelineCounterMap[name+"_"+namespace] = struct{}{}
 	m.PipelinesRunning.WithLabelValues().Set(float64(len(m.PipelineCounterMap)))
-	fmt.Printf("deletethis: incremented PipelinesRunning to %d, CustomMetrics=%p, %+v\n", len(m.PipelineCounterMap), m, m)
-	fmt.Printf("deletethis: incremented PipelinesRunning: customMetrics=%p, customMetrics=%+v, customMetrics.PipelinesRunning=%+v, customMetrics.PipelinesRunning.WithLabelValues()=%+v", m, m,
-		m.PipelinesRunning, m.PipelinesRunning.WithLabelValues())
 }
 
 // DecPipelineMetrics decrements the pipeline counter
@@ -290,7 +286,6 @@ func (m *CustomMetrics) DecPipelineMetrics(name, namespace string) {
 	defer pipelineLock.Unlock()
 	delete(m.PipelineCounterMap, name+"_"+namespace)
 	m.PipelinesRunning.WithLabelValues().Set(float64(len(m.PipelineCounterMap)))
-	fmt.Printf("deletethis: decremented PipelinesRunning to %d\n", len(m.PipelineCounterMap))
 }
 
 // IncISBServiceMetrics increments the ISBService counter if it doesn't already know about the ISBService
@@ -299,7 +294,6 @@ func (m *CustomMetrics) IncISBServiceMetrics(name, namespace string) {
 	defer isbServiceLock.Unlock()
 	m.ISBServiceCounterMap[name+"_"+namespace] = struct{}{}
 	m.ISBServicesRunning.WithLabelValues().Set(float64(len(m.ISBServiceCounterMap)))
-	fmt.Printf("deletethis: incremented ISBServicesRunning to %d\n", len(m.ISBServiceCounterMap))
 }
 
 // DecISBServiceMetrics decrements the ISBService counter
@@ -308,7 +302,6 @@ func (m *CustomMetrics) DecISBServiceMetrics(name, namespace string) {
 	defer isbServiceLock.Unlock()
 	delete(m.ISBServiceCounterMap, name+"_"+namespace)
 	m.ISBServicesRunning.WithLabelValues().Set(float64(len(m.ISBServiceCounterMap)))
-	fmt.Printf("deletethis: decremented ISBServicesRunning to %d\n", len(m.ISBServiceCounterMap))
 }
 
 // IncMonoVertexMetrics increments the MonoVertex counter if it doesn't already know about the MonoVertex
@@ -339,8 +332,6 @@ func (m *CustomMetrics) IncNumaflowControllerMetrics(name, namespace, version st
 	m.NumaflowControllerVersionCounter[version][name+"_"+namespace] = struct{}{}
 	for key, value := range m.NumaflowControllerVersionCounter {
 		m.NumaflowControllerRunning.WithLabelValues(key).Set(float64(len(value)))
-
-		fmt.Printf("deletethis: incremented NumaflowControllerRunning{%s} to %d, CustomMetrics=%p, %+v\n", key, len(value), m, m)
 	}
 }
 
@@ -351,6 +342,5 @@ func (m *CustomMetrics) DecNumaflowControllerMetrics(name, namespace, version st
 	delete(m.NumaflowControllerVersionCounter[version], name+"_"+namespace)
 	for key, value := range m.NumaflowControllerVersionCounter {
 		m.NumaflowControllerRunning.WithLabelValues(key).Set(float64(len(value)))
-		fmt.Printf("deletethis: decremented NumaflowControllerRunning{%s} to %d, CustomMetrics=%p, %+v\n", key, len(value), m, m)
 	}
 }

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -278,6 +279,9 @@ func (m *CustomMetrics) IncPipelinesRunningMetrics(name, namespace string) {
 	defer pipelineLock.Unlock()
 	m.PipelineCounterMap[name+"_"+namespace] = struct{}{}
 	m.PipelinesRunning.WithLabelValues().Set(float64(len(m.PipelineCounterMap)))
+	fmt.Printf("deletethis: incremented PipelinesRunning to %d, CustomMetrics=%p, %+v\n", len(m.PipelineCounterMap), m, m)
+	fmt.Printf("deletethis: incremented PipelinesRunning: customMetrics=%p, customMetrics=%+v, customMetrics.PipelinesRunning=%+v, customMetrics.PipelinesRunning.WithLabelValues()=%+v", m, m,
+		m.PipelinesRunning, m.PipelinesRunning.WithLabelValues())
 }
 
 // DecPipelineMetrics decrements the pipeline counter
@@ -286,6 +290,7 @@ func (m *CustomMetrics) DecPipelineMetrics(name, namespace string) {
 	defer pipelineLock.Unlock()
 	delete(m.PipelineCounterMap, name+"_"+namespace)
 	m.PipelinesRunning.WithLabelValues().Set(float64(len(m.PipelineCounterMap)))
+	fmt.Printf("deletethis: decremented PipelinesRunning to %d\n", len(m.PipelineCounterMap))
 }
 
 // IncISBServiceMetrics increments the ISBService counter if it doesn't already know about the ISBService
@@ -294,6 +299,7 @@ func (m *CustomMetrics) IncISBServiceMetrics(name, namespace string) {
 	defer isbServiceLock.Unlock()
 	m.ISBServiceCounterMap[name+"_"+namespace] = struct{}{}
 	m.ISBServicesRunning.WithLabelValues().Set(float64(len(m.ISBServiceCounterMap)))
+	fmt.Printf("deletethis: incremented ISBServicesRunning to %d\n", len(m.ISBServiceCounterMap))
 }
 
 // DecISBServiceMetrics decrements the ISBService counter
@@ -302,6 +308,7 @@ func (m *CustomMetrics) DecISBServiceMetrics(name, namespace string) {
 	defer isbServiceLock.Unlock()
 	delete(m.ISBServiceCounterMap, name+"_"+namespace)
 	m.ISBServicesRunning.WithLabelValues().Set(float64(len(m.ISBServiceCounterMap)))
+	fmt.Printf("deletethis: decremented ISBServicesRunning to %d\n", len(m.ISBServiceCounterMap))
 }
 
 // IncMonoVertexMetrics increments the MonoVertex counter if it doesn't already know about the MonoVertex
@@ -332,6 +339,8 @@ func (m *CustomMetrics) IncNumaflowControllerMetrics(name, namespace, version st
 	m.NumaflowControllerVersionCounter[version][name+"_"+namespace] = struct{}{}
 	for key, value := range m.NumaflowControllerVersionCounter {
 		m.NumaflowControllerRunning.WithLabelValues(key).Set(float64(len(value)))
+
+		fmt.Printf("deletethis: incremented NumaflowControllerRunning{%s} to %d, CustomMetrics=%p, %+v\n", key, len(value), m, m)
 	}
 }
 
@@ -342,5 +351,6 @@ func (m *CustomMetrics) DecNumaflowControllerMetrics(name, namespace, version st
 	delete(m.NumaflowControllerVersionCounter[version], name+"_"+namespace)
 	for key, value := range m.NumaflowControllerVersionCounter {
 		m.NumaflowControllerRunning.WithLabelValues(key).Set(float64(len(value)))
+		fmt.Printf("deletethis: decremented NumaflowControllerRunning{%s} to %d, CustomMetrics=%p, %+v\n", key, len(value), m, m)
 	}
 }

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -139,22 +139,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return err
 		}, testTimeout, testPollingInterval).Should(Succeed())
 
-		document("Verifying that the NumaflowControllerRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		// TODO: add test when dataLossPrevention envVar is added
-		// Eventually(func() metav1.ConditionStatus {
-		// 	rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		verifyNumaflowControllerRolloutReady()
 
 		verifyNumaflowControllerReady(Namespace)
 	})
@@ -171,21 +156,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return err
 		}, testTimeout, testPollingInterval).Should(Succeed())
 
-		document("Verifying that the ISBServiceRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		// Eventually(func() metav1.ConditionStatus {
-		// 	rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		verifyISBSvcRolloutReady(isbServiceRolloutName)
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 
@@ -209,21 +180,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			//return reflect.DeepEqual(pipelineSpec, retrievedPipelineSpec) // this may have had some false negatives due to "lifecycle" field maybe, or null values in one
 		})
 
-		document("Verifying that the PipelineRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
+		verifyPipelineRolloutReady(pipelineRolloutName)
 
 		verifyPipelineReady(Namespace, pipelineRolloutName, 2)
 
@@ -246,16 +203,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return monoVertexSpec.Source != nil
 		})
 
-		document("Verifying that the MonoVertexRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+		verifyMonoVertexRolloutReady(monoVertexRolloutName)
 
 		verifyMonoVertexReady(Namespace, monoVertexRolloutName)
 
@@ -323,21 +271,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return *retrievedPipelineSpec.Vertices[0].Source.Generator.RPU == int64(10)
 		})
 
-		document("Verifying that the PipelineRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
+		verifyPipelineRolloutReady(pipelineRolloutName)
 
 		verifyPipelineReady(Namespace, pipelineRolloutName, 2)
 
@@ -361,21 +295,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return d.Spec.Template.Spec.Containers[0].Image == "quay.io/numaio/numaflow-rc:v0.0.13"
 		})
 
-		document("Verifying that the NumaflowControllerRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		// Eventually(func() metav1.ConditionStatus {
-		// 	rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		verifyNumaflowControllerRolloutReady()
 
 		verifyNumaflowControllerReady(Namespace)
 
@@ -400,21 +320,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return retrievedISBServiceSpec.JetStream.Version == "2.9.8"
 		})
 
-		document("Verifying that the ISBServiceRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		// Eventually(func() metav1.ConditionStatus {
-		// 	rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		verifyISBSvcRolloutReady(isbServiceRolloutName)
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 
@@ -439,16 +345,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return retrievedMonoVertexSpec.Source.UDSource.Container.Image == "quay.io/numaio/numaflow-java/source-simple-source:v0.6.0"
 		})
 
-		document("Verifying that the MonoVertexRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+		verifyMonoVertexRolloutReady(monoVertexRolloutName)
 
 		verifyMonoVertexReady(Namespace, monoVertexRolloutName)
 

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -50,6 +50,31 @@ func verifyISBServiceSpec(namespace string, name string, f func(numaflowv1.Inter
 	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
+func verifyISBSvcRolloutReady(isbServiceRolloutName string) {
+	document("Verifying that the ISBServiceRollout is ready")
+
+	Eventually(func() bool {
+		rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+		return rollout.Status.Phase == apiv1.PhaseDeployed
+	}, testTimeout, testPollingInterval).Should(BeTrue())
+
+	Eventually(func() metav1.ConditionStatus {
+		rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+	Eventually(func() metav1.ConditionStatus {
+		rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+	// Eventually(func() metav1.ConditionStatus {
+	// 	rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+	// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+	// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+
+}
+
 func verifyISBSvcReady(namespace string, isbsvcName string, nodeSize int) {
 	document("Verifying that the ISBService exists")
 	Eventually(func() error {

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -49,6 +49,25 @@ func verifyMonoVertexSpec(namespace, name string, f func(numaflowv1.MonoVertexSp
 
 }
 
+func verifyMonoVertexRolloutReady(monoVertexRolloutName string) {
+	document("verifying that the MonoVertexRollout is ready")
+
+	Eventually(func() bool {
+		rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
+		return rollout.Status.Phase == apiv1.PhaseDeployed
+	}, testTimeout, testPollingInterval).Should(BeTrue())
+
+	Eventually(func() metav1.ConditionStatus {
+		rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
+		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+	Eventually(func() metav1.ConditionStatus {
+		rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
+		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+}
+
 func verifyMonoVertexReady(namespace, monoVertexName string) {
 
 	document("Verifying that the MonoVertex is running")

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -26,26 +26,37 @@ func verifyNumaflowControllerDeployment(namespace string, f func(appsv1.Deployme
 	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
+func verifyNumaflowControllerRolloutReady() {
+	document("Verifying that the NumaflowControllerRollout is ready")
+
+	Eventually(func() bool {
+		rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+		return rollout.Status.Phase == apiv1.PhaseDeployed
+	}, testTimeout, testPollingInterval).Should(BeTrue())
+
+	Eventually(func() metav1.ConditionStatus {
+		rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+	Eventually(func() metav1.ConditionStatus {
+		rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+	// TODO: add test when dataLossPrevention envVar is added
+	// Eventually(func() metav1.ConditionStatus {
+	// 	rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+	// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+	// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+}
+
 func verifyNumaflowControllerReady(namespace string) {
 	document("Verifying that the Numaflow Controller Deployment exists")
 	Eventually(func() error {
 		_, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 		return err
 	}, testTimeout, testPollingInterval).Should(Succeed())
-
-	document("Verifying that the Numaflow ControllerRollout is ready")
-	Eventually(func() bool {
-		rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-		if rollout == nil {
-			return false
-		}
-		childResourcesHealthyCondition := rollout.Status.GetCondition(apiv1.ConditionChildResourceHealthy)
-		if childResourcesHealthyCondition == nil {
-			return false
-		}
-		return childResourcesHealthyCondition.Status == metav1.ConditionTrue
-
-	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
 func updateNumaflowControllerRolloutInK8S(f func(apiv1.NumaflowControllerRollout) (apiv1.NumaflowControllerRollout, error)) {

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -55,6 +55,30 @@ func verifyPipelineStatus(namespace string, pipelineName string, f func(numaflow
 	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
+func verifyPipelineRolloutReady(pipelineRolloutName string) {
+	document("Verifying that the PipelineRollout is ready")
+
+	Eventually(func() bool {
+		rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+		return rollout.Status.Phase == apiv1.PhaseDeployed
+	}, testTimeout, testPollingInterval).Should(BeTrue())
+
+	Eventually(func() metav1.ConditionStatus {
+		rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
+	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+	Eventually(func() metav1.ConditionStatus {
+		rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+
+	Eventually(func() metav1.ConditionStatus {
+		rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
+	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
+}
+
 func verifyPipelineReady(namespace string, pipelineName string, numVertices int) {
 	document("Verifying that the Pipeline is running")
 	verifyPipelineStatus(namespace, pipelineName,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

1. the `Update()` function in the controller-runtime framework always returns the new object with the correct resourceVersion in it (as mentioned in [this](https://medium.com/@timebertt/kubernetes-controllers-at-scale-clients-caches-conflicts-patches-explained-aa0f7a8b4332) article). I wanted to do the same thing for our dynamic client Update functions. This way if we call it consecutively, we are unlikely to have any resource version conflicts that cause us to return an error. **Verified this by:** writing a unit test for it to confirm the updated resourceVersion gets returned from an `UpdateCR()` call and that we can make a subsequent call to `UpdateCR()`.
2. I noticed that we were using the dynamic client to update the Rollout CRs, which wasn't necessary, so I changed it to use the standard controller-runtime framework, thereby making the code simpler. Verified the calls to update status are working by running e2e and unit tests, and also updating the e2e test to check for `Rollout.Status.Phase` which it previously wasn't.
3. Removed the requirement from the unit tests that the "sync failure" metrics be 0. Normal resource version conflicts can cause this to increment. Note that the change above does cause there to be some errors issued some of the time where there weren't before (the previous code just updated `spec` and `status` and not any metadata such as `resourceVersion` so there was never a conflict), but actually conflicts are a good thing because it means we won't ignore more recent updates that have been made on the object. 

