### PR TITLE
feat: add a label to identify all Pipelines of a given PipelineRollout

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -39,6 +39,10 @@ const (
 	// LabelKeyISBServiceNameForPipeline is the label key used to identify the ISBService being used by a Pipeline
 	// This is useful as a Label to quickly locate all Pipelines of a given ISBService
 	LabelKeyISBServiceNameForPipeline = "numaplane.numaproj.io/isbsvc-name"
+
+	// LabelKeyPipelineRolloutForPipeline is the label key used to identify the PipelineRollout a Pipeline is managed by
+	// This is useful as a Label to quickly locate all Pipelines of a given PipelineRollout
+	LabelKeyPipelineRolloutForPipeline = "numaplane.numaproj.io/pipeline-rollout-name"
 )
 
 var (

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -855,6 +855,8 @@ func pipelineLabels(pipelineRollout *apiv1.PipelineRollout) (map[string]string, 
 		labelMapping[common.LabelKeyISBServiceNameForPipeline] = pipelineSpec.InterStepBufferServiceName
 	}
 
+	labelMapping[common.LabelKeyPipelineRolloutForPipeline] = pipelineRollout.Name
+
 	return labelMapping, nil
 }
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatus(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) error {

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/numaproj/numaplane/internal/common"
 	"strings"
 	"time"
 
@@ -36,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
-	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
@@ -140,6 +140,9 @@ var _ = Describe("PipelineRollout Controller", Ordered, func() {
 
 			By("Verifying the content of the pipeline spec")
 			Expect(createdResource.Spec).Should(Equal(pipelineSpec))
+
+			By("Verifying the label of the pipeline")
+			Expect(createdResource.Labels[common.LabelKeyPipelineRolloutForPipeline]).Should(Equal(pipelineRollout.Name))
 		})
 
 		It("Should have the PipelineRollout Status Phase has Deployed and ObservedGeneration matching Generation", func() {
@@ -677,7 +680,12 @@ func TestPipelineLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			pipelineRolloutName := "my-pipeline"
 			pipelineRollout := &apiv1.PipelineRollout{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: defaultNamespace,
+					Name:      pipelineRolloutName,
+				},
 				Spec: apiv1.PipelineRolloutSpec{
 					Pipeline: apiv1.Pipeline{
 						Spec: runtime.RawExtension{Raw: []byte(tt.jsonInput)},
@@ -690,8 +698,14 @@ func TestPipelineLabels(t *testing.T) {
 				t.Errorf("pipelineLabels() error = %v, expectError %v", err, tt.expectError)
 				return
 			}
-			if err == nil && labels[common.LabelKeyISBServiceNameForPipeline] != tt.expectedLabel {
-				t.Errorf("pipelineLabels() = %v, expected %v", common.LabelKeyISBServiceNameForPipeline, tt.expectedLabel)
+			if err == nil {
+				if labels[common.LabelKeyISBServiceNameForPipeline] != tt.expectedLabel {
+					t.Errorf("pipelineLabels() = %v, expected %v", common.LabelKeyISBServiceNameForPipeline, tt.expectedLabel)
+				}
+
+				if labels[common.LabelKeyPipelineRolloutForPipeline] != pipelineRolloutName {
+					t.Errorf("pipelineLabels() = %v, expected %v", common.LabelKeyPipelineRolloutForPipeline, pipelineRolloutName)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #254

### Modifications

This PR adds the label to the pipelines managed by numaplane, to quickly locate the Pipelines of a given PipelineRollout. This will be needed when there could be multiple pipelines associate with a pipelineRollout.

### Verification

`make test`