### PR TITLE
fix: MonoVerticesSyncFailed metric wasn't being incremented

### DIFF
--- a/internal/controller/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout_controller.go
@@ -320,6 +320,7 @@ func (r *MonoVertexRolloutReconciler) updateMonoVertexRolloutStatusToFailed(ctx 
 }
 
 func (r *MonoVertexRolloutReconciler) ErrorHandler(monoVertexRollout *apiv1.MonoVertexRollout, err error, reason, msg string) {
+	r.customMetrics.MonoVerticesSyncFailed.WithLabelValues().Inc()
 	r.recorder.Eventf(monoVertexRollout, corev1.EventTypeWarning, reason, msg+" %v", err.Error())
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

`MonoVerticesSyncFailed` metric didn't have any calls to increment it thus rendering it unhelpful as a metric.
Added call to increment this in appropriate place. 

### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->