### PR TITLE
test: add environment variable to enable dataLossPrevention for e2e testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,11 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        datalossprevention: ["true", "false"]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -149,29 +154,10 @@ jobs:
         env:
           GOPATH: /home/runner/go
         run:
-          KUBECONFIG=~/.kube/config VERSION=${{ github.sha }} DOCKER_PUSH=true make start
+          KUBECONFIG=~/.kube/config VERSION=${{ github.sha }} DOCKER_PUSH=true DATA_LOSS_PREVENTION=${{matrix.datalossprevention}} make start
 
       - name: Run e2e tests
         env:
           GOPATH: /home/runner/go
-        run: KUBECONFIG=~/.kube/config VERSION=${{ github.sha }} DOCKER_PUSH=true make test-e2e
-
-      - name: Create second cluster
-        run: |
-          export PATH=$PATH:/usr/local/bin
-          k3d cluster create e2e-data-loss-prevention
-          k3d kubeconfig get e2e-data-loss-prevention > ~/.kube/config
-          echo '127.0.0.1 localhost' | sudo tee -a /etc/hosts
-          echo 'Waiting for the cluster to be ready...'
-          until kubectl cluster-info; do sleep 1; done
-
-      - name: Install Numaplane with dataLossPrevention=true
-        env:
-          GOPATH: /home/runner/go
-        run:
-          KUBECONFIG=~/.kube/config VERSION=${{ github.sha }} DOCKER_PUSH=true TEST_MANIFEST_DIR=tests/manifests/special-cases/pause make start
-
-      - name: Run e2e tests with dataLossPrevention=true
-        env:
-          GOPATH: /home/runner/go
-        run: KUBECONFIG=~/.kube/config VERSION=${{ github.sha }} DOCKER_PUSH=true make test-e2e
+        run: KUBECONFIG=~/.kube/config VERSION=${{ github.sha }} DOCKER_PUSH=true DATA_LOSS_PREVENTION=${{matrix.datalossprevention}} make test-e2e
+        

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ GCFLAGS="all=-N -l"
 ENVTEST_K8S_VERSION = 1.28.0
 
 TEST_MANIFEST_DIR ?= tests/manifests/default
+TEST_PAUSE_MANIFEST_DIR ?= tests/manifests/special-cases/pause 
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -184,7 +185,11 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: start
 start: image
 	$(KUBECTL) apply -f tests/manifests/default/numaplane-ns.yaml
+ifeq ($(DATA_LOSS_PREVENTION), true)
+	$(KUBECTL) kustomize $(TEST_PAUSE_MANIFEST_DIR) | sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/$(IMG):$(BASE_VERSION)/$(IMG):$(VERSION)/' | $(KUBECTL) apply -f -
+else
 	$(KUBECTL) kustomize $(TEST_MANIFEST_DIR) | sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/$(IMG):$(BASE_VERSION)/$(IMG):$(VERSION)/' | $(KUBECTL) apply -f -
+endif
 
 ##@ Build Dependencies
 

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -35,6 +35,8 @@ var (
 	numaflowControllerRolloutClient planepkg.NumaflowControllerRolloutInterface
 	monoVertexRolloutClient         planepkg.MonoVertexRolloutInterface
 	kubeClient                      clientgo.Interface
+
+	dataLossPrevention string
 )
 
 const (

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -331,10 +331,16 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		if dataLossPrevention == "true" {
 			document("Verify that Pipelines are being paused by checking rollout condition")
-			Eventually(func() metav1.ConditionStatus {
-				rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-			}, testTimeout).Should(Equal(metav1.ConditionTrue))
+			Eventually(func() bool {
+				ncRollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+				ncCondStatus := getRolloutCondition(ncRollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+				plRollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+				plCondStatus := getRolloutCondition(plRollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
+				if ncCondStatus != metav1.ConditionTrue || plCondStatus != metav1.ConditionTrue {
+					return false
+				}
+				return true
+			}, testTimeout).Should(BeTrue())
 		}
 
 		// TODO: update this controller image when Numaflow v1.3.1 is released
@@ -366,10 +372,16 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		if dataLossPrevention == "true" {
 			document("Verify that Pipelines are being paused by checking rollout condition")
-			Eventually(func() metav1.ConditionStatus {
-				rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-			}, testTimeout).Should(Equal(metav1.ConditionTrue))
+			Eventually(func() bool {
+				isbRollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+				isbCondStatus := getRolloutCondition(isbRollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+				plRollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+				plCondStatus := getRolloutCondition(plRollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
+				if isbCondStatus != metav1.ConditionTrue || plCondStatus != metav1.ConditionTrue {
+					return false
+				}
+				return true
+			}, testTimeout).Should(BeTrue())
 		}
 
 		verifyISBServiceSpec(Namespace, isbServiceRolloutName, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -184,23 +184,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 		}, testTimeout, testPollingInterval).Should(Succeed())
 
 		verifyNumaflowControllerRolloutReady()
-		document("Verifying that the NumaflowControllerRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		if dataLossPrevention == "true" {
-			Eventually(func() metav1.ConditionStatus {
-				rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
-		}
 
 		verifyNumaflowControllerReady(Namespace)
 	})
@@ -218,23 +201,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 		}, testTimeout, testPollingInterval).Should(Succeed())
 
 		verifyISBSvcRolloutReady(isbServiceRolloutName)
-		document("Verifying that the ISBServiceRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		if dataLossPrevention == "true" {
-			Eventually(func() metav1.ConditionStatus {
-				rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
-		}
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 
@@ -307,6 +273,8 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return *retrievedPipelineSpec.Vertices[0].Source.Generator.RPU == int64(5)
 		})
 
+		verifyPipelineRolloutReady(pipelineRolloutName)
+
 		verifyPipelineReady(Namespace, pipelineRolloutName, 2)
 
 	})
