### PR TITLE
fix: delete old outputs directory before creating new one

### DIFF
--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -46,7 +46,14 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 
 	var err error
-	err = os.Mkdir("output", os.ModePerm)
+	// make output directory to store temporary outputs; if it's there from before delete it
+	directory := "output"
+	_, err = os.Stat(directory)
+	if err == nil {
+		err = os.RemoveAll(directory)
+		Expect(err).NotTo(HaveOccurred())
+	}
+	err = os.Mkdir(directory, os.ModePerm)
 	Expect(err).NotTo(HaveOccurred())
 
 	dataLossPrevention = os.Getenv("DATA_LOSS_PREVENTION")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Was getting an error trying to make the directory - need to delete previous directory first

I thought it was better to delete the previous directory (as opposed to skipping the `MkDir()`) so as to remove any previous outputs and start clean.


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->