### PR TITLE
test: adding Vertices and StatefulSets to artifact output

### DIFF
--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		verifyPipelineRolloutHealthy(pipelineRolloutName)
 		verifyInProgressStrategy(Namespace, pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
 
-		verifyPipelineRunning(Namespace, pipelineName, 3)
+		verifyPipelineRunning(Namespace, pipelineName, 2)
 
 	})
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		verifyPipelineRolloutHealthy(pipelineRolloutName)
 		verifyInProgressStrategy(Namespace, pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
 
-		verifyPipelineRunning(Namespace, pipelineName, 2)
+		verifyPipelineRunning(Namespace, pipelineName, 3)
 
 	})
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -109,6 +109,12 @@ var _ = BeforeSuite(func() {
 	if disableTestArtifacts != "true" {
 		wg.Add(1)
 		go watchPods()
+
+		wg.Add(1)
+		go watchStatefulSet()
+
+		wg.Add(1)
+		go watchVertices()
 	}
 
 })
@@ -153,6 +159,14 @@ func setupOutputDir() {
 	Expect(err).NotTo(HaveOccurred())
 	if disableTestArtifacts != "true" {
 		for _, dir := range dirs {
+			if dir == ResourceChangesPipelineOutputPath {
+				err = os.MkdirAll(filepath.Join(dir, "vertices"), os.ModePerm)
+				Expect(err).NotTo(HaveOccurred())
+			}
+			if dir == ResourceChangesISBServiceOutputPath {
+				err = os.MkdirAll(filepath.Join(dir, "statefulsets"), os.ModePerm)
+				Expect(err).NotTo(HaveOccurred())
+			}
 			err = os.MkdirAll(filepath.Join(dir, "pods"), os.ModePerm)
 			Expect(err).NotTo(HaveOccurred())
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #311 

### Modifications

Adds `Vertex` and `StatefulSet` to artifact output by keeping track of resource changes documented by `kubectl get -o yaml`.

### Verification

Ran `make test-e2e` locally to view artifacts output properly.

Running CI with bad test to view artifact output - https://github.com/numaproj/numaplane/pull/312/commits/59015758e2ebeed072f6934f3033e077251a9cd1