### PR TITLE
fix: refactor unstructured_util and reduce k8s api call

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -144,6 +144,10 @@ func main() {
 		numaLogger.Fatal(err, "Failed to start configmap watcher")
 	}
 
+	if err := kubernetes.SetDynamicClient(newRawConfig); err != nil {
+		numaLogger.Fatal(err, "Failed to set dynamic client")
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	pipelineRolloutReconciler := controller.NewPipelineRolloutReconciler(

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -153,7 +153,6 @@ func main() {
 	pipelineRolloutReconciler := controller.NewPipelineRolloutReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
-		newRawConfig,
 		customMetrics,
 		mgr.GetEventRecorderFor(apiv1.RolloutPipeline),
 	)
@@ -183,7 +182,6 @@ func main() {
 	isbServiceRolloutReconciler := controller.NewISBServiceRolloutReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
-		newRawConfig,
 		customMetrics,
 		mgr.GetEventRecorderFor(apiv1.RolloutISBSvc),
 	)
@@ -195,7 +193,6 @@ func main() {
 	monoVertexRolloutReconciler := controller.NewMonoVertexRolloutReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
-		newRawConfig,
 		customMetrics,
 		mgr.GetEventRecorderFor(apiv1.RolloutMonoVertex),
 	)

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -19,9 +19,20 @@ const (
 	// EnvLogLevel log level that is defined by `--loglevel` option
 	EnvLogLevel = "NUMAPLANE_LOG_LEVEL"
 
+	// NumaflowAPIGroup is the group of the Numaflow API
 	NumaflowAPIGroup = "numaflow.numaproj.io"
 
+	// NumaflowAPIVersion is the version of the Numaflow API
 	NumaflowAPIVersion = "v1alpha1"
+
+	// NumaflowPipelineKind is the kind of the Numaflow Pipeline
+	NumaflowPipelineKind = "Pipeline"
+
+	// NumaflowMonoVertexKind is the kind of the Numaflow MonoVertex
+	NumaflowMonoVertexKind = "MonoVertex"
+
+	// NumaflowISBServiceKind is the kind of the Numaflow ISB Service
+	NumaflowISBServiceKind = "InterStepBufferService"
 
 	// LABELS:
 

--- a/internal/controller/common_test.go
+++ b/internal/controller/common_test.go
@@ -6,17 +6,18 @@ import (
 	"testing"
 	"time"
 
-	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
-	numaflowversioned "github.com/numaproj/numaflow/pkg/client/clientset/versioned"
-	"github.com/numaproj/numaplane/internal/common"
-	"github.com/numaproj/numaplane/internal/controller/config"
-	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	k8sclientgo "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	numaflowversioned "github.com/numaproj/numaflow/pkg/client/clientset/versioned"
+	"github.com/numaproj/numaplane/internal/common"
+	"github.com/numaproj/numaplane/internal/controller/config"
+	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
 func createPipelineRolloutInK8S(ctx context.Context, t *testing.T, numaplaneClient client.Client, pipelineRollout *apiv1.PipelineRollout) {

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -64,7 +63,6 @@ const (
 type ISBServiceRolloutReconciler struct {
 	client        client.Client
 	scheme        *runtime.Scheme
-	restConfig    *rest.Config
 	customMetrics *metrics.CustomMetrics
 	// the recorder is used to record events
 	recorder record.EventRecorder
@@ -76,7 +74,6 @@ type ISBServiceRolloutReconciler struct {
 func NewISBServiceRolloutReconciler(
 	c client.Client,
 	s *runtime.Scheme,
-	restConfig *rest.Config,
 	customMetrics *metrics.CustomMetrics,
 	recorder record.EventRecorder,
 ) *ISBServiceRolloutReconciler {
@@ -84,7 +81,6 @@ func NewISBServiceRolloutReconciler(
 	r := &ISBServiceRolloutReconciler{
 		c,
 		s,
-		restConfig,
 		customMetrics,
 		recorder,
 		nil,

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -226,8 +226,8 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 
 	newISBServiceDef := &kubernetes.GenericObject{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "InterStepBufferService",
-			APIVersion: "numaflow.numaproj.io/v1alpha1",
+			Kind:       common.NumaflowISBServiceKind,
+			APIVersion: common.NumaflowAPIGroup + "/" + common.NumaflowAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            isbServiceRollout.Name,
@@ -449,7 +449,7 @@ func (r *ISBServiceRolloutReconciler) isISBServiceUpdating(ctx context.Context, 
 }
 
 func (r *ISBServiceRolloutReconciler) getPipelineList(ctx context.Context, rolloutNamespace string, rolloutName string) ([]*kubernetes.GenericObject, error) {
-	gvk := schema.GroupVersionKind{Group: common.NumaflowAPIGroup, Version: common.NumaflowAPIVersion, Kind: "Pipeline"}
+	gvk := schema.GroupVersionKind{Group: common.NumaflowAPIGroup, Version: common.NumaflowAPIVersion, Kind: common.NumaflowPipelineKind}
 	return kubernetes.ListResources(ctx, r.client, gvk,
 		client.InNamespace(rolloutNamespace),
 		client.MatchingLabels{common.LabelKeyISBServiceNameForPipeline: rolloutName},
@@ -611,7 +611,7 @@ func (r *ISBServiceRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Watch InterStepBufferServices
 	isbServiceUns := &unstructured.Unstructured{}
 	isbServiceUns.SetGroupVersionKind(schema.GroupVersionKind{
-		Kind:    "InterStepBufferService",
+		Kind:    common.NumaflowISBServiceKind,
 		Group:   common.NumaflowAPIGroup,
 		Version: common.NumaflowAPIVersion,
 	})

--- a/internal/controller/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout_controller_test.go
@@ -513,8 +513,8 @@ func createDefaultISBService(jetstreamVersion string, phase numaflowv1.ISBSvcPha
 	}
 	return &numaflowv1.InterStepBufferService{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "InterStepBufferService",
-			APIVersion: "numaflow.numaproj.io/v1alpha1",
+			Kind:       common.NumaflowISBServiceKind,
+			APIVersion: common.NumaflowAPIGroup + "/" + common.NumaflowAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      defaultISBSvcRolloutName,

--- a/internal/controller/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"testing"
 	"time"
 
@@ -255,6 +256,7 @@ func Test_reconcile_isbservicerollout_PPND(t *testing.T) {
 
 	restConfig, numaflowClientSet, numaplaneClient, k8sClientSet, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
+	assert.Nil(t, kubernetes.SetDynamicClient(restConfig))
 
 	config.GetConfigManagerInstance().UpdateUSDEConfig(config.USDEConfig{DefaultUpgradeStrategy: config.PPNDStrategyID})
 

--- a/internal/controller/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout_controller_test.go
@@ -20,15 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -43,9 +41,9 @@ import (
 	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/util"
+	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
 	"github.com/numaproj/numaplane/internal/util/metrics"
-
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 	commontest "github.com/numaproj/numaplane/tests/common"
 )
@@ -267,7 +265,7 @@ func Test_reconcile_isbservicerollout_PPND(t *testing.T) {
 
 	recorder := record.NewFakeRecorder(64)
 
-	r := NewISBServiceRolloutReconciler(numaplaneClient, scheme.Scheme, restConfig, customMetrics, recorder)
+	r := NewISBServiceRolloutReconciler(numaplaneClient, scheme.Scheme, customMetrics, recorder)
 
 	trueValue := true
 	falseValue := false

--- a/internal/controller/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout_controller.go
@@ -19,21 +19,15 @@ package controller
 import (
 	"context"
 	"fmt"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 	"time"
 
-	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
-	"github.com/numaproj/numaplane/internal/util/kubernetes"
-	"github.com/numaproj/numaplane/internal/util/logger"
-	"github.com/numaproj/numaplane/internal/util/metrics"
-	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,6 +36,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaplane/internal/util/kubernetes"
+	"github.com/numaproj/numaplane/internal/util/logger"
+	"github.com/numaproj/numaplane/internal/util/metrics"
+	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
 const (
@@ -52,7 +52,6 @@ const (
 type MonoVertexRolloutReconciler struct {
 	client        client.Client
 	scheme        *runtime.Scheme
-	restConfig    *rest.Config
 	customMetrics *metrics.CustomMetrics
 	// the recorder is used to record events
 	recorder record.EventRecorder
@@ -61,7 +60,6 @@ type MonoVertexRolloutReconciler struct {
 func NewMonoVertexRolloutReconciler(
 	client client.Client,
 	s *runtime.Scheme,
-	restConfig *rest.Config,
 	customMetrics *metrics.CustomMetrics,
 	recorder record.EventRecorder,
 ) *MonoVertexRolloutReconciler {
@@ -69,7 +67,6 @@ func NewMonoVertexRolloutReconciler(
 	return &MonoVertexRolloutReconciler{
 		client,
 		s,
-		restConfig,
 		customMetrics,
 		recorder,
 	}

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -343,7 +343,7 @@ func (r *NumaflowControllerRolloutReconciler) getChildTypeString() string {
 }
 
 func (r *NumaflowControllerRolloutReconciler) getPipelineList(ctx context.Context, rolloutNamespace string, _ string) ([]*kubernetes.GenericObject, error) {
-	return kubernetes.ListLiveResource(ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", rolloutNamespace, common.LabelKeyPipelineRolloutForPipeline, "")
+	return kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", rolloutNamespace, common.LabelKeyPipelineRolloutForPipeline, "")
 }
 
 func (r *NumaflowControllerRolloutReconciler) getRolloutKey(rolloutNamespace string, rolloutName string) string {

--- a/internal/controller/numaflowcontrollerrollout_controller_test.go
+++ b/internal/controller/numaflowcontrollerrollout_controller_test.go
@@ -351,6 +351,7 @@ func Test_reconcile_numaflowcontrollerrollout_PPND(t *testing.T) {
 
 	restConfig, numaflowClientSet, numaplaneClient, k8sClientSet, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
+	assert.Nil(t, kubernetes.SetDynamicClient(restConfig))
 
 	config.GetConfigManagerInstance().UpdateUSDEConfig(config.USDEConfig{DefaultUpgradeStrategy: config.PPNDStrategyID})
 	controllerDefinitions, err := getNumaflowControllerDefinitions("../../tests/config/controller-definitions-config.yaml")

--- a/internal/controller/pause.go
+++ b/internal/controller/pause.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sync"
 
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/rest"
 )
 
 var (
@@ -72,19 +72,19 @@ func (pm *PauseModule) getPauseRequest(requester string) (*bool, bool) {
 }
 
 // pause pipeline
-func (pm *PauseModule) pausePipeline(ctx context.Context, restConfig *rest.Config, pipeline *kubernetes.GenericObject) error {
+func (pm *PauseModule) pausePipeline(ctx context.Context, c client.Client, pipeline *kubernetes.GenericObject) error {
 	var existingPipelineSpec PipelineSpec
 	if err := json.Unmarshal(pipeline.Spec.Raw, &existingPipelineSpec); err != nil {
 		return err
 	}
 
-	return pm.updatePipelineLifecycle(ctx, restConfig, pipeline, "Paused")
+	return pm.updatePipelineLifecycle(ctx, c, pipeline, "Paused")
 }
 
 // resume pipeline
 // lock the maps while we change pipeline lifecycle so nobody changes their pause request
 // while we run; otherwise, they may think they are pausing the pipeline while it's running
-func (pm *PauseModule) runPipelineIfSafe(ctx context.Context, restConfig *rest.Config, pipeline *kubernetes.GenericObject) (bool, error) {
+func (pm *PauseModule) runPipelineIfSafe(ctx context.Context, c client.Client, pipeline *kubernetes.GenericObject) (bool, error) {
 	pm.lock.RLock()
 	defer pm.lock.RUnlock()
 
@@ -101,21 +101,21 @@ func (pm *PauseModule) runPipelineIfSafe(ctx context.Context, restConfig *rest.C
 		return false, nil
 	}
 
-	err := pm.updatePipelineLifecycle(ctx, restConfig, pipeline, "Running")
+	err := pm.updatePipelineLifecycle(ctx, c, pipeline, "Running")
 	if err != nil {
 		return false, err
 	}
 	return true, nil
 }
 
-func (pm *PauseModule) updatePipelineLifecycle(ctx context.Context, restConfig *rest.Config, pipeline *kubernetes.GenericObject, phase string) error {
+func (pm *PauseModule) updatePipelineLifecycle(ctx context.Context, c client.Client, pipeline *kubernetes.GenericObject, phase string) error {
 
 	err := withDesiredPhase(pipeline, phase)
 	if err != nil {
 		return err
 	}
 
-	err = kubernetes.UpdateCR(ctx, pipeline, "pipelines")
+	err = kubernetes.UpdateResource(ctx, c, pipeline)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/pause.go
+++ b/internal/controller/pause.go
@@ -115,7 +115,7 @@ func (pm *PauseModule) updatePipelineLifecycle(ctx context.Context, restConfig *
 		return err
 	}
 
-	err = kubernetes.UpdateCR(ctx, restConfig, pipeline, "pipelines")
+	err = kubernetes.UpdateCR(ctx, pipeline, "pipelines")
 	if err != nil {
 		return err
 	}

--- a/internal/controller/pause.go
+++ b/internal/controller/pause.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sync"
 
-	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/numaproj/numaplane/internal/util/kubernetes"
 )
 
 var (

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -498,7 +498,7 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 	// don't risk out-of-date cache while performing PPND or Progressive strategy - get
 	// the most current version of the Pipeline just in case
 	if inProgressStrategy != apiv1.UpgradeStrategyNoOp {
-		existingPipelineDef, err = kubernetes.GetLiveResource(ctx, r.restConfig, newPipelineDef, "pipelines")
+		existingPipelineDef, err = kubernetes.GetLiveResource(ctx, newPipelineDef, "pipelines")
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				numaLogger.WithValues("pipelineDefinition", *newPipelineDef).Warn("Pipeline not found.")
@@ -569,7 +569,7 @@ func (r *PipelineRolloutReconciler) processPipelineStatus(ctx context.Context, p
 
 	// Get existing Pipeline
 	// TODO: Eliminate the need for this call to GetLiveResource, instead use the existingPipelineDef from the reconcile
-	existingPipelineDef, err := kubernetes.GetLiveResource(ctx, r.restConfig, pipelineDef, "pipelines")
+	existingPipelineDef, err := kubernetes.GetLiveResource(ctx, pipelineDef, "pipelines")
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			numaLogger.WithValues("pipelineDefinition", *pipelineDef).Warn("Pipeline not found. Unable to process status during this reconciliation.")
@@ -732,7 +732,7 @@ func checkPipelineStatus(ctx context.Context, pipeline *kubernetes.GenericObject
 }
 
 func updatePipelineSpec(ctx context.Context, restConfig *rest.Config, obj *kubernetes.GenericObject) error {
-	return kubernetes.UpdateCR(ctx, restConfig, obj, "pipelines")
+	return kubernetes.UpdateCR(ctx, obj, "pipelines")
 }
 
 func pipelineLabels(pipelineRollout *apiv1.PipelineRollout, upgradeState string) (map[string]string, error) {
@@ -770,7 +770,7 @@ func (r *PipelineRolloutReconciler) getPipelineName(
 	upgradeState string,
 ) (string, error) {
 	pipelines, err := kubernetes.ListLiveResource(
-		ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines",
+		ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines",
 		pipelineRollout.Namespace, fmt.Sprintf(
 			"%s=%s,%s=%s", common.LabelKeyPipelineRolloutForPipeline, pipelineRollout.Name,
 			common.LabelKeyUpgradeState, upgradeState,

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -568,6 +568,7 @@ func (r *PipelineRolloutReconciler) processPipelineStatus(ctx context.Context, p
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				numaLogger.WithValues("pipelineDefinition", *pipelineDef).Warn("Pipeline not found. Unable to process status during this reconciliation.")
+				return nil
 			} else {
 				return fmt.Errorf("error getting Pipeline for status processing: %v", err)
 			}

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"maps"
 	"reflect"
 	"strings"
@@ -33,7 +31,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -668,7 +668,7 @@ func (r *PipelineRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Watch Pipelines
 	pipelineUns := &unstructured.Unstructured{}
 	pipelineUns.SetGroupVersionKind(schema.GroupVersionKind{
-		Kind:    "Pipeline",
+		Kind:    common.NumaflowPipelineKind,
 		Group:   common.NumaflowAPIGroup,
 		Version: common.NumaflowAPIVersion,
 	})
@@ -827,8 +827,8 @@ func (r *PipelineRolloutReconciler) makePipelineDefinition(
 ) (*kubernetes.GenericObject, error) {
 	return &kubernetes.GenericObject{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pipeline",
-			APIVersion: "numaflow.numaproj.io/v1alpha1",
+			Kind:       common.NumaflowPipelineKind,
+			APIVersion: common.NumaflowAPIGroup + "/" + common.NumaflowAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            pipelineName,

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -754,7 +754,6 @@ func Test_processExistingPipeline_PPND(t *testing.T) {
 	r := NewPipelineRolloutReconciler(
 		numaplaneClient,
 		scheme.Scheme,
-		restConfig,
 		customMetrics,
 		recorder)
 
@@ -996,7 +995,6 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 	r := NewPipelineRolloutReconciler(
 		numaplaneClient,
 		scheme.Scheme,
-		restConfig,
 		customMetrics,
 		recorder)
 

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -731,6 +731,7 @@ func pipelineWithDesiredPhase(spec numaflowv1.PipelineSpec, phase numaflowv1.Pip
 func Test_processExistingPipeline_PPND(t *testing.T) {
 	restConfig, numaflowClientSet, numaplaneClient, _, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
+	assert.Nil(t, kubernetes.SetDynamicClient(restConfig))
 
 	config.GetConfigManagerInstance().UpdateUSDEConfig(config.USDEConfig{
 		DefaultUpgradeStrategy:    config.PPNDStrategyID,
@@ -977,6 +978,7 @@ func Test_processExistingPipeline_PPND(t *testing.T) {
 func Test_processExistingPipeline_Progressive(t *testing.T) {
 	restConfig, numaflowClientSet, numaplaneClient, _, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
+	assert.Nil(t, kubernetes.SetDynamicClient(restConfig))
 
 	config.GetConfigManagerInstance().UpdateUSDEConfig(config.USDEConfig{
 		DefaultUpgradeStrategy:    config.ProgressiveStrategyID,

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -955,7 +955,7 @@ func Test_processExistingPipeline_PPND(t *testing.T) {
 				GetPauseModule().pauseRequests[GetPauseModule().getISBServiceKey(defaultNamespace, "my-isbsvc")] = tc.isbServicePauseRequest
 			}
 
-			_, err = r.reconcile(context.Background(), rollout, time.Now())
+			_, _, err = r.reconcile(context.Background(), rollout, time.Now())
 			assert.NoError(t, err)
 
 			////// check results:
@@ -1199,7 +1199,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			_, err = r.reconcile(context.Background(), rollout, time.Now())
+			_, _, err = r.reconcile(context.Background(), rollout, time.Now())
 			assert.NoError(t, err)
 
 			////// check results:

--- a/internal/controller/pipelinerollout_ppnd.go
+++ b/internal/controller/pipelinerollout_ppnd.go
@@ -64,7 +64,7 @@ func (r *PipelineRolloutReconciler) processExistingPipelineWithPPND(ctx context.
 					return false, err
 				}
 			}
-			err = kubernetes.UpdateCR(ctx, newPipelineDef, "pipelines")
+			err = kubernetes.UpdateResource(ctx, r.client, newPipelineDef)
 			if err != nil {
 				return false, err
 			}
@@ -205,14 +205,14 @@ func (r *PipelineRolloutReconciler) setPipelineLifecycle(ctx context.Context, pa
 	if pause && !lifeCycleIsPaused {
 		numaLogger.Info("pausing pipeline")
 		r.recorder.Eventf(existingPipelineDef, "Normal", "PipelinePause", "pausing pipeline")
-		if err := GetPauseModule().pausePipeline(ctx, r.restConfig, existingPipelineDef); err != nil {
+		if err := GetPauseModule().pausePipeline(ctx, r.client, existingPipelineDef); err != nil {
 			return err
 		}
 	} else if !pause && lifeCycleIsPaused {
 		numaLogger.Info("resuming pipeline")
 		r.recorder.Eventf(existingPipelineDef, "Normal", "PipelineResume", "resuming pipeline")
 
-		run, err := GetPauseModule().runPipelineIfSafe(ctx, r.restConfig, existingPipelineDef)
+		run, err := GetPauseModule().runPipelineIfSafe(ctx, r.client, existingPipelineDef)
 		if err != nil {
 			return err
 		}

--- a/internal/controller/pipelinerollout_ppnd.go
+++ b/internal/controller/pipelinerollout_ppnd.go
@@ -64,7 +64,7 @@ func (r *PipelineRolloutReconciler) processExistingPipelineWithPPND(ctx context.
 					return false, err
 				}
 			}
-			err = kubernetes.UpdateCR(ctx, r.restConfig, newPipelineDef, "pipelines")
+			err = kubernetes.UpdateCR(ctx, newPipelineDef, "pipelines")
 			if err != nil {
 				return false, err
 			}

--- a/internal/controller/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout_progressive.go
@@ -26,13 +26,13 @@ func (r *PipelineRolloutReconciler) processExistingPipelineWithProgressive(
 	}
 
 	// Get the object to see if it exists
-	_, err = kubernetes.GetLiveResource(ctx, r.restConfig, newUpgradingPipelineDef, "pipelines")
+	_, err = kubernetes.GetLiveResource(ctx, newUpgradingPipelineDef, "pipelines")
 	if err != nil {
 		// create object as it doesn't exist
 		if apierrors.IsNotFound(err) {
 
 			numaLogger.Debugf("Upgrading Pipeline %s/%s doesn't exist so creating", newUpgradingPipelineDef.Namespace, newUpgradingPipelineDef.Name)
-			err = kubernetes.CreateCR(ctx, r.restConfig, newUpgradingPipelineDef, "pipelines")
+			err = kubernetes.CreateCR(ctx, newUpgradingPipelineDef, "pipelines")
 			if err != nil {
 				return false, err
 			}
@@ -79,7 +79,7 @@ func (r *PipelineRolloutReconciler) processUpgradingPipelineStatus(
 	}
 
 	// Get existing upgrading Pipeline
-	existingUpgradingPipelineDef, err := kubernetes.GetLiveResource(ctx, r.restConfig, pipelineDef, "pipelines")
+	existingUpgradingPipelineDef, err := kubernetes.GetLiveResource(ctx, pipelineDef, "pipelines")
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			numaLogger.WithValues("pipelineDefinition", *pipelineDef).
@@ -137,7 +137,7 @@ func (r *PipelineRolloutReconciler) processUpgradingPipelineStatus(
 			return false, err
 		}
 		if pipelineNeedsToUpdate {
-			err = kubernetes.UpdateCR(ctx, r.restConfig, pipelineDef, "pipelines")
+			err = kubernetes.UpdateCR(ctx, pipelineDef, "pipelines")
 			if err != nil {
 				return false, err
 			}
@@ -158,7 +158,7 @@ func (r *PipelineRolloutReconciler) updatePipelineLabel(
 	pipeline.Labels = labelMapping
 
 	// TODO: use patch instead
-	err := kubernetes.UpdateCR(ctx, restConfig, pipeline, "pipelines")
+	err := kubernetes.UpdateCR(ctx, pipeline, "pipelines")
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (r *PipelineRolloutReconciler) getRecyclablePipelines(
 	pipelineRollout *apiv1.PipelineRollout,
 ) ([]*kubernetes.GenericObject, error) {
 	return kubernetes.ListLiveResource(
-		ctx, r.restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines",
+		ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines",
 		pipelineRollout.Namespace, fmt.Sprintf(
 			"%s=%s,%s=%s", common.LabelKeyPipelineRolloutForPipeline, pipelineRollout.Name,
 			common.LabelKeyUpgradeState, common.LabelValueUpgradeRecyclable,
@@ -212,7 +212,7 @@ func (r *PipelineRolloutReconciler) processRecyclablePipelineStatus(
 	if pipelinePhase == numaflowv1.PipelinePhasePaused {
 		// check if `pipelineStatus.DrainedOnPause` is true
 		if pipelineStatus.DrainedOnPause {
-			err = kubernetes.DeleteCR(ctx, r.restConfig, pipelineDef, "pipelines")
+			err = kubernetes.DeleteCR(ctx, pipelineDef, "pipelines")
 			if err != nil {
 				return err
 			}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -143,6 +143,8 @@ var _ = BeforeSuite(func() {
 		customMetrics = metrics.RegisterCustomMetrics()
 	}
 
+	Expect(kubernetes.SetDynamicClient(k8sManager.GetConfig())).To(Succeed())
+
 	err = NewPipelineRolloutReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), cfg, customMetrics,
 		k8sManager.GetEventRecorderFor(apiv1.RolloutPipeline)).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -145,15 +145,15 @@ var _ = BeforeSuite(func() {
 
 	Expect(kubernetes.SetDynamicClient(k8sManager.GetConfig())).To(Succeed())
 
-	err = NewPipelineRolloutReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), cfg, customMetrics,
+	err = NewPipelineRolloutReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), customMetrics,
 		k8sManager.GetEventRecorderFor(apiv1.RolloutPipeline)).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = NewISBServiceRolloutReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), cfg, customMetrics,
+	err = NewISBServiceRolloutReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), customMetrics,
 		k8sManager.GetEventRecorderFor(apiv1.RolloutISBSvc)).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = NewMonoVertexRolloutReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), cfg, customMetrics,
+	err = NewMonoVertexRolloutReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), customMetrics,
 		k8sManager.GetEventRecorderFor(apiv1.RolloutMonoVertex)).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/util/kubernetes/dynamic_clientset.go
+++ b/internal/util/kubernetes/dynamic_clientset.go
@@ -1,0 +1,20 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+var dynamicClient *dynamic.DynamicClient
+
+func SetDynamicClient(restConfig *rest.Config) error {
+	var err error
+	dynamicClient, err = dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic client: %v", err)
+	}
+
+	return nil
+}

--- a/internal/util/kubernetes/unstructured_util_test.go
+++ b/internal/util/kubernetes/unstructured_util_test.go
@@ -85,8 +85,8 @@ func TestCreateUpdateGetListDeleteCR(t *testing.T) {
 
 	pipelineObject := &GenericObject{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pipeline",
-			APIVersion: "numaflow.numaproj.io/v1alpha1",
+			Kind:       common.NumaflowPipelineKind,
+			APIVersion: common.NumaflowAPIGroup + "/" + common.NumaflowAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-pipeline",
@@ -128,7 +128,7 @@ func TestCreateUpdateGetListDeleteCR(t *testing.T) {
 	assert.Len(t, pipelineList, 1)
 
 	// List resource with cache
-	gvk := schema.GroupVersionKind{Group: common.NumaflowAPIGroup, Version: common.NumaflowAPIVersion, Kind: "Pipeline"}
+	gvk := schema.GroupVersionKind{Group: common.NumaflowAPIGroup, Version: common.NumaflowAPIVersion, Kind: common.NumaflowPipelineKind}
 	pipelineList, err = ListResources(context.Background(), runtimeClient, gvk, client.InNamespace(namespace), client.MatchingLabels{"test": "value"})
 	assert.Nil(t, err)
 	assert.Len(t, pipelineList, 1)

--- a/internal/util/kubernetes/unstructured_util_test.go
+++ b/internal/util/kubernetes/unstructured_util_test.go
@@ -52,6 +52,7 @@ func TestCreateUpdateGetListDeleteCR(t *testing.T) {
 	assert.Nil(t, err)
 	runtimeClient, err := client.New(restConfig, client.Options{Scheme: runtime.NewScheme()})
 	assert.Nil(t, err)
+	assert.Nil(t, SetDynamicClient(restConfig))
 
 	pipelineSpec := numaflowv1.PipelineSpec{
 		Vertices: []numaflowv1.AbstractVertex{
@@ -95,9 +96,9 @@ func TestCreateUpdateGetListDeleteCR(t *testing.T) {
 			Raw: pipelineSpecRaw,
 		},
 	}
-	err = CreateCR(context.Background(), restConfig, pipelineObject, "pipelines")
+	err = CreateCR(context.Background(), pipelineObject, "pipelines")
 	assert.Nil(t, err)
-	pipelineObject, err = GetLiveResource(context.Background(), restConfig, pipelineObject, "pipelines")
+	pipelineObject, err = GetLiveResource(context.Background(), pipelineObject, "pipelines")
 	assert.Nil(t, err)
 	version1 := pipelineObject.ResourceVersion
 	fmt.Printf("Created CR, resource version=%s\n", version1)
@@ -109,7 +110,7 @@ func TestCreateUpdateGetListDeleteCR(t *testing.T) {
 
 	// Updating should return the result Pipeline with the updated ResourceVersion
 	pipelineObject.ObjectMeta.Labels = map[string]string{"test": "value"}
-	err = UpdateCR(context.Background(), restConfig, pipelineObject, "pipelines")
+	err = UpdateCR(context.Background(), pipelineObject, "pipelines")
 	assert.Nil(t, err)
 	version2 := pipelineObject.ResourceVersion
 
@@ -117,19 +118,19 @@ func TestCreateUpdateGetListDeleteCR(t *testing.T) {
 	assert.NotEqual(t, version1, version2)
 
 	// Doing a GET should return the same thing
-	pipelineObject, err = GetLiveResource(context.Background(), restConfig, pipelineObject, "pipelines")
+	pipelineObject, err = GetLiveResource(context.Background(), pipelineObject, "pipelines")
 	assert.Nil(t, err)
 	assert.Equal(t, version2, pipelineObject.ResourceVersion)
 
 	// Do another update
 	pipelineObject.ObjectMeta.Labels["test-2"] = "value-2"
-	err = UpdateCR(context.Background(), restConfig, pipelineObject, "pipelines")
+	err = UpdateCR(context.Background(), pipelineObject, "pipelines")
 	assert.Nil(t, err)
 	version3 := pipelineObject.ResourceVersion
 	assert.NotEqual(t, version2, version3)
 
 	// List resource
-	pipelineList, err := ListLiveResource(context.Background(), restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", namespace, "test=value", "")
+	pipelineList, err := ListLiveResource(context.Background(), common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", namespace, "test=value", "")
 	assert.Nil(t, err)
 	assert.Len(t, pipelineList, 1)
 
@@ -139,9 +140,9 @@ func TestCreateUpdateGetListDeleteCR(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, pipelineList, 1)
 
-	err = DeleteCR(context.Background(), restConfig, pipelineObject, "pipelines")
+	err = DeleteCR(context.Background(), pipelineObject, "pipelines")
 	assert.Nil(t, err)
-	pipelineList, err = ListLiveResource(context.Background(), restConfig, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", namespace, "test=value", "")
+	pipelineList, err = ListLiveResource(context.Background(), common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", namespace, "test=value", "")
 	assert.Nil(t, err)
 	assert.Len(t, pipelineList, 0)
 }

--- a/internal/util/kubernetes/unstructured_util_test.go
+++ b/internal/util/kubernetes/unstructured_util_test.go
@@ -96,7 +96,7 @@ func TestCreateUpdateGetListDeleteCR(t *testing.T) {
 			Raw: pipelineSpecRaw,
 		},
 	}
-	err = CreateCR(context.Background(), pipelineObject, "pipelines")
+	err = CreateResource(context.Background(), runtimeClient, pipelineObject)
 	assert.Nil(t, err)
 	pipelineObject, err = GetLiveResource(context.Background(), pipelineObject, "pipelines")
 	assert.Nil(t, err)
@@ -110,7 +110,7 @@ func TestCreateUpdateGetListDeleteCR(t *testing.T) {
 
 	// Updating should return the result Pipeline with the updated ResourceVersion
 	pipelineObject.ObjectMeta.Labels = map[string]string{"test": "value"}
-	err = UpdateCR(context.Background(), pipelineObject, "pipelines")
+	err = UpdateResource(context.Background(), runtimeClient, pipelineObject)
 	assert.Nil(t, err)
 	version2 := pipelineObject.ResourceVersion
 
@@ -121,13 +121,6 @@ func TestCreateUpdateGetListDeleteCR(t *testing.T) {
 	pipelineObject, err = GetLiveResource(context.Background(), pipelineObject, "pipelines")
 	assert.Nil(t, err)
 	assert.Equal(t, version2, pipelineObject.ResourceVersion)
-
-	// Do another update
-	pipelineObject.ObjectMeta.Labels["test-2"] = "value-2"
-	err = UpdateCR(context.Background(), pipelineObject, "pipelines")
-	assert.Nil(t, err)
-	version3 := pipelineObject.ResourceVersion
-	assert.NotEqual(t, version2, version3)
 
 	// List resource
 	pipelineList, err := ListLiveResource(context.Background(), common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", namespace, "test=value", "")
@@ -140,7 +133,7 @@ func TestCreateUpdateGetListDeleteCR(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, pipelineList, 1)
 
-	err = DeleteCR(context.Background(), pipelineObject, "pipelines")
+	err = DeleteResource(context.Background(), runtimeClient, pipelineObject)
 	assert.Nil(t, err)
 	pipelineList, err = ListLiveResource(context.Background(), common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines", namespace, "test=value", "")
 	assert.Nil(t, err)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #344

### Modifications
- MonoVertex Watch should be Unstructured
- Remove redundant code from unstructured_util
- Prevent calls to REST API when getting Status of child
- Set DynamicClient at once, instead of generating it in each API call

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

Verified in local kind cluster

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->