### PR TITLE
test: change MonoVertexRollout update test to be more stable

### DIFF
--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -528,7 +528,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		// new MonoVertex spec
 		updatedMonoVertexSpec := monoVertexSpec
-		updatedMonoVertexSpec.Source.UDSource.Container.Image = "quay.io/numaio/numaflow-java/source-simple-source:v0.6.0"
+		updatedMonoVertexSpec.Source.UDSource.Container.Image = "quay.io/numaio/numaflow-python/simple-source:stable"
 		rawSpec, err := json.Marshal(updatedMonoVertexSpec)
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -538,7 +538,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		})
 
 		verifyMonoVertexSpec(Namespace, monoVertexRolloutName, func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec) bool {
-			return retrievedMonoVertexSpec.Source.UDSource.Container.Image == "quay.io/numaio/numaflow-java/source-simple-source:v0.6.0"
+			return retrievedMonoVertexSpec.Source.UDSource.Container.Image == "quay.io/numaio/numaflow-python/simple-source:stable"
 		})
 
 		verifyMonoVertexRolloutReady(monoVertexRolloutName)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #314 

### Modifications

MonoVertex currently ends up unhealthy in testing since we are updating the source image to an unstable and outdated version that is incompatible with Numaflow. This changes it to update to the most stable Python image instead.


### Verification

Ran `make test-e2e` locally and checked MonoVertex logs to see that it is still healthy.