### PR TITLE
feat: Add health metrics for monovertex

### DIFF
--- a/internal/controller/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout_controller.go
@@ -155,6 +155,14 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 	startTime := time.Now()
 	numaLogger := logger.FromContext(ctx)
 
+	defer func() {
+		if monoVertexRollout.Status.IsHealthy() {
+			r.customMetrics.MonoVerticesHealth.WithLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name).Set(1)
+		} else {
+			r.customMetrics.MonoVerticesHealth.WithLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name).Set(0)
+		}
+	}()
+
 	// remove finalizers if monoVertexRollout is being deleted
 	if !monoVertexRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting MonoVertexRollout")
@@ -164,6 +172,7 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 		// generate metrics for MonoVertex deletion
 		r.customMetrics.DecMonoVertexMetrics(monoVertexRollout.Name, monoVertexRollout.Namespace)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerMonoVertexRollout, "delete").Observe(time.Since(startTime).Seconds())
+		r.customMetrics.MonoVerticesHealth.DeleteLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name)
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
@@ -63,7 +63,7 @@ func init() {
 	SchemeBuilder.Register(&MonoVertexRollout{}, &MonoVertexRolloutList{})
 }
 
-// IsHealthy indicates whether the InterStepBufferService is healthy or not
+// IsHealthy indicates whether the MonoVertexRollout is healthy.
 func (mv *MonoVertexRolloutStatus) IsHealthy() bool {
 	if mv.Phase != PhaseDeployed {
 		return false

--- a/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
@@ -65,5 +65,5 @@ func init() {
 
 // IsHealthy indicates whether the MonoVertexRollout is healthy.
 func (mv *MonoVertexRolloutStatus) IsHealthy() bool {
-	return mv.Phase == PhaseDeployed
+	return mv.Phase == PhaseDeployed || mv.Phase == PhasePending
 }

--- a/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
@@ -62,3 +62,11 @@ type MonoVertexRolloutList struct {
 func init() {
 	SchemeBuilder.Register(&MonoVertexRollout{}, &MonoVertexRolloutList{})
 }
+
+// IsHealthy indicates whether the InterStepBufferService is healthy or not
+func (mv *MonoVertexRolloutStatus) IsHealthy() bool {
+	if mv.Phase != PhaseDeployed {
+		return false
+	}
+	return mv.IsReady()
+}

--- a/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
@@ -65,8 +65,5 @@ func init() {
 
 // IsHealthy indicates whether the MonoVertexRollout is healthy.
 func (mv *MonoVertexRolloutStatus) IsHealthy() bool {
-	if mv.Phase != PhaseDeployed {
-		return false
-	}
-	return mv.IsReady()
+	return mv.Phase == PhaseDeployed
 }

--- a/pkg/apis/numaplane/v1alpha1/status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/status_types.go
@@ -201,16 +201,3 @@ func (s *Status) markTypeStatus(t ConditionType, status metav1.ConditionStatus, 
 		ObservedGeneration: generation,
 	})
 }
-
-// IsReady returns true when all the conditions are true
-func (s *Status) IsReady() bool {
-	if len(s.Conditions) == 0 {
-		return false
-	}
-	for _, c := range s.Conditions {
-		if c.Status != metav1.ConditionTrue {
-			return false
-		}
-	}
-	return true
-}

--- a/pkg/apis/numaplane/v1alpha1/status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/status_types.go
@@ -201,3 +201,16 @@ func (s *Status) markTypeStatus(t ConditionType, status metav1.ConditionStatus, 
 		ObservedGeneration: generation,
 	})
 }
+
+// IsReady returns true when all the conditions are true
+func (s *Status) IsReady() bool {
+	if len(s.Conditions) == 0 {
+		return false
+	}
+	for _, c := range s.Conditions {
+		if c.Status != metav1.ConditionTrue {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes: https://github.com/numaproj/numaplane/issues/233

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

Add rollout health metrics for monovertex

### Verification
- verified in local k8s cluster
```bash
# HELP numaplane_monovertex_rollout_health A metric to indicate whether the MonoVertex is healthy. '1' means healthy, '0' means unhealthy
# TYPE numaplane_monovertex_rollout_health gauge
numaplane_monovertex_rollout_health{intuit_alert="true",monovertex="my-monovertex",namespace="example-namespace"} 1
```

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->