### PR TITLE
fix: functional test for checking correct number of pipeline vertices running

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -64,7 +64,7 @@ func verifyPodsRunning(namespace string, numPods int, labelSelector string) {
 
 	Eventually(func() bool {
 		podsList, _ := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
-		if podsList != nil && len(podsList.Items) >= numPods {
+		if podsList != nil && len(podsList.Items) == numPods {
 			for _, pod := range podsList.Items {
 				if pod.Status.Phase != "Running" {
 					return false

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -358,7 +358,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		verifyNumaflowControllerReady(Namespace)
 
-		verifyPipelineReady(Namespace, pipelineRolloutName, 2)
+		verifyPipelineReady(Namespace, pipelineRolloutName, 3)
 
 	})
 
@@ -401,7 +401,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
 
-		verifyPipelineReady(Namespace, pipelineRolloutName, 2)
+		verifyPipelineReady(Namespace, pipelineRolloutName, 3)
 
 	})
 

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -93,7 +93,7 @@ func verifyPipelineReady(namespace string, pipelineName string, numVertices int)
 	// Get Pipeline Pods to verify they're all up
 	document("Verifying that the Pipeline is ready")
 	// check "vertex" Pods
-	verifyPodsRunning(namespace, 2, vertexLabelSelector)
+	verifyPodsRunning(namespace, numVertices, vertexLabelSelector)
 	verifyPodsRunning(namespace, 1, daemonLabelSelector)
 
 }


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Function in test that was supposed to be checking for a certain number of vertices running wasn't using the parameter passed in. Also, since the test switches from using 2 to 3 vertices, need to pass in 3 once the spec gets changed.


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->