### PR TITLE
feat: add a label to identify the promoted/deployed pipeline for a pipelineRollout

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -52,11 +52,11 @@ const (
 	// a NumaRollout.
 	LabelKeyUpgradeState = "numaplane.numaproj.io/upgrade-state"
 
-	// LabelValueUpgradePromoted is the label value indicate the resource, managed by a NumaRollout, is promoted
+	// LabelValueUpgradePromoted is the label value indicating that the resource managed by a NumaRollout is promoted
 	// after an upgrade.
 	LabelValueUpgradePromoted UpgradeState = "promoted"
 
-	// LabelValueUpgradeInProgress is the label value indicate the resource, managed by a NumaRollout, is in the progress
+	// LabelValueUpgradeInProgress is the label value indicating that the resource managed by a NumaRollout is in progress
 	// of upgrade.
 	LabelValueUpgradeInProgress UpgradeState = "in-progress"
 )

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -9,6 +9,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// UpgradeState is the enum to track the possible state of
+// a resource upgrade, it can only be `promoted` or `in-progress`.
+type UpgradeState string
+
 const (
 	// SSAManager is the default numaplane manager name used by server-side apply syncs
 	SSAManager = "numaplane-controller"
@@ -43,6 +47,18 @@ const (
 	// LabelKeyPipelineRolloutForPipeline is the label key used to identify the PipelineRollout a Pipeline is managed by
 	// This is useful as a Label to quickly locate all Pipelines of a given PipelineRollout
 	LabelKeyPipelineRolloutForPipeline = "numaplane.numaproj.io/pipeline-rollout-name"
+
+	// LabelKeyUpgradeState is the label key used to identify the upgrade state of a resource that is managed by
+	// a NumaRollout.
+	LabelKeyUpgradeState = "numaplane.numaproj.io/upgrade-state"
+
+	// LabelValueUpgradePromoted is the label value indicate the resource, managed by a NumaRollout, is promoted
+	// after an upgrade.
+	LabelValueUpgradePromoted UpgradeState = "promoted"
+
+	// LabelValueUpgradeInProgress is the label value indicate the resource, managed by a NumaRollout, is in the progress
+	// of upgrade.
+	LabelValueUpgradeInProgress UpgradeState = "in-progress"
 )
 
 var (

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -45,7 +45,6 @@ import (
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaplane/internal/common"
-
 	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
@@ -866,6 +865,7 @@ func pipelineLabels(pipelineRollout *apiv1.PipelineRollout) (map[string]string, 
 	}
 
 	labelMapping[common.LabelKeyPipelineRolloutForPipeline] = pipelineRollout.Name
+	labelMapping[common.LabelKeyUpgradeState] = string(common.LabelValueUpgradePromoted)
 
 	return labelMapping, nil
 }

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -20,23 +20,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/numaproj/numaplane/internal/common"
 	"strings"
-	"time"
-
 	"testing"
-
-	"github.com/stretchr/testify/assert"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
@@ -143,6 +141,7 @@ var _ = Describe("PipelineRollout Controller", Ordered, func() {
 
 			By("Verifying the label of the pipeline")
 			Expect(createdResource.Labels[common.LabelKeyPipelineRolloutForPipeline]).Should(Equal(pipelineRollout.Name))
+			Expect(createdResource.Labels[common.LabelKeyUpgradeState]).Should(Equal(string(common.LabelValueUpgradePromoted)))
 		})
 
 		It("Should have the PipelineRollout Status Phase has Deployed and ObservedGeneration matching Generation", func() {
@@ -686,6 +685,10 @@ func TestPipelineLabels(t *testing.T) {
 
 				if labels[common.LabelKeyPipelineRolloutForPipeline] != pipelineRolloutName {
 					t.Errorf("pipelineLabels() = %v, expected %v", common.LabelKeyPipelineRolloutForPipeline, pipelineRolloutName)
+				}
+
+				if labels[common.LabelKeyUpgradeState] != string(common.LabelValueUpgradePromoted) {
+					t.Errorf("pipelineLabels() = %v, expected %v", common.LabelKeyUpgradeState, string(common.LabelValueUpgradePromoted))
 				}
 			}
 		})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #272 

### Modifications

Added the label `numaplane.numaproj.io/upgrade-state: promoted` to uniquely identify the deployed/promoted pipeline associate with a PipelineRollout, together with label `numaplane.numaproj.io/pipeline-rollout-name: pipeline-rollout-name`, instead of using the PipelineRollout name. And the `upgrade-state` label can only be in `promoted` or `in-progress`, the later should only be used for no down time upgrade feature.


### Verification

`make test`