### PR TITLE
fix: nc/isbservice rollouts will not wait for unowned pipelines to pause

### DIFF
--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -374,7 +374,8 @@ func (r *ISBServiceRolloutReconciler) isISBServiceUpdating(ctx context.Context, 
 }
 
 func (r *ISBServiceRolloutReconciler) getPipelineList(ctx context.Context, rolloutNamespace string, rolloutName string) ([]*kubernetes.GenericObject, error) {
-	return kubernetes.ListCR(ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", rolloutNamespace, fmt.Sprintf("%s=%s", common.LabelKeyISBServiceNameForPipeline, rolloutName), "")
+	// here
+	return kubernetes.ListCR(ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", rolloutNamespace, fmt.Sprintf("%s=%s,%s", common.LabelKeyISBServiceNameForPipeline, rolloutName, common.LabelKeyPipelineRolloutForPipeline), "")
 }
 
 // Apply pod disruption budget for the ISBService

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -327,7 +327,6 @@ func (r *NumaflowControllerRolloutReconciler) getChildTypeString() string {
 }
 
 func (r *NumaflowControllerRolloutReconciler) getPipelineList(ctx context.Context, rolloutNamespace string, _ string) ([]*kubernetes.GenericObject, error) {
-	// here
 	return kubernetes.ListCR(ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", rolloutNamespace, common.LabelKeyPipelineRolloutForPipeline, "")
 }
 

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -327,7 +327,8 @@ func (r *NumaflowControllerRolloutReconciler) getChildTypeString() string {
 }
 
 func (r *NumaflowControllerRolloutReconciler) getPipelineList(ctx context.Context, rolloutNamespace string, _ string) ([]*kubernetes.GenericObject, error) {
-	return kubernetes.ListCR(ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", rolloutNamespace, "", "")
+	// here
+	return kubernetes.ListCR(ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", rolloutNamespace, common.LabelKeyPipelineRolloutForPipeline, "")
 }
 
 func (r *NumaflowControllerRolloutReconciler) getRolloutKey(rolloutNamespace string, rolloutName string) string {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #245 

### Modifications

If dataLossPrevention is enabled and there are pipelines that are not owned by a PipelineRollout in a namespace, when updating a NumaflowController/ISBServiceRollout they would wait for this pipeline to pause that never would. This is because this pipeline is never told to pause (intended) and the controllers for each rollout just list pipelines in the namespace to watch.

We change this query for pipelines in the namespace to check that they are owned by a PipelineRollout:
```
kubectl get pl -n {namespace} -l numaplane.numaproj.io/pipeline-rollout-name
``` 

### Verification

Checked locally that updates on a NumaflowController and ISBService rollout both succeeded with a unowned pipeline existing in the namespace.