### PR TITLE
feat: Pipeline No Downtime Upgrade

### DIFF
--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -374,7 +374,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 		controllerutil.AddFinalizer(pipelineRollout, finalizerName)
 	}
 
-	newPipelineDef, err := r.makePipelineDefinition(ctx, pipelineRollout)
+	newPipelineDef, err := r.makeRunningPipelineDefinition(ctx, pipelineRollout)
 	if err != nil {
 		return false, err
 	}
@@ -506,15 +506,13 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 
 	case apiv1.UpgradeStrategyProgressive:
 		if pipelineNeedsToUpdate {
-			numaLogger.Error(errors.New("Progressive not supported"), "Progressive not supported")
-			//TODO (just an idea of what it might look like below...)
-			//	done, err := r.processExistingPipelineWithProgressive(...)
-			//if err != nil {
-			//	return err
-			//}
-			//if done {
-			//	r.unsetInProgressStrategy(namespacedName)
-			//}
+			done, err := r.processExistingPipelineWithProgressive(ctx, pipelineRollout, newPipelineDef, pipelineNeedsToUpdate)
+			if err != nil {
+				return err
+			}
+			if done {
+				r.inProgressStrategyMgr.unsetStrategy(ctx, pipelineRollout)
+			}
 		}
 	default:
 		if pipelineNeedsToUpdate && upgradeStrategyType == apiv1.UpgradeStrategyApply {
@@ -539,7 +537,7 @@ func pipelineObservedGenerationCurrent(generation int64, observedGeneration int6
 func (r *PipelineRolloutReconciler) processPipelineStatus(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) error {
 	numaLogger := logger.FromContext(ctx)
 
-	pipelineDef, err := r.makePipelineDefinition(ctx, pipelineRollout)
+	pipelineDef, err := r.makeRunningPipelineDefinition(ctx, pipelineRollout)
 	if err != nil {
 		return err
 	}
@@ -705,7 +703,7 @@ func updatePipelineSpec(ctx context.Context, restConfig *rest.Config, obj *kuber
 	return kubernetes.UpdateCR(ctx, restConfig, obj, "pipelines")
 }
 
-func pipelineLabels(pipelineRollout *apiv1.PipelineRollout) (map[string]string, error) {
+func pipelineLabels(pipelineRollout *apiv1.PipelineRollout, upgradeState string) (map[string]string, error) {
 	var pipelineSpec PipelineSpec
 	labelMapping := map[string]string{
 		common.LabelKeyISBServiceNameForPipeline: "default",
@@ -718,7 +716,7 @@ func pipelineLabels(pipelineRollout *apiv1.PipelineRollout) (map[string]string, 
 	}
 
 	labelMapping[common.LabelKeyPipelineRolloutForPipeline] = pipelineRollout.Name
-	labelMapping[common.LabelKeyUpgradeState] = string(common.LabelValueUpgradePromoted)
+	labelMapping[common.LabelKeyUpgradeState] = upgradeState
 
 	return labelMapping, nil
 }
@@ -732,20 +730,24 @@ func (r *PipelineRolloutReconciler) updatePipelineRolloutStatusToFailed(ctx cont
 }
 
 // getPipelineName retrieves the name of the current running pipeline managed by the given
-// pipelineRollout through the `promoted` label. If no such pipeline exists, then it
-// constructs the name by calculating the suffix and appending to the PipelineRollout name.
-func (r *PipelineRolloutReconciler) getPipelineName(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) (string, error) {
+// pipelineRollout through the `promoted` label. Unless there is non such pipeline exist, then
+// construct the name by calculate the suffix and append to the PipelineRollout name.
+func (r *PipelineRolloutReconciler) getPipelineName(
+	ctx context.Context,
+	pipelineRollout *apiv1.PipelineRollout,
+	upgradeState string,
+) (string, error) {
 	pipelines, err := kubernetes.ListCR(
 		ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines",
 		pipelineRollout.Namespace, fmt.Sprintf(
 			"%s=%s,%s=%s", common.LabelKeyPipelineRolloutForPipeline, pipelineRollout.Name,
-			common.LabelKeyUpgradeState, common.LabelValueUpgradePromoted,
+			common.LabelKeyPipelineRolloutForPipeline, upgradeState,
 		), "")
 	if err != nil {
 		return "", err
 	}
 	if len(pipelines) > 1 {
-		return "", fmt.Errorf("there should only be one promoted pipeline")
+		return "", fmt.Errorf("there should only be one promoted or upgrade in progress pipeline")
 	} else if len(pipelines) == 0 {
 		suffixName, err := r.calPipelineNameSuffix(ctx, pipelineRollout)
 		if err != nil {
@@ -770,16 +772,28 @@ func (r *PipelineRolloutReconciler) calPipelineNameSuffix(ctx context.Context, p
 	return "-" + fmt.Sprint(*pipelineRollout.Status.NameCount), nil
 }
 
-func (r *PipelineRolloutReconciler) makePipelineDefinition(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) (*kubernetes.GenericObject, error) {
-	labels, err := pipelineLabels(pipelineRollout)
-	if err != nil {
-		return nil, err
-	}
-	pipelineName, err := r.getPipelineName(ctx, pipelineRollout)
+func (r *PipelineRolloutReconciler) makeRunningPipelineDefinition(
+	ctx context.Context,
+	pipelineRollout *apiv1.PipelineRollout,
+) (*kubernetes.GenericObject, error) {
+	pipelineName, err := r.getPipelineName(ctx, pipelineRollout, string(common.LabelValueUpgradePromoted))
 	if err != nil {
 		return nil, err
 	}
 
+	labels, err := pipelineLabels(pipelineRollout, string(common.LabelValueUpgradePromoted))
+	if err != nil {
+		return nil, err
+	}
+
+	return r.makePipelineDefinition(pipelineRollout, pipelineName, labels)
+}
+
+func (r *PipelineRolloutReconciler) makePipelineDefinition(
+	pipelineRollout *apiv1.PipelineRollout,
+	pipelineName string,
+	labels map[string]string,
+) (*kubernetes.GenericObject, error) {
 	return &kubernetes.GenericObject{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pipeline",

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -731,8 +731,8 @@ func (r *PipelineRolloutReconciler) updatePipelineRolloutStatusToFailed(ctx cont
 }
 
 // getPipelineName retrieves the name of the current running pipeline managed by the given
-// pipelineRollout through the `promoted` label. Unless there is non such pipeline exist, then
-// construct the name by calculate the suffix and append to the PipelineRollout name.
+// pipelineRollout through the `promoted` label. Unless no such pipeline exists, then
+// construct the name by calculating the suffix and appending to the PipelineRollout name.
 func (r *PipelineRolloutReconciler) getPipelineName(
 	ctx context.Context,
 	pipelineRollout *apiv1.PipelineRollout,

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -742,7 +742,7 @@ func (r *PipelineRolloutReconciler) getPipelineName(
 		ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines",
 		pipelineRollout.Namespace, fmt.Sprintf(
 			"%s=%s,%s=%s", common.LabelKeyPipelineRolloutForPipeline, pipelineRollout.Name,
-			common.LabelKeyPipelineRolloutForPipeline, upgradeState,
+			common.LabelKeyUpgradeState, upgradeState,
 		), "")
 	if err != nil {
 		return "", err

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -506,7 +506,7 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 
 	case apiv1.UpgradeStrategyProgressive:
 		if pipelineNeedsToUpdate {
-			done, err := r.processExistingPipelineWithProgressive(ctx, pipelineRollout, newPipelineDef, pipelineNeedsToUpdate)
+			done, err := r.processExistingPipelineWithProgressive(ctx, pipelineRollout, existingPipelineDef)
 			if err != nil {
 				return err
 			}
@@ -514,6 +514,7 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 				r.inProgressStrategyMgr.unsetStrategy(ctx, pipelineRollout)
 			}
 		}
+		// TODO: clean up old pipeline when drained
 	default:
 		if pipelineNeedsToUpdate && upgradeStrategyType == apiv1.UpgradeStrategyApply {
 			if err := updatePipelineSpec(ctx, r.restConfig, newPipelineDef); err != nil {
@@ -769,7 +770,10 @@ func (r *PipelineRolloutReconciler) calPipelineNameSuffix(ctx context.Context, p
 		}
 	}
 
-	return "-" + fmt.Sprint(*pipelineRollout.Status.NameCount), nil
+	preNameCount := *pipelineRollout.Status.NameCount
+	*pipelineRollout.Status.NameCount++
+
+	return "-" + fmt.Sprint(preNameCount), nil
 }
 
 func (r *PipelineRolloutReconciler) makeRunningPipelineDefinition(

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -588,24 +588,28 @@ func TestPipelineLabels(t *testing.T) {
 	tests := []struct {
 		name          string
 		jsonInput     string
+		upgradeState  string
 		expectedLabel string
 		expectError   bool
 	}{
 		{
 			name:          "Valid Input",
 			jsonInput:     `{"interStepBufferServiceName": "buffer-service"}`,
+			upgradeState:  string(common.LabelValueUpgradePromoted),
 			expectedLabel: "buffer-service",
 			expectError:   false,
 		},
 		{
 			name:          "Missing InterStepBufferServiceName",
 			jsonInput:     `{}`,
+			upgradeState:  string(common.LabelValueUpgradePromoted),
 			expectedLabel: "default",
 			expectError:   false,
 		},
 		{
 			name:          "Invalid JSON",
 			jsonInput:     `{"interStepBufferServiceName": "buffer-service"`,
+			upgradeState:  string(common.LabelValueUpgradeInProgress),
 			expectedLabel: "",
 			expectError:   true,
 		},
@@ -626,7 +630,7 @@ func TestPipelineLabels(t *testing.T) {
 				},
 			}
 
-			labels, err := pipelineLabels(pipelineRollout)
+			labels, err := pipelineLabels(pipelineRollout, tt.upgradeState)
 			if (err != nil) != tt.expectError {
 				t.Errorf("pipelineLabels() error = %v, expectError %v", err, tt.expectError)
 				return
@@ -640,8 +644,8 @@ func TestPipelineLabels(t *testing.T) {
 					t.Errorf("pipelineLabels() = %v, expected %v", common.LabelKeyPipelineRolloutForPipeline, pipelineRolloutName)
 				}
 
-				if labels[common.LabelKeyUpgradeState] != string(common.LabelValueUpgradePromoted) {
-					t.Errorf("pipelineLabels() = %v, expected %v", common.LabelKeyUpgradeState, string(common.LabelValueUpgradePromoted))
+				if labels[common.LabelKeyUpgradeState] != tt.upgradeState {
+					t.Errorf("pipelineLabels() = %v, expected %v", common.LabelKeyUpgradeState, tt.upgradeState)
 				}
 			}
 		})

--- a/internal/controller/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout_progressive.go
@@ -3,20 +3,24 @@ package controller
 import (
 	"context"
 	"fmt"
+
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+
 	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
+// processExistingPipelineWithProgressive should be only called when determined there is
+// an update required and should use progressive strategy.
 func (r *PipelineRolloutReconciler) processExistingPipelineWithProgressive(
 	ctx context.Context, pipelineRollout *apiv1.PipelineRollout,
-	newPipelineDef *kubernetes.GenericObject, pipelineNeedsToUpdate bool,
+	existingPipelineDef *kubernetes.GenericObject,
 ) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
-
 	newUpgradingPipelineDef, err := r.makeUpgradingPipelineDefinition(ctx, pipelineRollout)
 	if err != nil {
 		return false, err
@@ -28,27 +32,22 @@ func (r *PipelineRolloutReconciler) processExistingPipelineWithProgressive(
 		// create object as it doesn't exist
 		if apierrors.IsNotFound(err) {
 
-			//pipelineRollout.Status.MarkPending()
-
 			numaLogger.Debugf("Upgrading Pipeline %s/%s doesn't exist so creating", newUpgradingPipelineDef.Namespace, newUpgradingPipelineDef.Name)
 			err = kubernetes.CreateCR(ctx, r.restConfig, newUpgradingPipelineDef, "pipelines")
 			if err != nil {
 				return false, err
 			}
-			//pipelineRollout.Status.MarkDeployed(pipelineRollout.Generation)
-			//r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerPipelineRollout, "create").Observe(time.Since(syncStartTime).Seconds())
-			return false, nil
+		} else {
+			return false, fmt.Errorf("error getting Pipeline: %v", err)
 		}
-
-		return false, fmt.Errorf("error getting Pipeline: %v", err)
 	}
 
-	err = r.processUpgradingPipelineStatus(ctx, pipelineRollout)
+	done, err := r.processUpgradingPipelineStatus(ctx, pipelineRollout, existingPipelineDef)
 	if err != nil {
 		return false, err
 	}
 
-	return true, nil
+	return done, nil
 }
 
 func (r *PipelineRolloutReconciler) makeUpgradingPipelineDefinition(
@@ -71,40 +70,80 @@ func (r *PipelineRolloutReconciler) makeUpgradingPipelineDefinition(
 func (r *PipelineRolloutReconciler) processUpgradingPipelineStatus(
 	ctx context.Context,
 	pipelineRollout *apiv1.PipelineRollout,
-) error {
+	existingPipelineDef *kubernetes.GenericObject,
+) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
 
 	pipelineDef, err := r.makeUpgradingPipelineDefinition(ctx, pipelineRollout)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Get existing upgrading Pipeline
 	existingUpgradingPipelineDef, err := kubernetes.GetCR(ctx, r.restConfig, pipelineDef, "pipelines")
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			numaLogger.WithValues("pipelineDefinition", *pipelineDef).Warn("Pipeline not found. Unable to process status during this reconciliation.")
+			numaLogger.WithValues("pipelineDefinition", *pipelineDef).
+				Warn("Pipeline not found. Unable to process status during this reconciliation.")
 		} else {
-			return fmt.Errorf("error getting Pipeline for status processing: %v", err)
+			return false, fmt.Errorf("error getting Pipeline for status processing: %v", err)
 		}
 	}
 
 	pipelineStatus, err := kubernetes.ParseStatus(existingUpgradingPipelineDef)
 	if err != nil {
-		return fmt.Errorf("failed to parse Pipeline Status from pipeline CR: %+v, %v", existingUpgradingPipelineDef, err)
+		return false, fmt.Errorf("failed to parse Pipeline Status from pipeline CR: %+v, %v", existingUpgradingPipelineDef, err)
 	}
 
 	pipelinePhase := numaflowv1.PipelinePhase(pipelineStatus.Phase)
 	if pipelinePhase == numaflowv1.PipelinePhaseFailed {
-		//	pipelineRO.status = "PROGRESSIVE failed"
+		pipelineRollout.Status.MarkPipelineProgressiveUpgradeFailed("New Pipeline Failed", pipelineRollout.Generation)
+		return false, nil
 	} else if pipelinePhase == numaflowv1.PipelinePhaseRunning {
-		// TODO: label the new pipeline as promoted
-		// pause pipeline_old
-	} else {
-		// TODO: ensure the latest pipeline spec is applied
-		// apply pipeline_new
-		//continue (re-enqueue)
-	}
+		// Label the new pipeline as promoted and then remove the label from the old pipeline,
+		// since per PipelineRollout is reconciled only once at a time, we do not
+		// need to worry about consistency issue.
+		err = r.updatePipelineLabel(ctx, r.restConfig, existingUpgradingPipelineDef, string(common.LabelValueUpgradePromoted))
+		if err != nil {
+			return false, err
+		}
 
+		err = r.updatePipelineLabel(ctx, r.restConfig, existingPipelineDef, "")
+		if err != nil {
+			return false, err
+		}
+
+		pipelineRollout.Status.MarkPipelineProgressiveUpgradeSucceeded("New Pipeline Running", pipelineRollout.Generation)
+		pipelineRollout.Status.MarkDeployed(pipelineRollout.Generation)
+
+		// TODO: pause old pipeline
+		return true, nil
+	} else {
+		// Ensure the latest pipeline spec is applied
+		err = kubernetes.UpdateCR(ctx, r.restConfig, pipelineDef, "pipelines")
+		if err != nil {
+			return false, err
+		}
+		//continue (re-enqueue)
+		return false, nil
+	}
+}
+
+func (r *PipelineRolloutReconciler) updatePipelineLabel(
+	ctx context.Context,
+	restConfig *rest.Config,
+	pipeline *kubernetes.GenericObject,
+	updateState string,
+) error {
+	labelMapping := pipeline.Labels
+	labelMapping[common.LabelKeyUpgradeState] = updateState
+	pipeline.Labels = labelMapping
+
+	// TODO: use patch instead
+	err := kubernetes.UpdateCR(ctx, restConfig, pipeline, "pipelines")
+	if err != nil {
+		return err
+	}
 	return nil
+
 }

--- a/internal/controller/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout_progressive.go
@@ -1,0 +1,110 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaplane/internal/common"
+	"github.com/numaproj/numaplane/internal/util/kubernetes"
+	"github.com/numaproj/numaplane/internal/util/logger"
+	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (r *PipelineRolloutReconciler) processExistingPipelineWithProgressive(
+	ctx context.Context, pipelineRollout *apiv1.PipelineRollout,
+	newPipelineDef *kubernetes.GenericObject, pipelineNeedsToUpdate bool,
+) (bool, error) {
+	numaLogger := logger.FromContext(ctx)
+
+	newUpgradingPipelineDef, err := r.makeUpgradingPipelineDefinition(ctx, pipelineRollout)
+	if err != nil {
+		return false, err
+	}
+
+	// Get the object to see if it exists
+	_, err = kubernetes.GetCR(ctx, r.restConfig, newUpgradingPipelineDef, "pipelines")
+	if err != nil {
+		// create object as it doesn't exist
+		if apierrors.IsNotFound(err) {
+
+			//pipelineRollout.Status.MarkPending()
+
+			numaLogger.Debugf("Upgrading Pipeline %s/%s doesn't exist so creating", newUpgradingPipelineDef.Namespace, newUpgradingPipelineDef.Name)
+			err = kubernetes.CreateCR(ctx, r.restConfig, newUpgradingPipelineDef, "pipelines")
+			if err != nil {
+				return false, err
+			}
+			//pipelineRollout.Status.MarkDeployed(pipelineRollout.Generation)
+			//r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerPipelineRollout, "create").Observe(time.Since(syncStartTime).Seconds())
+			return false, nil
+		}
+
+		return false, fmt.Errorf("error getting Pipeline: %v", err)
+	}
+
+	err = r.processUpgradingPipelineStatus(ctx, pipelineRollout)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (r *PipelineRolloutReconciler) makeUpgradingPipelineDefinition(
+	ctx context.Context,
+	pipelineRollout *apiv1.PipelineRollout,
+) (*kubernetes.GenericObject, error) {
+	pipelineName, err := r.getPipelineName(ctx, pipelineRollout, string(common.LabelValueUpgradeInProgress))
+	if err != nil {
+		return nil, err
+	}
+
+	labels, err := pipelineLabels(pipelineRollout, string(common.LabelValueUpgradeInProgress))
+	if err != nil {
+		return nil, err
+	}
+
+	return r.makePipelineDefinition(pipelineRollout, pipelineName, labels)
+}
+
+func (r *PipelineRolloutReconciler) processUpgradingPipelineStatus(
+	ctx context.Context,
+	pipelineRollout *apiv1.PipelineRollout,
+) error {
+	numaLogger := logger.FromContext(ctx)
+
+	pipelineDef, err := r.makeUpgradingPipelineDefinition(ctx, pipelineRollout)
+	if err != nil {
+		return err
+	}
+
+	// Get existing upgrading Pipeline
+	existingUpgradingPipelineDef, err := kubernetes.GetCR(ctx, r.restConfig, pipelineDef, "pipelines")
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			numaLogger.WithValues("pipelineDefinition", *pipelineDef).Warn("Pipeline not found. Unable to process status during this reconciliation.")
+		} else {
+			return fmt.Errorf("error getting Pipeline for status processing: %v", err)
+		}
+	}
+
+	pipelineStatus, err := kubernetes.ParseStatus(existingUpgradingPipelineDef)
+	if err != nil {
+		return fmt.Errorf("failed to parse Pipeline Status from pipeline CR: %+v, %v", existingUpgradingPipelineDef, err)
+	}
+
+	pipelinePhase := numaflowv1.PipelinePhase(pipelineStatus.Phase)
+	if pipelinePhase == numaflowv1.PipelinePhaseFailed {
+		//	pipelineRO.status = "PROGRESSIVE failed"
+	} else if pipelinePhase == numaflowv1.PipelinePhaseRunning {
+		// TODO: label the new pipeline as promoted
+		// pause pipeline_old
+	} else {
+		// TODO: ensure the latest pipeline spec is applied
+		// apply pipeline_new
+		//continue (re-enqueue)
+	}
+
+	return nil
+}

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -24,6 +24,9 @@ import (
 const (
 	// ConditionPipelinePausingOrPaused indicates that the Pipeline is either pausing or paused.
 	ConditionPipelinePausingOrPaused ConditionType = "PipelinePausingOrPaused"
+
+	// ConditionPipelineProgressiveUpgradeSucceeded indicates that whether the progressive upgrade for the Pipeline succeeded.
+	ConditionPipelineProgressiveUpgradeSucceeded ConditionType = "ConditionPipelineProgressiveUpgradeSucceed"
 )
 
 // PipelineRolloutSpec defines the desired state of PipelineRollout
@@ -50,6 +53,7 @@ type PipelineRolloutStatus struct {
 }
 
 type UpgradeStrategy string
+type UpgradeState string
 
 const (
 	UpgradeStrategyNoOp        UpgradeStrategy = ""
@@ -93,6 +97,14 @@ func (status *PipelineRolloutStatus) MarkPipelinePausingOrPaused(reason, message
 
 func (status *PipelineRolloutStatus) MarkPipelineUnpaused(generation int64) {
 	status.MarkFalse(ConditionPipelinePausingOrPaused, "Unpaused", "Pipeline unpaused", generation)
+}
+
+func (status *PipelineRolloutStatus) MarkPipelineProgressiveUpgradeSucceeded(message string, generation int64) {
+	status.MarkTrueWithReason(ConditionPipelineProgressiveUpgradeSucceeded, "Succeeded", message, generation)
+}
+
+func (status *PipelineRolloutStatus) MarkPipelineProgressiveUpgradeFailed(message string, generation int64) {
+	status.MarkFalse(ConditionPipelineProgressiveUpgradeSucceeded, "Failed", message, generation)
 }
 
 func (status *PipelineRolloutStatus) SetUpgradeInProgress(upgradeStrategy UpgradeStrategy) {

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -26,7 +26,7 @@ const (
 	ConditionPipelinePausingOrPaused ConditionType = "PipelinePausingOrPaused"
 
 	// ConditionPipelineProgressiveUpgradeSucceeded indicates that whether the progressive upgrade for the Pipeline succeeded.
-	ConditionPipelineProgressiveUpgradeSucceeded ConditionType = "ConditionPipelineProgressiveUpgradeSucceed"
+	ConditionPipelineProgressiveUpgradeSucceeded ConditionType = "PipelineProgressiveUpgradeSucceed"
 )
 
 // PipelineRolloutSpec defines the desired state of PipelineRollout


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #225

### Modifications

Pipeline No Downtime upgrade which creates a second pipeline when upgrade strategy is `progressive`. A follow up  will do clean up for the old pipeline, e.g. pause the pipeline and delete after drain is completed.


### Verification

`make test`
Run in local cluster, apply a namespace config to set the upgrade strategy to `progressive` and see a new pipeline running and `PipelineProgressiveUpgradeSucceed` in the PipelineRollout to be true.

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->