### PR TITLE
fix: adding persistence to isbsvc used in functional test

### DIFF
--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -123,10 +124,14 @@ var (
 		},
 	}
 
+	volSize, _     = apiresource.ParseQuantity("10Mi")
 	isbServiceSpec = numaflowv1.InterStepBufferServiceSpec{
 		Redis: nil,
 		JetStream: &numaflowv1.JetStreamBufferService{
 			Version: "2.9.6",
+			Persistence: &numaflowv1.PersistenceStrategy{
+				VolumeSize: &volSize,
+			},
 		},
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

There are occasional CI e2e failures due to there being no persistence set for the isbsvc. This means that if an isbsvc Pod goes down at the wrong time, information as far as buffers and buckets can be lost.

<!-- TODO: Say what changes you made (including any design decisions) -->

This sets persistence for the initially created isbsvc and also after it gets updated.

This is the result of `kubectl get isbsvc -o yaml` during the test:

```
- apiVersion: numaflow.numaproj.io/v1alpha1
  kind: InterStepBufferService
  metadata:
    creationTimestamp: "2024-10-01T01:54:55Z"
    finalizers:
    - isbsvc-controller
    generation: 2
    name: test-isbservice-rollout
    namespace: numaplane-system
    ownerReferences:
    - apiVersion: numaplane.numaproj.io/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: ISBServiceRollout
      name: test-isbservice-rollout
      uid: 170afb1a-9f8c-4e3b-abba-0dca57a4569d
    resourceVersion: "8355157"
    uid: 0782964f-16a8-4e3a-9f09-97f838020bc0
  spec:
    jetstream:
      persistence:
        volumeSize: 10Mi
      version: 2.9.8
```


### Verification

e2e test is passing (ran 3 times)