@@ -323,8 +291,8 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
-		document("Verify that child Pipeline is paused by checking rollout condition")
 		if dataLossPrevention == "true" {
+			document("Verify that child Pipeline is paused by checking rollout condition")
 			Eventually(func() metav1.ConditionStatus {
 				rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
@@ -343,21 +311,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return len(retrievedPipelineSpec.Vertices) == 3
 		})
 
-		document("Verifying that the PipelineRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
+		verifyPipelineRolloutReady(pipelineRolloutName)
 
 		verifyPipelineReady(Namespace, pipelineRolloutName, 3)
 
@@ -375,8 +329,8 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
-		document("Verify that Pipelines are being paused by checking rollout condition")
 		if dataLossPrevention == "true" {
+			document("Verify that Pipelines are being paused by checking rollout condition")
 			Eventually(func() metav1.ConditionStatus {
 				rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
@@ -390,23 +344,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 		})
 
 		verifyNumaflowControllerRolloutReady()
-		document("Verifying that the NumaflowControllerRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		if dataLossPrevention == "true" {
-			Eventually(func() metav1.ConditionStatus {
-				rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
-		}
 
 		verifyNumaflowControllerReady(Namespace)
 
@@ -427,8 +364,8 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
-		document("Verify that Pipelines are being paused by checking rollout condition")
 		if dataLossPrevention == "true" {
+			document("Verify that Pipelines are being paused by checking rollout condition")
 			Eventually(func() metav1.ConditionStatus {
 				rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
@@ -440,23 +377,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 		})
 
 		verifyISBSvcRolloutReady(isbServiceRolloutName)
-		document("Verifying that the ISBServiceRollout conditions are as expected")
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		Eventually(func() metav1.ConditionStatus {
-			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
-
-		if dataLossPrevention == "true" {
-			Eventually(func() metav1.ConditionStatus {
-				rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
-		}
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -296,7 +296,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			Eventually(func() metav1.ConditionStatus {
 				rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+			}, testTimeout).Should(Equal(metav1.ConditionTrue))
 		}
 
 		// wait for update to reconcile
@@ -334,7 +334,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			Eventually(func() metav1.ConditionStatus {
 				rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+			}, testTimeout).Should(Equal(metav1.ConditionTrue))
 		}
 
 		// TODO: update this controller image when Numaflow v1.3.1 is released
@@ -369,7 +369,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			Eventually(func() metav1.ConditionStatus {
 				rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+			}, testTimeout).Should(Equal(metav1.ConditionTrue))
 		}
 
 		verifyISBServiceSpec(Namespace, isbServiceRolloutName, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -32,6 +32,7 @@ import (
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 
+	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
@@ -331,6 +332,10 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		if dataLossPrevention == "true" {
 			document("Verify that Pipelines are being paused by checking rollout condition")
+			verifyPipelineStatus(Namespace, pipelineRolloutName,
+				func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus kubernetes.GenericStatus) bool {
+					return retrievedPipelineStatus.Phase == string(numaflowv1.PipelinePhasePaused)
+				})
 			Eventually(func() bool {
 				ncRollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
 				ncCondStatus := getRolloutCondition(ncRollout.Status.Conditions, apiv1.ConditionPausingPipelines)
@@ -372,6 +377,10 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		if dataLossPrevention == "true" {
 			document("Verify that Pipelines are being paused by checking rollout condition")
+			verifyPipelineStatus(Namespace, pipelineRolloutName,
+				func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus kubernetes.GenericStatus) bool {
+					return retrievedPipelineStatus.Phase == string(numaflowv1.PipelinePhasePaused)
+				})
 			Eventually(func() bool {
 				isbRollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 				isbCondStatus := getRolloutCondition(isbRollout.Status.Conditions, apiv1.ConditionPausingPipelines)

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -150,11 +150,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-		// TODO: add test when dataLossPrevention envVar is added
-		// Eventually(func() metav1.ConditionStatus {
-		// 	rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		if dataLossPrevention == "true" {
+			Eventually(func() metav1.ConditionStatus {
+				rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
+		}
 
 		verifyNumaflowControllerReady(Namespace)
 	})
@@ -182,10 +183,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-		// Eventually(func() metav1.ConditionStatus {
-		// 	rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		if dataLossPrevention == "true" {
+			Eventually(func() metav1.ConditionStatus {
+				rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
+		}
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 
@@ -303,13 +306,13 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
-		// TODO: check that when pipeline is being updated, it is being paused
-		//       could set envVar to signify dataLossPrevention is on
-		// Eventually(func() metav1.ConditionStatus {
-		// 	rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRollouName, metav1.GetOptions{})
-		//
-		// return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+		document("Verify that child Pipeline is paused by checking rollout condition")
+		if dataLossPrevention == "true" {
+			Eventually(func() metav1.ConditionStatus {
+				rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
+			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+		}
 
 		// wait for update to reconcile
 		time.Sleep(5 * time.Second)
@@ -355,6 +358,14 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
+		document("Verify that Pipelines are being paused by checking rollout condition")
+		if dataLossPrevention == "true" {
+			Eventually(func() metav1.ConditionStatus {
+				rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+		}
+
 		// TODO: update this controller image when Numaflow v1.3.1 is released
 		//       versions prior to v1.3.0 do not reconcile MonoVertex
 		verifyNumaflowControllerDeployment(Namespace, func(d appsv1.Deployment) bool {
@@ -372,10 +383,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-		// Eventually(func() metav1.ConditionStatus {
-		// 	rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		if dataLossPrevention == "true" {
+			Eventually(func() metav1.ConditionStatus {
+				rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
+		}
 
 		verifyNumaflowControllerReady(Namespace)
 
@@ -396,6 +409,14 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
+		document("Verify that Pipelines are being paused by checking rollout condition")
+		if dataLossPrevention == "true" {
+			Eventually(func() metav1.ConditionStatus {
+				rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
+		}
+
 		verifyISBServiceSpec(Namespace, isbServiceRolloutName, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream.Version == "2.9.8"
 		})
@@ -411,10 +432,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-		// Eventually(func() metav1.ConditionStatus {
-		// 	rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-		// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+		if dataLossPrevention == "true" {
+			Eventually(func() metav1.ConditionStatus {
+				rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+				return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+			}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
+		}
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -68,10 +68,13 @@ func verifyISBSvcRolloutReady(isbServiceRolloutName string) {
 		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-	// Eventually(func() metav1.ConditionStatus {
-	// 	rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-	// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-	// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+	if dataLossPrevention == "true" {
+		document("Verifying that the ISBServiceRollout PausingPipelines condition is as expected")
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
+	}
 
 }
 

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -44,11 +44,14 @@ func verifyNumaflowControllerRolloutReady() {
 		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-	// TODO: add test when dataLossPrevention envVar is added
-	// Eventually(func() metav1.ConditionStatus {
-	// 	rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-	// 	return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-	// }, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionUnknown))
+	if dataLossPrevention == "true" {
+		document("Verifying that the NumaflowControllerRollout PausingPipelines condition is as expected")
+		Eventually(func() metav1.ConditionStatus {
+			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+		}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
+	}
+
 }
 
 func verifyNumaflowControllerReady(namespace string) {

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -77,6 +77,7 @@ func verifyPipelineRolloutReady(pipelineRolloutName string) {
 		rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 		return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
 	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionFalse))
+
 }
 
 func verifyPipelineReady(namespace string, pipelineName string, numVertices int) {

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -36,7 +36,7 @@ func verifyPipelineSpec(namespace string, pipelineName string, f func(numaflowv1
 
 func verifyPipelineStatus(namespace string, pipelineName string, f func(numaflowv1.PipelineSpec, kubernetes.GenericStatus) bool) {
 
-	document("verifying PipelineStatus")
+	// document("verifying PipelineStatus")
 	var retrievedPipelineSpec numaflowv1.PipelineSpec
 	var retrievedPipelineStatus kubernetes.GenericStatus
 	Eventually(func() bool {
@@ -52,7 +52,7 @@ func verifyPipelineStatus(namespace string, pipelineName string, f func(numaflow
 		}
 
 		return f(retrievedPipelineSpec, retrievedPipelineStatus)
-	}, testTimeout, testPollingInterval).Should(BeTrue())
+	}, testTimeout).Should(BeTrue())
 }
 
 func verifyPipelineRolloutReady(pipelineRolloutName string) {

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -43,6 +44,8 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+
+	dataLossPrevention = os.Getenv("DATA_LOSS_PREVENTION")
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #259 

This pull request introduces the DATA_LOSS_PREVENTION environment variable. When this is set, the user will be able to:

- run make start to install the manifests that set the `dataLossPrevention` flag to `true`
- run make test-e2e to run specific cases to check that resources are pausing when being updated (PPND)

With this change, we are also able to split the currently long e2e test run on the Github CI into two separate runs using a matrix. These two runs are for when this dataLossPrevention flag is enabled or not to accurately test functionality.

### Modifications

Modify Makefile to use DATA_LOSS_PREVENTION flag to install pause manifests.

e2e tests now includes logic that is only checked when this environment variable is set.

Changed the update Pipeline e2e test to be a more substantial change (adding a vertex) for future testing later where we determine whether or not an upgrade truly requires a pause.

### Verification

Ran make start and make test-e2e with the variable set or not multiple times to check both scenarios.