### PR TITLE
fix: revert changes to Updating Rollout Status to see if it fixes e2e intermittent failures

### DIFF
--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -540,7 +540,26 @@ func (r *ISBServiceRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ISBServiceRolloutReconciler) updateISBServiceRolloutStatus(ctx context.Context, isbServiceRollout *apiv1.ISBServiceRollout) error {
-	return r.client.Status().Update(ctx, isbServiceRollout)
+	rawSpec := runtime.RawExtension{}
+	err := util.StructToStruct(&isbServiceRollout.Spec, &rawSpec)
+	if err != nil {
+		return fmt.Errorf("unable to convert ISBServiceRollout Spec to GenericObject Spec: %v", err)
+	}
+
+	rawStatus := runtime.RawExtension{}
+	err = util.StructToStruct(&isbServiceRollout.Status, &rawStatus)
+	if err != nil {
+		return fmt.Errorf("unable to convert ISBServiceRollout Status to GenericObject Status: %v", err)
+	}
+
+	obj := kubernetes.GenericObject{
+		TypeMeta:   isbServiceRollout.TypeMeta,
+		ObjectMeta: isbServiceRollout.ObjectMeta,
+		Spec:       rawSpec,
+		Status:     rawStatus,
+	}
+
+	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "isbservicerollouts")
 }
 
 func (r *ISBServiceRolloutReconciler) updateISBServiceRolloutStatusToFailed(ctx context.Context, isbServiceRollout *apiv1.ISBServiceRollout, err error) error {

--- a/internal/controller/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout_controller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
 	"github.com/numaproj/numaplane/internal/util/metrics"
@@ -291,7 +292,26 @@ func (r *MonoVertexRolloutReconciler) updateMonoVertex(ctx context.Context, mono
 }
 
 func (r *MonoVertexRolloutReconciler) updateMonoVertexRolloutStatus(ctx context.Context, monoVertexRollout *apiv1.MonoVertexRollout) error {
-	return r.client.Status().Update(ctx, monoVertexRollout)
+	rawSpec := runtime.RawExtension{}
+	err := util.StructToStruct(&monoVertexRollout.Spec, &rawSpec)
+	if err != nil {
+		return fmt.Errorf("unable to convert MonoVertexRollout Spec to GenericObject Spec: %v", err)
+	}
+
+	rawStatus := runtime.RawExtension{}
+	err = util.StructToStruct(&monoVertexRollout.Status, &rawStatus)
+	if err != nil {
+		return fmt.Errorf("unable to convert MonoVertexRollout Status to GenericObject Status: %v", err)
+	}
+
+	obj := kubernetes.GenericObject{
+		TypeMeta:   monoVertexRollout.TypeMeta,
+		ObjectMeta: monoVertexRollout.ObjectMeta,
+		Spec:       rawSpec,
+		Status:     rawStatus,
+	}
+
+	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "monovertexrollouts")
 }
 
 func (r *MonoVertexRolloutReconciler) updateMonoVertexRolloutStatusToFailed(ctx context.Context, monoVertexRollout *apiv1.MonoVertexRollout, err error) error {

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -53,6 +53,7 @@ import (
 	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/sync"
+	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
 	"github.com/numaproj/numaplane/internal/util/metrics"
@@ -789,7 +790,26 @@ func toUnstructuredAndApplyLabel(manifests []string, name string) ([]*unstructur
 }
 
 func (r *NumaflowControllerRolloutReconciler) updateNumaflowControllerRolloutStatus(ctx context.Context, controllerRollout *apiv1.NumaflowControllerRollout) error {
-	return r.client.Status().Update(ctx, controllerRollout)
+	rawSpec := runtime.RawExtension{}
+	err := util.StructToStruct(&controllerRollout.Spec, &rawSpec)
+	if err != nil {
+		return fmt.Errorf("unable to convert NumaflowControllerRollout Spec to GenericObject Spec: %v", err)
+	}
+
+	rawStatus := runtime.RawExtension{}
+	err = util.StructToStruct(&controllerRollout.Status, &rawStatus)
+	if err != nil {
+		return fmt.Errorf("unable to convert NumaflowControllerRollout Status to GenericObject Status: %v", err)
+	}
+
+	obj := kubernetes.GenericObject{
+		TypeMeta:   controllerRollout.TypeMeta,
+		ObjectMeta: controllerRollout.ObjectMeta,
+		Spec:       rawSpec,
+		Status:     rawStatus,
+	}
+
+	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "numaflowcontrollerrollouts")
 }
 
 func (r *NumaflowControllerRolloutReconciler) updateNumaflowControllerRolloutStatusToFailed(ctx context.Context, controllerRollout *apiv1.NumaflowControllerRollout, err error) error {

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -861,7 +861,26 @@ func pipelineLabels(pipelineRollout *apiv1.PipelineRollout) (map[string]string, 
 	return labelMapping, nil
 }
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatus(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) error {
-	return r.client.Status().Update(ctx, pipelineRollout)
+	rawSpec := runtime.RawExtension{}
+	err := util.StructToStruct(&pipelineRollout.Spec, &rawSpec)
+	if err != nil {
+		return fmt.Errorf("unable to convert PipelineRollout Spec to GenericObject Spec: %v", err)
+	}
+
+	rawStatus := runtime.RawExtension{}
+	err = util.StructToStruct(&pipelineRollout.Status, &rawStatus)
+	if err != nil {
+		return fmt.Errorf("unable to convert PipelineRollout Status to GenericObject Status: %v", err)
+	}
+
+	obj := kubernetes.GenericObject{
+		TypeMeta:   pipelineRollout.TypeMeta,
+		ObjectMeta: pipelineRollout.ObjectMeta,
+		Spec:       rawSpec,
+		Status:     rawStatus,
+	}
+
+	return kubernetes.UpdateStatus(ctx, r.restConfig, &obj, "pipelinerollouts")
 }
 
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatusToFailed(ctx context.Context, pipelineRollout *apiv1.PipelineRollout, err error) error {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

For some reason, removing this code seems to reliably cause the e2e tests to pass again.

One thing that this change did was create more opportunities for resourceVersion conflict, such that an error would be returned to `Reconcile()`. Although, it seems that in all of the Rollouts, the Status would only be updated at the end of the `Reconcile()` function anyway. So, I'm not sure how returning an error and thus calling `Reconcile()` again would be a problem. ?

Will revert this for now and figure out the issue separately.


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->