### PR TITLE
fix: added namespace to metric numaflow_pipeline_paused_seconds

### DIFF
--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -616,7 +616,7 @@ func (r *PipelineRolloutReconciler) setChildResourcesPauseCondition(pipelineRoll
 
 func (r *PipelineRolloutReconciler) updatePauseMetric(pipelineRollout *apiv1.PipelineRollout) {
 	timeElapsed := time.Since(pipelineRollout.Status.PauseStatus.LastPauseBeginTime.Time)
-	r.customMetrics.PipelinePausedSeconds.WithLabelValues(pipelineRollout.Name).Set(timeElapsed.Seconds())
+	r.customMetrics.PipelinePausedSeconds.WithLabelValues(pipelineRollout.Namespace, pipelineRollout.Name).Set(timeElapsed.Seconds())
 }
 
 func (r *PipelineRolloutReconciler) needsUpdate(old, new *apiv1.PipelineRollout) bool {

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -128,7 +128,7 @@ var (
 		Name:        "numaflow_pipeline_paused_seconds",
 		Help:        "Duration a pipeline was paused for",
 		ConstLabels: defaultLabels,
-	}, []string{LabelName})
+	}, []string{LabelNamespace, LabelName})
 
 	// pipelinesSynced Check the total number of pipeline synced
 	pipelinesSynced = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #309 

### Modifications

Added namespace to the `numaflow_pipeline_paused_seconds` metric.


### Verification

Forwarded port 8080 of the numaplane-controller-manager pod and looked at the metric `numaflow_pipeline_paused_seconds` after pausing the pipeline by setting the `lifecycle.desiredPhase` to `Paused` in the PipelineRollout.
