### PR TITLE
feat: Allow annotation to specify that a pipeline should temporarily allow data loss

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -48,6 +48,10 @@ const (
 	// This is useful as a Label to quickly locate all Pipelines of a given PipelineRollout
 	LabelKeyPipelineRolloutForPipeline = "numaplane.numaproj.io/pipeline-rollout-name"
 
+	// LabelKeyAllowDataLoss is the label key on a Pipeline to indicate that PPND strategy can skip the usual pausing required
+	// this includes both the case of pausing for Pipeline updating as well as for NumaflowController and isbsvc updating
+	LabelKeyAllowDataLoss = "numaplane.numaproj.io/allow-data-loss"
+
 	// LabelKeyUpgradeState is the label key used to identify the upgrade state of a resource that is managed by
 	// a NumaRollout.
 	LabelKeyUpgradeState = "numaplane.numaproj.io/upgrade-state"

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -303,7 +303,7 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 	switch upgradeStrategy {
 	case config.PPNDStrategyID:
 
-		return processChildObjectWithPPND(ctx, isbServiceRollout, r, isbServiceNeedsUpdating, isbServiceIsUpdating, func() error {
+		return processChildObjectWithPPND(ctx, r.client, isbServiceRollout, r, isbServiceNeedsUpdating, isbServiceIsUpdating, func() error {
 			r.recorder.Eventf(isbServiceRollout, corev1.EventTypeNormal, "PipelinesPaused", "All Pipelines have paused for ISBService update")
 			err = r.updateISBService(ctx, isbServiceRollout, newISBServiceDef)
 			if err != nil {

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -292,7 +292,7 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 			controllerRollout.Status.MarkDeployed(controllerRollout.Generation)
 		}
 
-		needsRequeue, err := processChildObjectWithPPND(ctx, controllerRollout, r, controllerDeploymentNeedsUpdating,
+		needsRequeue, err := processChildObjectWithPPND(ctx, r.client, controllerRollout, r, controllerDeploymentNeedsUpdating,
 			controllerDeploymentIsUpdating, func() error {
 				r.recorder.Eventf(controllerRollout, corev1.EventTypeNormal, "AllPipelinesPaused", "All Pipelines have paused so Numaflow Controller can safely update")
 				phase, err := r.sync(controllerRollout, namespace, numaLogger)

--- a/internal/controller/pause_requester.go
+++ b/internal/controller/pause_requester.go
@@ -50,7 +50,7 @@ func processChildObjectWithPPND(ctx context.Context, k8sclient client.Client, ro
 		if !pauseRequestUpdated && resourceNeedsUpdating {
 
 			// check if the pipelines are all paused (or can't be paused)
-			allPaused, err := areAllPipelinesPausedOrUnpausible(ctx, k8sclient, pauseRequester, rolloutNamespace, rolloutName)
+			allPaused, err := areAllPipelinesPausedOrWontPause(ctx, k8sclient, pauseRequester, rolloutNamespace, rolloutName)
 			if err != nil {
 				return false, err
 			}
@@ -104,7 +104,7 @@ func requestPipelinesPause(ctx context.Context, pauseRequester PauseRequester, r
 
 // check if all Pipelines corresponding to this Rollout have paused or are otherwise not pausible (contract with Numaflow is that this is Pipelines which are "Failed")
 // or have an exception for allowing data loss
-func areAllPipelinesPausedOrUnpausible(ctx context.Context, k8sClient client.Client, pauseRequester PauseRequester, rolloutNamespace string, rolloutName string) (bool, error) {
+func areAllPipelinesPausedOrWontPause(ctx context.Context, k8sClient client.Client, pauseRequester PauseRequester, rolloutNamespace string, rolloutName string) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
 	pipelines, err := pauseRequester.getPipelineList(ctx, rolloutNamespace, rolloutName)
 	if err != nil {
@@ -119,8 +119,8 @@ func areAllPipelinesPausedOrUnpausible(ctx context.Context, k8sClient client.Cli
 			return false, err
 		}
 
-		if isPipelinePausedOrWontPause(ctx, pipeline, pipelineRollout) {
-			numaLogger.Debugf("pipeline %q not paused or unpausible", pipeline.Name)
+		if !isPipelinePausedOrWontPause(ctx, pipeline, pipelineRollout) {
+			numaLogger.Debugf("pipeline %q not paused or won't pause", pipeline.Name)
 			return false, nil
 		}
 	}

--- a/internal/controller/pause_requester.go
+++ b/internal/controller/pause_requester.go
@@ -109,13 +109,21 @@ func areAllPipelinesPausedOrUnpausible(ctx context.Context, pauseRequester Pause
 		return false, err
 	}
 	for _, pipeline := range pipelines {
-		status, err := kubernetes.ParseStatus(pipeline)
+		/*status, err := kubernetes.ParseStatus(pipeline)
 		if err != nil {
 			return false, err
 		}
 		if status.Phase != "Paused" && status.Phase != "Failed" && !pipeline.allowingDataLoss() {
 			numaLogger.Debugf("pipeline %q has status.phase=%q", pipeline.Name, status.Phase)
 
+			return false, nil
+		}*/
+
+		// get PipelineRollout parent of pipeline
+		pipelineRolloutName := getPipelineRolloutName(pipeline.Name)
+
+		if isPipelinePausedOrUnpausible(ctx, pipeline) {
+			numaLogger.Debugf("pipeline %q not paused or unpausible", pipeline.Name)
 			return false, nil
 		}
 	}

--- a/internal/controller/pause_requester.go
+++ b/internal/controller/pause_requester.go
@@ -119,9 +119,6 @@ func areAllPipelinesPausedOrUnpausible(ctx context.Context, pauseRequester Pause
 			return false, nil
 		}*/
 
-		// get PipelineRollout parent of pipeline
-		pipelineRolloutName := getPipelineRolloutName(pipeline.Name)
-
 		if isPipelinePausedOrUnpausible(ctx, pipeline) {
 			numaLogger.Debugf("pipeline %q not paused or unpausible", pipeline.Name)
 			return false, nil

--- a/internal/controller/pause_requester.go
+++ b/internal/controller/pause_requester.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
+	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -28,7 +29,7 @@ type PauseRequester interface {
 // return:
 // - true if needs a requeue
 // - error if any (note we'll automatically reuqueue if there's an error anyway)
-func processChildObjectWithPPND(ctx context.Context, rollout client.Object, pauseRequester PauseRequester,
+func processChildObjectWithPPND(ctx context.Context, k8sclient client.Client, rollout client.Object, pauseRequester PauseRequester,
 	resourceNeedsUpdating bool, resourceIsUpdating bool, updateFunc func() error) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
 
@@ -49,7 +50,7 @@ func processChildObjectWithPPND(ctx context.Context, rollout client.Object, paus
 		if !pauseRequestUpdated && resourceNeedsUpdating {
 
 			// check if the pipelines are all paused (or can't be paused)
-			allPaused, err := areAllPipelinesPausedOrUnpausible(ctx, pauseRequester, rolloutNamespace, rolloutName)
+			allPaused, err := areAllPipelinesPausedOrUnpausible(ctx, k8sclient, pauseRequester, rolloutNamespace, rolloutName)
 			if err != nil {
 				return false, err
 			}
@@ -102,24 +103,23 @@ func requestPipelinesPause(ctx context.Context, pauseRequester PauseRequester, r
 }
 
 // check if all Pipelines corresponding to this Rollout have paused or are otherwise not pausible (contract with Numaflow is that this is Pipelines which are "Failed")
-func areAllPipelinesPausedOrUnpausible(ctx context.Context, pauseRequester PauseRequester, rolloutNamespace string, rolloutName string) (bool, error) {
+// or have an exception for allowing data loss
+func areAllPipelinesPausedOrUnpausible(ctx context.Context, k8sClient client.Client, pauseRequester PauseRequester, rolloutNamespace string, rolloutName string) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
 	pipelines, err := pauseRequester.getPipelineList(ctx, rolloutNamespace, rolloutName)
 	if err != nil {
 		return false, err
 	}
 	for _, pipeline := range pipelines {
-		/*status, err := kubernetes.ParseStatus(pipeline)
-		if err != nil {
+
+		// Get PipelineRollout CR
+		pipelineRolloutName := getPipelineRolloutName(pipeline.Name)
+		pipelineRollout := &apiv1.PipelineRollout{}
+		if err := k8sClient.Get(ctx, k8stypes.NamespacedName{Namespace: rolloutNamespace, Name: pipelineRolloutName}, pipelineRollout); err != nil {
 			return false, err
 		}
-		if status.Phase != "Paused" && status.Phase != "Failed" && !pipeline.allowingDataLoss() {
-			numaLogger.Debugf("pipeline %q has status.phase=%q", pipeline.Name, status.Phase)
 
-			return false, nil
-		}*/
-
-		if isPipelinePausedOrUnpausible(ctx, pipeline) {
+		if isPipelinePausedOrUnpausible(ctx, pipeline, pipelineRollout) {
 			numaLogger.Debugf("pipeline %q not paused or unpausible", pipeline.Name)
 			return false, nil
 		}

--- a/internal/controller/pause_requester.go
+++ b/internal/controller/pause_requester.go
@@ -119,7 +119,7 @@ func areAllPipelinesPausedOrUnpausible(ctx context.Context, k8sClient client.Cli
 			return false, err
 		}
 
-		if isPipelinePausedOrUnpausible(ctx, pipeline, pipelineRollout) {
+		if isPipelinePausedOrWontPause(ctx, pipeline, pipelineRollout) {
 			numaLogger.Debugf("pipeline %q not paused or unpausible", pipeline.Name)
 			return false, nil
 		}

--- a/internal/controller/pause_requester.go
+++ b/internal/controller/pause_requester.go
@@ -113,7 +113,7 @@ func areAllPipelinesPausedOrUnpausible(ctx context.Context, pauseRequester Pause
 		if err != nil {
 			return false, err
 		}
-		if status.Phase != "Paused" && status.Phase != "Failed" {
+		if status.Phase != "Paused" && status.Phase != "Failed" && !pipeline.allowingDataLoss() {
 			numaLogger.Debugf("pipeline %q has status.phase=%q", pipeline.Name, status.Phase)
 
 			return false, nil

--- a/internal/controller/pipelinerollout_ppnd.go
+++ b/internal/controller/pipelinerollout_ppnd.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
@@ -228,7 +229,11 @@ func (r *PipelineRolloutReconciler) setPipelineLifecycle(ctx context.Context, pa
 //   - Annotated to allow data loss
 func isPipelinePausedOrUnpausible(ctx context.Context, pipeline *kubernetes.GenericObject) bool {
 
-	// we need PipelineRollout...
+	allowDataLoss := false
+	annotation, found := pipeline.Annotations[common.LabelKeyAllowDataLoss]
+	if found && annotation == "true" {
+		allowDataLoss = true
+	}
 
-	return checkPipelineStatus(ctx, pipeline, numaflowv1.PipelinePhasePaused) || checkPipelineStatus(ctx, pipeline, numaflowv1.PipelinePhaseFailed)
+	return checkPipelineStatus(ctx, pipeline, numaflowv1.PipelinePhasePaused) || checkPipelineStatus(ctx, pipeline, numaflowv1.PipelinePhaseFailed) || allowDataLoss
 }

--- a/internal/controller/pipelinerollout_ppnd.go
+++ b/internal/controller/pipelinerollout_ppnd.go
@@ -77,9 +77,9 @@ func (r *PipelineRolloutReconciler) processExistingPipelineWithPPND(ctx context.
 	// are we done with PPND?
 	doneWithPPND := !shouldBePaused
 
-	// but if the PipelineRollout says to pause and we're Paused, this is also "doneWithPPND"
+	// but if the PipelineRollout says to pause and we're Paused (or won't pause), stop doing PPND in that case too
 	specBasedPause := newPipelineSpec.Lifecycle.DesiredPhase == string(numaflowv1.PipelinePhasePaused) || newPipelineSpec.Lifecycle.DesiredPhase == string(numaflowv1.PipelinePhasePausing)
-	if specBasedPause && checkPipelineStatus(ctx, existingPipelineDef, numaflowv1.PipelinePhasePaused) {
+	if specBasedPause && isPipelinePausedOrWontPause(ctx, existingPipelineDef, pipelineRollout) {
 		doneWithPPND = true
 	}
 

--- a/internal/controller/pipelinerollout_ppnd.go
+++ b/internal/controller/pipelinerollout_ppnd.go
@@ -222,7 +222,13 @@ func (r *PipelineRolloutReconciler) setPipelineLifecycle(ctx context.Context, pa
 	return nil
 }
 
+// either pipeline must be:
+//   - Paused
+//   - Failed (contract with Numaflow is that unpausible Pipelines are "Failed" pipelines)
+//   - Annotated to allow data loss
 func isPipelinePausedOrUnpausible(ctx context.Context, pipeline *kubernetes.GenericObject) bool {
-	// contract with Numaflow is that unpausible Pipelines are "Failed" pipelines
+
+	// we need PipelineRollout...
+
 	return checkPipelineStatus(ctx, pipeline, numaflowv1.PipelinePhasePaused) || checkPipelineStatus(ctx, pipeline, numaflowv1.PipelinePhaseFailed)
 }

--- a/internal/controller/pipelinerollout_ppnd.go
+++ b/internal/controller/pipelinerollout_ppnd.go
@@ -79,7 +79,7 @@ func (r *PipelineRolloutReconciler) processExistingPipelineWithPPND(ctx context.
 
 	// but if the PipelineRollout says to pause and we're Paused, this is also "doneWithPPND"
 	specBasedPause := newPipelineSpec.Lifecycle.DesiredPhase == string(numaflowv1.PipelinePhasePaused) || newPipelineSpec.Lifecycle.DesiredPhase == string(numaflowv1.PipelinePhasePausing)
-	if specBasedPause && isPipelinePausedOrWontPause(ctx, existingPipelineDef, pipelineRollout) {
+	if specBasedPause && checkPipelineStatus(ctx, existingPipelineDef, numaflowv1.PipelinePhasePaused) {
 		doneWithPPND = true
 	}
 
@@ -117,7 +117,8 @@ func (r *PipelineRolloutReconciler) shouldBePaused(ctx context.Context, pipeline
 
 	wontPause := checkIfPipelineWontPause(ctx, existingPipelineDef, pipelineRollout)
 
-	shouldBePaused := (pipelineNeedsToUpdate || externalPauseRequest || specBasedPause) && !wontPause
+	ppndPause := (pipelineNeedsToUpdate || externalPauseRequest) && !wontPause
+	shouldBePaused := ppndPause || specBasedPause
 	numaLogger.Debugf("shouldBePaused=%t, pipelineNeedsToUpdate=%t, externalPauseRequest=%t, specBasedPause=%t, wontPause=%t",
 		shouldBePaused, pipelineNeedsToUpdate, externalPauseRequest, specBasedPause, wontPause)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes: #295 

### Modifications

I have actually written the ArgoCD extension locally. I have added to it the capability to apply an "allow-data-loss" annotation to the PipelineRollout while the PipelineRollout is in the middle of the PPND Upgrade strategy, and to remove it any time that the annotation is present, whether or not in the middle of PPND Upgrade.

This introduces that annotation. The annotation is observed whether the Pipeline is pausing due to its own need to update or if it's pausing because the Numaflow Controller or isbsvc are updating.


### Verification

Tested end to end with ArgoCD. Tested with a slow Pipeline in the middle of draining, in which I added the annotation in the middle of "Pausing" - it did not complete the drain and updated the spec and went back to "Running" at that time.

Also tested as part of a Numaflow Controller update (with the same slow pipeline). In the middle of the Numaflow Controller trying to update and waiting for the pause, I added the annotation on the PipelineRollout. The pipeline did not get drained fully and went back to "Running". 