### PR TITLE
fix: pod artifacts were not populating properly. Fixes #301

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -162,9 +162,8 @@ func getPodLogs(client clientgo.Interface, namespace, labelSelector, containerNa
 func watchPods() {
 
 	ctx := context.Background()
-
 	defer wg.Done()
-	watcher, err := kubeClient.CoreV1().Pods(Namespace).Watch(ctx, metav1.ListOptions{})
+	watcher, err := kubeClient.CoreV1().Pods(Namespace).Watch(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/part-of=numaflow"})
 	if err != nil {
 		fmt.Printf("Failed to start watcher: %v\n", err)
 		return
@@ -193,7 +192,7 @@ func watchPods() {
 						fileName = filepath.Join(ResourceChangesISBServiceOutputPath, "pods", strings.Join([]string{pod.Name, ".yaml"}, ""))
 					case "mono-vertex", "mono-vertex-daemon":
 						fileName = filepath.Join(ResourceChangesMonoVertexOutputPath, "pods", strings.Join([]string{pod.Name, ".yaml"}, ""))
-					case "daemon", "vertex":
+					case "daemon", "vertex", "job":
 						fileName = filepath.Join(ResourceChangesPipelineOutputPath, "pods", strings.Join([]string{pod.Name, ".yaml"}, ""))
 					}
 

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -194,6 +194,8 @@ func watchPods() {
 						fileName = filepath.Join(ResourceChangesMonoVertexOutputPath, "pods", strings.Join([]string{pod.Name, ".yaml"}, ""))
 					case "daemon", "vertex", "job":
 						fileName = filepath.Join(ResourceChangesPipelineOutputPath, "pods", strings.Join([]string{pod.Name, ".yaml"}, ""))
+					default:
+						continue
 					}
 
 					file, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -388,14 +388,14 @@ var _ = Describe("Functional e2e", Serial, func() {
 		verifyPipelinePaused(Namespace, pipelineRolloutName, pipelineName)
 		// TODO: add back after Numaflow fixes this to not go from Paused to Pausing
 		//document("verifying Pipeline stays paused")
-		Consistently(func() bool {
+		/*Consistently(func() bool {
 			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 			_, _, retrievedPipelineStatus, err := getPipelineFromK8S(Namespace, pipelineRolloutName)
 			if err != nil {
 				return false
 			}
 			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused) == metav1.ConditionTrue && retrievedPipelineStatus.Phase == numaflowv1.PipelinePhasePaused
-		}, 1*time.Minute, testPollingInterval).Should(BeTrue())
+		}, 1*time.Minute, testPollingInterval).Should(BeTrue())*/
 
 		verifyInProgressStrategy(Namespace, pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -388,14 +388,14 @@ var _ = Describe("Functional e2e", Serial, func() {
 		verifyPipelinePaused(Namespace, pipelineRolloutName, pipelineName)
 		// TODO: add back after Numaflow fixes this to not go from Paused to Pausing
 		//document("verifying Pipeline stays paused")
-		/*Consistently(func() bool {
+		Consistently(func() bool {
 			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 			_, _, retrievedPipelineStatus, err := getPipelineFromK8S(Namespace, pipelineRolloutName)
 			if err != nil {
 				return false
 			}
-			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused) == metav1.ConditionTrue && retrievedPipelineStatus.Phase == string(numaflowv1.PipelinePhasePaused)
-		}, 1*time.Minute, testPollingInterval).Should(BeTrue())*/
+			return getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused) == metav1.ConditionTrue && retrievedPipelineStatus.Phase == numaflowv1.PipelinePhasePaused
+		}, 1*time.Minute, testPollingInterval).Should(BeTrue())
 
 		verifyInProgressStrategy(Namespace, pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #301

### Modifications

We were previously not collecting `job` pod logs before. This was causing issues when creating logs for both PipelineRollout and MonoVertexRollout pods. Therefore, we have now included them which has fixed the issue.

### Verification

Running `make test-e2e` locally with both failing and successful tests.

Running on Github CI with a failing test to view artifacts output properly - https://github.com/numaproj/numaplane/pull/303/commits/9106f8fe6302b73ff4c09158b0ef78e97d2ccbbf