### PR TITLE
fix: change polling interval in e2e test back to 10ms

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -401,7 +401,7 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .spec.replicas
+    - jsonPath: .status.desiredReplicas
       name: Desired
       type: string
     - jsonPath: .status.replicas
@@ -900,7 +900,7 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .spec.replicas
+    - jsonPath: .status.desiredReplicas
       name: Desired
       type: string
     - jsonPath: .status.replicas

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -36,7 +36,7 @@ var (
 	cancel              context.CancelFunc
 	suiteTimeout        = 30 * time.Minute // Note: if we start seeing "client rate limiter: context deadline exceeded", we need to increase this value
 	testTimeout         = 2 * time.Minute
-	testPollingInterval = 1 * time.Second
+	testPollingInterval = 10 * time.Millisecond
 
 	pipelineRolloutClient           planepkg.PipelineRolloutInterface
 	isbServiceRolloutClient         planepkg.ISBServiceRolloutInterface

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -560,7 +560,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 				return false
 			}
 			return true
-		}).WithTimeout(testTimeout).WithPolling(1*time.Second).Should(BeFalse(), "The PipelineRollout should have been deleted but it was found.")
+		}).WithTimeout(testTimeout).Should(BeFalse(), "The PipelineRollout should have been deleted but it was found.")
 
 		document("Verifying Pipeline deletion")
 
@@ -573,7 +573,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 				return false
 			}
 			return true
-		}).WithTimeout(testTimeout).WithPolling(1*time.Second).Should(BeFalse(), "The Pipeline should have been deleted but it was found.")
+		}).WithTimeout(testTimeout).Should(BeFalse(), "The Pipeline should have been deleted but it was found.")
 
 	})
 
@@ -595,7 +595,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 				return false
 			}
 			return true
-		}).WithTimeout(testTimeout).WithPolling(1*time.Second).Should(BeFalse(), "The MonoVertexRollout should have been deleted but it was found.")
+		}).WithTimeout(testTimeout).Should(BeFalse(), "The MonoVertexRollout should have been deleted but it was found.")
 
 		document("Verifying MonoVertex deletion")
 
@@ -608,7 +608,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 				return false
 			}
 			return true
-		}).WithTimeout(testTimeout).WithPolling(1*time.Second).Should(BeFalse(), "The MonoVertex should have been deleted but it was found.")
+		}).WithTimeout(testTimeout).Should(BeFalse(), "The MonoVertex should have been deleted but it was found.")
 	})
 
 	It("Should delete the ISBServiceRollout and child ISBService", func() {
@@ -629,7 +629,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 				return false
 			}
 			return true
-		}).WithTimeout(testTimeout).WithPolling(1*time.Second).Should(BeFalse(), "The ISBServiceRollout should have been deleted but it was found.")
+		}).WithTimeout(testTimeout).Should(BeFalse(), "The ISBServiceRollout should have been deleted but it was found.")
 
 		document("Verifying ISBService deletion")
 
@@ -642,7 +642,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 				return false
 			}
 			return true
-		}).WithTimeout(testTimeout).WithPolling(1*time.Second).Should(BeFalse(), "The ISBService should have been deleted but it was found.")
+		}).WithTimeout(testTimeout).Should(BeFalse(), "The ISBService should have been deleted but it was found.")
 
 	})
 
@@ -662,7 +662,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 				return false
 			}
 			return true
-		}).WithTimeout(testTimeout).WithPolling(1*time.Second).Should(BeFalse(), "The NumaflowControllerRollout should have been deleted but it was found.")
+		}).WithTimeout(testTimeout).Should(BeFalse(), "The NumaflowControllerRollout should have been deleted but it was found.")
 
 		document("Verifying Numaflow Controller deletion")
 
@@ -675,7 +675,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 				return false
 			}
 			return true
-		}).WithTimeout(testTimeout).WithPolling(1*time.Second).Should(BeFalse(), "The deployment should have been deleted but it was found.")
+		}).WithTimeout(testTimeout).Should(BeFalse(), "The deployment should have been deleted but it was found.")
 
 	})
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

I originally changed the polling for many of our calls to 1 second out of fear that there would be a rate limiting issue that would cause false failures.

However, I am seeing some intermittent CI failures due to not catching the pausing fast enough, so we need to make sure we check frequently.

So, thinking to change back to 10ms until we see an actual case where this fails due to rate limiting. It may be that 10ms is fine (I tried looking up what the default rate limit would be but couldn't easily find that information).

