### PR TITLE
feat: allow for multiple instances of the NumaflowController

### DIFF
--- a/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
@@ -51,6 +51,8 @@ spec:
             properties:
               controller:
                 properties:
+                  instanceID:
+                    type: string
                   version:
                     type: string
                 required:

--- a/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
@@ -168,8 +168,8 @@ spec:
             type: object
         type: object
         x-kubernetes-validations:
-        - message: The metadata name must be 'numaflow-controller'
-          rule: (self.metadata.name == "numaflow-controller")
+        - message: The metadata name must start with 'numaflow-controller'
+          rule: matches(self.metadata.name, '^numaflow-controller.*')
     served: true
     storage: true
     subresources:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -504,6 +504,8 @@ spec:
             properties:
               controller:
                 properties:
+                  instanceID:
+                    type: string
                   version:
                     type: string
                 required:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -621,8 +621,8 @@ spec:
             type: object
         type: object
         x-kubernetes-validations:
-        - message: The metadata name must be 'numaflow-controller'
-          rule: (self.metadata.name == "numaflow-controller")
+        - message: The metadata name must start with 'numaflow-controller'
+          rule: matches(self.metadata.name, '^numaflow-controller.*')
     served: true
     storage: true
     subresources:

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -454,6 +454,10 @@ func ownerExists(existingRefs []interface{}, ownerRef map[string]interface{}) bo
 }
 
 func resolveManifestTemplate(manifest string, rollout *apiv1.NumaflowControllerRollout) ([]byte, error) {
+	if rollout == nil {
+		return []byte(manifest), nil
+	}
+
 	tmpl, err := template.New("manifest").Parse(manifest)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse manifest: %v", err)

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -639,8 +639,8 @@ func getDeploymentCondition(status appsv1.DeploymentStatus, condType appsv1.Depl
 // - whether it exists
 // - error if any
 func (r *NumaflowControllerRolloutReconciler) getNumaflowControllerDeployment(ctx context.Context, controllerRollout *apiv1.NumaflowControllerRollout) (*appsv1.Deployment, bool, error) {
-	instaceID := controllerRollout.Spec.Controller.InstanceID
-	numaflowControllerDeploymentInstanceName := fmt.Sprintf("%s%s", NumaflowControllerDeploymentName, instaceID)
+	instanceID := controllerRollout.Spec.Controller.InstanceID
+	numaflowControllerDeploymentInstanceName := fmt.Sprintf("%s%s", NumaflowControllerDeploymentName, instanceID)
 
 	deployment := &appsv1.Deployment{}
 	if err := r.client.Get(ctx, k8stypes.NamespacedName{Namespace: controllerRollout.Namespace, Name: numaflowControllerDeploymentInstanceName}, deployment); err != nil {

--- a/internal/controller/numaflowcontrollerrollout_controller_test.go
+++ b/internal/controller/numaflowcontrollerrollout_controller_test.go
@@ -99,7 +99,7 @@ var _ = Describe("NumaflowControllerRollout Controller", Ordered, func() {
 			resource.Name = "test-numaflow-controller"
 			err := k8sClient.Create(ctx, &resource)
 			Expect(err).NotTo(Succeed())
-			Expect(err.Error()).To(ContainSubstring("The metadata name must be 'numaflow-controller'"))
+			Expect(err.Error()).To(ContainSubstring("The metadata name must start with 'numaflow-controller'"))
 		})
 
 		It("Should throw duplicate resource error", func() {

--- a/internal/controller/numaflowcontrollerrollout_controller_test.go
+++ b/internal/controller/numaflowcontrollerrollout_controller_test.go
@@ -347,6 +347,77 @@ func Test_getControllerDeploymentVersion(t *testing.T) {
 
 }
 
+func Test_resolveManifestTemplate(t *testing.T) {
+	defaultInstanceID := "123"
+
+	defaultRollout := &apiv1.NumaflowControllerRollout{
+		Spec: apiv1.NumaflowControllerRolloutSpec{
+			Controller: apiv1.Controller{
+				InstanceID: defaultInstanceID,
+			},
+		},
+	}
+
+	testCases := []struct {
+		name             string
+		manifest         string
+		rollout          *apiv1.NumaflowControllerRollout
+		expectedManifest string
+		expectedError    error
+	}{
+		{
+			name:             "nil rollout",
+			manifest:         "",
+			rollout:          nil,
+			expectedManifest: "",
+			expectedError:    nil,
+		}, {
+			name:             "empty manifest",
+			manifest:         "",
+			rollout:          defaultRollout,
+			expectedManifest: "",
+			expectedError:    nil,
+		}, {
+			name:             "manifest with invalid template field",
+			manifest:         "this is {{.Invalid}} invalid",
+			rollout:          defaultRollout,
+			expectedManifest: "",
+			expectedError:    fmt.Errorf("unable to apply information to manifest: template: manifest:1:10: executing \"manifest\" at <.Invalid>: can't evaluate field Invalid in type struct { InstanceID string }"),
+		}, {
+			name:     "manifest with valid template and rollout without instanceID",
+			manifest: "valid-template-no-id{{.InstanceID}}",
+			rollout: &apiv1.NumaflowControllerRollout{
+				Spec: apiv1.NumaflowControllerRolloutSpec{
+					Controller: apiv1.Controller{},
+				},
+			},
+			expectedManifest: "valid-template-no-id",
+			expectedError:    nil,
+		}, {
+			name:             "manifest with valid template and rollout with instanceID",
+			manifest:         "valid-template-no-id{{.InstanceID}}",
+			rollout:          defaultRollout,
+			expectedManifest: fmt.Sprintf("valid-template-no-id%s", defaultInstanceID),
+			expectedError:    nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifestBytes, err := resolveManifestTemplate(tc.manifest, tc.rollout)
+
+			if tc.expectedError != nil {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectedManifest, string(manifestBytes))
+		})
+	}
+}
+
 func Test_reconcile_numaflowcontrollerrollout_PPND(t *testing.T) {
 
 	restConfig, numaflowClientSet, numaplaneClient, k8sClientSet, err := commontest.PrepareK8SEnvironment()

--- a/internal/controller/numaflowcontrollerrollout_controller_test.go
+++ b/internal/controller/numaflowcontrollerrollout_controller_test.go
@@ -382,10 +382,10 @@ func Test_resolveManifestTemplate(t *testing.T) {
 			manifest:         "this is {{.Invalid}} invalid",
 			rollout:          defaultRollout,
 			expectedManifest: "",
-			expectedError:    fmt.Errorf("unable to apply information to manifest: template: manifest:1:10: executing \"manifest\" at <.Invalid>: can't evaluate field Invalid in type struct { InstanceID string }"),
+			expectedError:    fmt.Errorf("unable to apply information to manifest: template: manifest:1:10: executing \"manifest\" at <.Invalid>: can't evaluate field Invalid in type struct { InstanceSuffix string }"),
 		}, {
 			name:     "manifest with valid template and rollout without instanceID",
-			manifest: "valid-template-no-id{{.InstanceID}}",
+			manifest: "valid-template-no-id{{.InstanceSuffix}}",
 			rollout: &apiv1.NumaflowControllerRollout{
 				Spec: apiv1.NumaflowControllerRolloutSpec{
 					Controller: apiv1.Controller{},
@@ -395,9 +395,9 @@ func Test_resolveManifestTemplate(t *testing.T) {
 			expectedError:    nil,
 		}, {
 			name:             "manifest with valid template and rollout with instanceID",
-			manifest:         "valid-template-no-id{{.InstanceID}}",
+			manifest:         "valid-template-no-id{{.InstanceSuffix}}",
 			rollout:          defaultRollout,
-			expectedManifest: fmt.Sprintf("valid-template-no-id%s", defaultInstanceID),
+			expectedManifest: fmt.Sprintf("valid-template-no-id-%s", defaultInstanceID),
 			expectedError:    nil,
 		},
 	}

--- a/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
@@ -42,7 +42,7 @@ type NumaflowControllerRolloutStatus struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:validation:XValidation:rule=(self.metadata.name == "numaflow-controller"), message="The metadata name must be 'numaflow-controller'"
+// +kubebuilder:validation:XValidation:rule="matches(self.metadata.name, '^numaflow-controller.*')",message="The metadata name must start with 'numaflow-controller'"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
 // NumaflowControllerRollout is the Schema for the numaflowcontrollerrollouts API

--- a/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
@@ -24,7 +24,8 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 type Controller struct {
-	Version string `json:"version"`
+	InstanceID string `json:"instanceID,omitempty"`
+	Version    string `json:"version"`
 }
 
 // NumaflowControllerRolloutSpec defines the desired state of NumaflowControllerRollout

--- a/tests/manifests/default/controller_def_1.3.3-copy1.yaml
+++ b/tests/manifests/default/controller_def_1.3.3-copy1.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: numaflow-controller-definitions-1.3.3-copy1 
+  name: numaflow-controller-definitions-1.3.3-copy1
   namespace: numaplane-system
   labels:
     "numaplane.numaproj.io/config": numaflow-controller-definitions
@@ -13,26 +13,26 @@ data:
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-sa
+            name: numaflow-sa{{.InstanceID}}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-server-sa
+            name: numaflow-server-sa{{.InstanceID}}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server
+              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           rules:
           - apiGroups:
             - ""
@@ -51,7 +51,7 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role
+            name: numaflow-role{{.InstanceID}}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -158,7 +158,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-role
+            name: numaflow-server-role{{.InstanceID}}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -224,7 +224,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-role
+            name: numaflow-server-secrets-role{{.InstanceID}}
           rules:
           - apiGroups:
             - ""
@@ -241,16 +241,16 @@ data:
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server
+              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -259,14 +259,14 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role-binding
+            name: numaflow-role-binding{{.InstanceID}}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-role
+            name: numaflow-role{{.InstanceID}}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-sa
+            name: numaflow-sa{{.InstanceID}}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -275,14 +275,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-binding
+            name: numaflow-server-binding{{.InstanceID}}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-role
+            name: numaflow-server-role{{.InstanceID}}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa
+            name: numaflow-server-sa{{.InstanceID}}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -291,14 +291,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-binding
+            name: numaflow-server-secrets-binding{{.InstanceID}}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-secrets-role
+            name: numaflow-server-secrets-role{{.InstanceID}}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa
+            name: numaflow-server-sa{{.InstanceID}}
           ---
           apiVersion: v1
           data:
@@ -306,7 +306,7 @@ data:
             server.disable.auth: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-cmd-params-config
+            name: numaflow-cmd-params-config{{.InstanceID}}
           ---
           apiVersion: v1
           data:
@@ -464,7 +464,7 @@ data:
                     startCommand: /nats-server
           kind: ConfigMap
           metadata:
-            name: numaflow-controller-config
+            name: numaflow-controller-config{{.InstanceID}}
           ---
           apiVersion: v1
           data:
@@ -484,14 +484,14 @@ data:
                     - readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-dex-server-config
+            name: numaflow-dex-server-config{{.InstanceID}}
           ---
           apiVersion: v1
           data:
             admin.enabled: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-server-local-user-config
+            name: numaflow-server-local-user-config{{.InstanceID}}
           ---
           apiVersion: v1
           data:
@@ -512,12 +512,12 @@ data:
               # g, my-github-org:my-github-team, role:readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-server-rbac-config
+            name: numaflow-server-rbac-config{{.InstanceID}}
           ---
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-dex-secrets
+            name: numaflow-dex-secrets{{.InstanceID}}
           stringData:
             dex-github-client-id: <GITHUB_CLIENT_ID>
             dex-github-client-secret: <GITHUB_CLIENT_SECRET>
@@ -525,26 +525,26 @@ data:
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-server-secrets
+            name: numaflow-server-secrets{{.InstanceID}}
           type: Opaque
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           spec:
             ports:
             - port: 5556
               targetPort: 5556
             selector:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server
+              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
               app.kubernetes.io/part-of: numaflow
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-server
+            name: numaflow-server{{.InstanceID}}
           spec:
             ports:
             - port: 8443
@@ -558,7 +558,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-controller
+            name: numaflow-controller{{.InstanceID}}
           spec:
             replicas: 1
             selector:
@@ -578,7 +578,7 @@ data:
                   - controller
                   env:
                   - name: NUMAFLOW_IMAGE
-                    value: quay.io/numaio/numaflow-rc:v1.3.3-copy1
+                    value: quay.io/numaproj/numaflow:v1.3.3-copy1
                   - name: NAMESPACE
                     valueFrom:
                       fieldRef:
@@ -587,39 +587,39 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_DISABLED
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.disabled
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.duration
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.deadline
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.period
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
-                  image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
+                  image: quay.io/numaproj/numaflow:v1.3.3-copy1
                   imagePullPolicy: Always
                   livenessProbe:
                     httpGet:
@@ -650,27 +650,27 @@ data:
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-sa
+                serviceAccountName: numaflow-sa{{.InstanceID}}
                 volumes:
                 - configMap:
-                    name: numaflow-controller-config
+                    name: numaflow-controller-config{{.InstanceID}}
                   name: controller-config-volume
           ---
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           spec:
             selector:
               matchLabels:
                 app.kubernetes.io/component: dex-server
-                app.kubernetes.io/name: numaflow-dex-server
+                app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
                 app.kubernetes.io/part-of: numaflow
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: dex-server
-                  app.kubernetes.io/name: numaflow-dex-server
+                  app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
                   app.kubernetes.io/part-of: numaflow
               spec:
                 containers:
@@ -683,12 +683,12 @@ data:
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-id
-                        name: numaflow-dex-secrets
+                        name: numaflow-dex-secrets{{.InstanceID}}
                   - name: GITHUB_CLIENT_SECRET
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-secret
-                        name: numaflow-dex-secrets
+                        name: numaflow-dex-secrets{{.InstanceID}}
                   image: dexidp/dex:v2.37.0
                   imagePullPolicy: Always
                   name: dex
@@ -712,15 +712,15 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
-                  image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
+                  image: quay.io/numaproj/numaflow:v1.3.3-copy1
                   imagePullPolicy: Always
                   name: dex-init
                   volumeMounts:
@@ -730,13 +730,13 @@ data:
                     name: tls
                   - mountPath: /tmp
                     name: generated-dex-config
-                serviceAccountName: numaflow-dex-server
+                serviceAccountName: numaflow-dex-server{{.InstanceID}}
                 volumes:
                 - configMap:
                     items:
                     - key: config.yaml
                       path: config.yaml
-                    name: numaflow-dex-server-config
+                    name: numaflow-dex-server-config{{.InstanceID}}
                   name: connector-config
                 - emptyDir: {}
                   name: tls
@@ -746,7 +746,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-server
+            name: numaflow-server{{.InstanceID}}
           spec:
             replicas: 1
             selector:
@@ -773,69 +773,69 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.insecure
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_PORT_NUMBER
                     valueFrom:
                       configMapKeyRef:
                         key: server.port
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_NAMESPACED
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_READONLY
                     valueFrom:
                       configMapKeyRef:
                         key: server.readonly
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_DISABLE_AUTH
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_DEX_SERVER_ADDR
                     valueFrom:
                       configMapKeyRef:
                         key: server.dex.server
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_ADDRESS
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_CORS_ALLOWED_ORIGINS
                     valueFrom:
                       configMapKeyRef:
                         key: server.cors.allowed.origins
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_DAEMON_CLIENT_PROTOCOL
                     valueFrom:
                       configMapKeyRef:
                         key: server.daemon.client.protocol
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
-                  image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
+                  image: quay.io/numaproj/numaflow:v1.3.3-copy1
                   imagePullPolicy: Always
                   livenessProbe:
                     httpGet:
@@ -869,9 +869,9 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
-                  image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
+                  image: quay.io/numaproj/numaflow:v1.3.3-copy1
                   imagePullPolicy: Always
                   name: server-init
                   volumeMounts:
@@ -888,18 +888,18 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
-                  image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
+                  image: quay.io/numaproj/numaflow:v1.3.3-copy1
                   imagePullPolicy: Always
                   name: server-secrets-init
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-server-sa
+                serviceAccountName: numaflow-server-sa{{.InstanceID}}
                 volumes:
                 - emptyDir: {}
                   name: env-volume
                 - configMap:
-                    name: numaflow-server-rbac-config
+                    name: numaflow-server-rbac-config{{.InstanceID}}
                   name: rbac-config

--- a/tests/manifests/default/controller_def_1.3.3-copy1.yaml
+++ b/tests/manifests/default/controller_def_1.3.3-copy1.yaml
@@ -578,7 +578,7 @@ data:
                   - controller
                   env:
                   - name: NUMAFLOW_IMAGE
-                    value: quay.io/numaproj/numaflow:v1.3.3-copy1
+                    value: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   - name: NAMESPACE
                     valueFrom:
                       fieldRef:
@@ -619,7 +619,7 @@ data:
                         key: controller.leader.election.lease.renew.period
                         name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
-                  image: quay.io/numaproj/numaflow:v1.3.3-copy1
+                  image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
                   livenessProbe:
                     httpGet:
@@ -720,7 +720,7 @@ data:
                         key: server.base.href
                         name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
-                  image: quay.io/numaproj/numaflow:v1.3.3-copy1
+                  image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
                   name: dex-init
                   volumeMounts:
@@ -835,7 +835,7 @@ data:
                         key: server.daemon.client.protocol
                         name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
-                  image: quay.io/numaproj/numaflow:v1.3.3-copy1
+                  image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
                   livenessProbe:
                     httpGet:
@@ -871,7 +871,7 @@ data:
                         key: server.base.href
                         name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
-                  image: quay.io/numaproj/numaflow:v1.3.3-copy1
+                  image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
                   name: server-init
                   volumeMounts:
@@ -890,7 +890,7 @@ data:
                         key: server.disable.auth
                         name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
-                  image: quay.io/numaproj/numaflow:v1.3.3-copy1
+                  image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
                   name: server-secrets-init
                 securityContext:

--- a/tests/manifests/default/controller_def_1.3.3-copy1.yaml
+++ b/tests/manifests/default/controller_def_1.3.3-copy1.yaml
@@ -13,26 +13,26 @@ data:
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-sa{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-sa{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+              app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           rules:
           - apiGroups:
             - ""
@@ -51,7 +51,7 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -158,7 +158,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -224,7 +224,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-secrets-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
             - ""
@@ -241,16 +241,16 @@ data:
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+              app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -259,14 +259,14 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-role-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-role{{ .InstanceSuffix }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-sa{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -275,14 +275,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-role{{ .InstanceSuffix }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-sa{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -291,14 +291,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-secrets-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-secrets-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-secrets-role{{ .InstanceSuffix }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-sa{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
@@ -306,7 +306,7 @@ data:
             server.disable.auth: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
@@ -464,7 +464,7 @@ data:
                     startCommand: /nats-server
           kind: ConfigMap
           metadata:
-            name: numaflow-controller-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-controller-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
@@ -484,14 +484,14 @@ data:
                     - readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-dex-server-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
             admin.enabled: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-server-local-user-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-local-user-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
@@ -512,12 +512,12 @@ data:
               # g, my-github-org:my-github-team, role:readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-server-rbac-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-rbac-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-secrets{{ .InstanceSuffix }}
           stringData:
             dex-github-client-id: <GITHUB_CLIENT_ID>
             dex-github-client-secret: <GITHUB_CLIENT_SECRET>
@@ -525,26 +525,26 @@ data:
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-server-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-secrets{{ .InstanceSuffix }}
           type: Opaque
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           spec:
             ports:
             - port: 5556
               targetPort: 5556
             selector:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+              app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server{{ .InstanceSuffix }}
           spec:
             ports:
             - port: 8443
@@ -558,7 +558,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-controller{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-controller{{ .InstanceSuffix }}
           spec:
             replicas: 1
             selector:
@@ -587,37 +587,37 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_DISABLED
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.disabled
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.duration
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.deadline
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.period
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
@@ -650,27 +650,27 @@ data:
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                serviceAccountName: numaflow-sa{{ .InstanceSuffix }}
                 volumes:
                 - configMap:
-                    name: numaflow-controller-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                    name: numaflow-controller-config{{ .InstanceSuffix }}
                   name: controller-config-volume
           ---
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           spec:
             selector:
               matchLabels:
                 app.kubernetes.io/component: dex-server
-                app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
                 app.kubernetes.io/part-of: numaflow
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: dex-server
-                  app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                  app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
                   app.kubernetes.io/part-of: numaflow
               spec:
                 containers:
@@ -683,12 +683,12 @@ data:
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-id
-                        name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-dex-secrets{{ .InstanceSuffix }}
                   - name: GITHUB_CLIENT_SECRET
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-secret
-                        name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-dex-secrets{{ .InstanceSuffix }}
                   image: dexidp/dex:v2.37.0
                   imagePullPolicy: Always
                   name: dex
@@ -712,13 +712,13 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
@@ -730,13 +730,13 @@ data:
                     name: tls
                   - mountPath: /tmp
                     name: generated-dex-config
-                serviceAccountName: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                serviceAccountName: numaflow-dex-server{{ .InstanceSuffix }}
                 volumes:
                 - configMap:
                     items:
                     - key: config.yaml
                       path: config.yaml
-                    name: numaflow-dex-server-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                    name: numaflow-dex-server-config{{ .InstanceSuffix }}
                   name: connector-config
                 - emptyDir: {}
                   name: tls
@@ -746,7 +746,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server{{ .InstanceSuffix }}
           spec:
             replicas: 1
             selector:
@@ -773,67 +773,67 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.insecure
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_PORT_NUMBER
                     valueFrom:
                       configMapKeyRef:
                         key: server.port
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_NAMESPACED
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_READONLY
                     valueFrom:
                       configMapKeyRef:
                         key: server.readonly
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DISABLE_AUTH
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DEX_SERVER_ADDR
                     valueFrom:
                       configMapKeyRef:
                         key: server.dex.server
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_ADDRESS
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_CORS_ALLOWED_ORIGINS
                     valueFrom:
                       configMapKeyRef:
                         key: server.cors.allowed.origins
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DAEMON_CLIENT_PROTOCOL
                     valueFrom:
                       configMapKeyRef:
                         key: server.daemon.client.protocol
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
@@ -869,7 +869,7 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
@@ -888,7 +888,7 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
@@ -896,10 +896,10 @@ data:
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                serviceAccountName: numaflow-server-sa{{ .InstanceSuffix }}
                 volumes:
                 - emptyDir: {}
                   name: env-volume
                 - configMap:
-                    name: numaflow-server-rbac-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                    name: numaflow-server-rbac-config{{ .InstanceSuffix }}
                   name: rbac-config

--- a/tests/manifests/default/controller_def_1.3.3-copy1.yaml
+++ b/tests/manifests/default/controller_def_1.3.3-copy1.yaml
@@ -13,26 +13,26 @@ data:
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-sa{{.InstanceID}}
+            name: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-server-sa{{.InstanceID}}
+            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
+              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           rules:
           - apiGroups:
             - ""
@@ -51,7 +51,7 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role{{.InstanceID}}
+            name: numaflow-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -158,7 +158,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-role{{.InstanceID}}
+            name: numaflow-server-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -224,7 +224,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-role{{.InstanceID}}
+            name: numaflow-server-secrets-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           rules:
           - apiGroups:
             - ""
@@ -241,16 +241,16 @@ data:
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
+              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -259,14 +259,14 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role-binding{{.InstanceID}}
+            name: numaflow-role-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-role{{.InstanceID}}
+            name: numaflow-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-sa{{.InstanceID}}
+            name: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -275,14 +275,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-binding{{.InstanceID}}
+            name: numaflow-server-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-role{{.InstanceID}}
+            name: numaflow-server-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa{{.InstanceID}}
+            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -291,14 +291,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-binding{{.InstanceID}}
+            name: numaflow-server-secrets-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-secrets-role{{.InstanceID}}
+            name: numaflow-server-secrets-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa{{.InstanceID}}
+            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           data:
@@ -306,7 +306,7 @@ data:
             server.disable.auth: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-cmd-params-config{{.InstanceID}}
+            name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           data:
@@ -464,7 +464,7 @@ data:
                     startCommand: /nats-server
           kind: ConfigMap
           metadata:
-            name: numaflow-controller-config{{.InstanceID}}
+            name: numaflow-controller-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           data:
@@ -484,14 +484,14 @@ data:
                     - readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-dex-server-config{{.InstanceID}}
+            name: numaflow-dex-server-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           data:
             admin.enabled: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-server-local-user-config{{.InstanceID}}
+            name: numaflow-server-local-user-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           data:
@@ -512,12 +512,12 @@ data:
               # g, my-github-org:my-github-team, role:readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-server-rbac-config{{.InstanceID}}
+            name: numaflow-server-rbac-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-dex-secrets{{.InstanceID}}
+            name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           stringData:
             dex-github-client-id: <GITHUB_CLIENT_ID>
             dex-github-client-secret: <GITHUB_CLIENT_SECRET>
@@ -525,26 +525,26 @@ data:
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-server-secrets{{.InstanceID}}
+            name: numaflow-server-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           type: Opaque
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           spec:
             ports:
             - port: 5556
               targetPort: 5556
             selector:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
+              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
               app.kubernetes.io/part-of: numaflow
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-server{{.InstanceID}}
+            name: numaflow-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           spec:
             ports:
             - port: 8443
@@ -558,7 +558,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-controller{{.InstanceID}}
+            name: numaflow-controller{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           spec:
             replicas: 1
             selector:
@@ -587,37 +587,37 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_DISABLED
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.disabled
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.duration
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.deadline
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.period
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
@@ -650,27 +650,27 @@ data:
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-sa{{.InstanceID}}
+                serviceAccountName: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                 volumes:
                 - configMap:
-                    name: numaflow-controller-config{{.InstanceID}}
+                    name: numaflow-controller-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   name: controller-config-volume
           ---
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           spec:
             selector:
               matchLabels:
                 app.kubernetes.io/component: dex-server
-                app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
+                app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                 app.kubernetes.io/part-of: numaflow
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: dex-server
-                  app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
+                  app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   app.kubernetes.io/part-of: numaflow
               spec:
                 containers:
@@ -683,12 +683,12 @@ data:
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-id
-                        name: numaflow-dex-secrets{{.InstanceID}}
+                        name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   - name: GITHUB_CLIENT_SECRET
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-secret
-                        name: numaflow-dex-secrets{{.InstanceID}}
+                        name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   image: dexidp/dex:v2.37.0
                   imagePullPolicy: Always
                   name: dex
@@ -712,13 +712,13 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
@@ -730,13 +730,13 @@ data:
                     name: tls
                   - mountPath: /tmp
                     name: generated-dex-config
-                serviceAccountName: numaflow-dex-server{{.InstanceID}}
+                serviceAccountName: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                 volumes:
                 - configMap:
                     items:
                     - key: config.yaml
                       path: config.yaml
-                    name: numaflow-dex-server-config{{.InstanceID}}
+                    name: numaflow-dex-server-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   name: connector-config
                 - emptyDir: {}
                   name: tls
@@ -746,7 +746,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-server{{.InstanceID}}
+            name: numaflow-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           spec:
             replicas: 1
             selector:
@@ -773,67 +773,67 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.insecure
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_PORT_NUMBER
                     valueFrom:
                       configMapKeyRef:
                         key: server.port
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_NAMESPACED
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_READONLY
                     valueFrom:
                       configMapKeyRef:
                         key: server.readonly
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DISABLE_AUTH
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DEX_SERVER_ADDR
                     valueFrom:
                       configMapKeyRef:
                         key: server.dex.server
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_ADDRESS
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_CORS_ALLOWED_ORIGINS
                     valueFrom:
                       configMapKeyRef:
                         key: server.cors.allowed.origins
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DAEMON_CLIENT_PROTOCOL
                     valueFrom:
                       configMapKeyRef:
                         key: server.daemon.client.protocol
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
@@ -869,7 +869,7 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
@@ -888,7 +888,7 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   image: quay.io/numaio/numaflow-rc:v1.3.3-copy1
                   imagePullPolicy: Always
@@ -896,10 +896,10 @@ data:
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-server-sa{{.InstanceID}}
+                serviceAccountName: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                 volumes:
                 - emptyDir: {}
                   name: env-volume
                 - configMap:
-                    name: numaflow-server-rbac-config{{.InstanceID}}
+                    name: numaflow-server-rbac-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   name: rbac-config

--- a/tests/manifests/default/controller_def_1.3.3.yaml
+++ b/tests/manifests/default/controller_def_1.3.3.yaml
@@ -13,26 +13,26 @@ data:
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-sa{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-sa{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+              app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           rules:
           - apiGroups:
             - ""
@@ -51,7 +51,7 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -158,7 +158,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -224,7 +224,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-secrets-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
             - ""
@@ -241,16 +241,16 @@ data:
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+              app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -259,14 +259,14 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-role-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-role{{ .InstanceSuffix }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-sa{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -275,14 +275,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-role{{ .InstanceSuffix }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-sa{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -291,14 +291,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-secrets-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-secrets-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-secrets-role{{ .InstanceSuffix }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-sa{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
@@ -306,7 +306,7 @@ data:
             server.disable.auth: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
@@ -464,7 +464,7 @@ data:
                     startCommand: /nats-server
           kind: ConfigMap
           metadata:
-            name: numaflow-controller-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-controller-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
@@ -484,14 +484,14 @@ data:
                     - readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-dex-server-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
             admin.enabled: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-server-local-user-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-local-user-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
@@ -512,12 +512,12 @@ data:
               # g, my-github-org:my-github-team, role:readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-server-rbac-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-rbac-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-secrets{{ .InstanceSuffix }}
           stringData:
             dex-github-client-id: <GITHUB_CLIENT_ID>
             dex-github-client-secret: <GITHUB_CLIENT_SECRET>
@@ -525,26 +525,26 @@ data:
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-server-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server-secrets{{ .InstanceSuffix }}
           type: Opaque
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           spec:
             ports:
             - port: 5556
               targetPort: 5556
             selector:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+              app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server{{ .InstanceSuffix }}
           spec:
             ports:
             - port: 8443
@@ -558,7 +558,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-controller{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-controller{{ .InstanceSuffix }}
           spec:
             replicas: 1
             selector:
@@ -587,37 +587,37 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_DISABLED
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.disabled
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.duration
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.deadline
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.period
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -650,27 +650,27 @@ data:
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                serviceAccountName: numaflow-sa{{ .InstanceSuffix }}
                 volumes:
                 - configMap:
-                    name: numaflow-controller-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                    name: numaflow-controller-config{{ .InstanceSuffix }}
                   name: controller-config-volume
           ---
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-dex-server{{ .InstanceSuffix }}
           spec:
             selector:
               matchLabels:
                 app.kubernetes.io/component: dex-server
-                app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
                 app.kubernetes.io/part-of: numaflow
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: dex-server
-                  app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                  app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
                   app.kubernetes.io/part-of: numaflow
               spec:
                 containers:
@@ -683,12 +683,12 @@ data:
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-id
-                        name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-dex-secrets{{ .InstanceSuffix }}
                   - name: GITHUB_CLIENT_SECRET
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-secret
-                        name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-dex-secrets{{ .InstanceSuffix }}
                   image: dexidp/dex:v2.37.0
                   imagePullPolicy: Always
                   name: dex
@@ -712,13 +712,13 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -730,13 +730,13 @@ data:
                     name: tls
                   - mountPath: /tmp
                     name: generated-dex-config
-                serviceAccountName: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                serviceAccountName: numaflow-dex-server{{ .InstanceSuffix }}
                 volumes:
                 - configMap:
                     items:
                     - key: config.yaml
                       path: config.yaml
-                    name: numaflow-dex-server-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                    name: numaflow-dex-server-config{{ .InstanceSuffix }}
                   name: connector-config
                 - emptyDir: {}
                   name: tls
@@ -746,7 +746,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+            name: numaflow-server{{ .InstanceSuffix }}
           spec:
             replicas: 1
             selector:
@@ -773,67 +773,67 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.insecure
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_PORT_NUMBER
                     valueFrom:
                       configMapKeyRef:
                         key: server.port
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_NAMESPACED
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_READONLY
                     valueFrom:
                       configMapKeyRef:
                         key: server.readonly
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DISABLE_AUTH
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DEX_SERVER_ADDR
                     valueFrom:
                       configMapKeyRef:
                         key: server.dex.server
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_ADDRESS
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_CORS_ALLOWED_ORIGINS
                     valueFrom:
                       configMapKeyRef:
                         key: server.cors.allowed.origins
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DAEMON_CLIENT_PROTOCOL
                     valueFrom:
                       configMapKeyRef:
                         key: server.daemon.client.protocol
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -869,7 +869,7 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -888,7 +888,7 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -896,10 +896,10 @@ data:
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                serviceAccountName: numaflow-server-sa{{ .InstanceSuffix }}
                 volumes:
                 - emptyDir: {}
                   name: env-volume
                 - configMap:
-                    name: numaflow-server-rbac-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
+                    name: numaflow-server-rbac-config{{ .InstanceSuffix }}
                   name: rbac-config

--- a/tests/manifests/default/controller_def_1.3.3.yaml
+++ b/tests/manifests/default/controller_def_1.3.3.yaml
@@ -13,26 +13,26 @@ data:
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-sa{{.InstanceID}}
+            name: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-server-sa{{.InstanceID}}
+            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
+              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           rules:
           - apiGroups:
             - ""
@@ -51,7 +51,7 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role{{.InstanceID}}
+            name: numaflow-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -158,7 +158,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-role{{.InstanceID}}
+            name: numaflow-server-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -224,7 +224,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-role{{.InstanceID}}
+            name: numaflow-server-secrets-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           rules:
           - apiGroups:
             - ""
@@ -241,16 +241,16 @@ data:
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
+              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -259,14 +259,14 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role-binding{{.InstanceID}}
+            name: numaflow-role-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-role{{.InstanceID}}
+            name: numaflow-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-sa{{.InstanceID}}
+            name: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -275,14 +275,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-binding{{.InstanceID}}
+            name: numaflow-server-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-role{{.InstanceID}}
+            name: numaflow-server-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa{{.InstanceID}}
+            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -291,14 +291,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-binding{{.InstanceID}}
+            name: numaflow-server-secrets-binding{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-secrets-role{{.InstanceID}}
+            name: numaflow-server-secrets-role{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa{{.InstanceID}}
+            name: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           data:
@@ -306,7 +306,7 @@ data:
             server.disable.auth: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-cmd-params-config{{.InstanceID}}
+            name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           data:
@@ -464,7 +464,7 @@ data:
                     startCommand: /nats-server
           kind: ConfigMap
           metadata:
-            name: numaflow-controller-config{{.InstanceID}}
+            name: numaflow-controller-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           data:
@@ -484,14 +484,14 @@ data:
                     - readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-dex-server-config{{.InstanceID}}
+            name: numaflow-dex-server-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           data:
             admin.enabled: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-server-local-user-config{{.InstanceID}}
+            name: numaflow-server-local-user-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           data:
@@ -512,12 +512,12 @@ data:
               # g, my-github-org:my-github-team, role:readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-server-rbac-config{{.InstanceID}}
+            name: numaflow-server-rbac-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           ---
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-dex-secrets{{.InstanceID}}
+            name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           stringData:
             dex-github-client-id: <GITHUB_CLIENT_ID>
             dex-github-client-secret: <GITHUB_CLIENT_SECRET>
@@ -525,26 +525,26 @@ data:
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-server-secrets{{.InstanceID}}
+            name: numaflow-server-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           type: Opaque
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           spec:
             ports:
             - port: 5556
               targetPort: 5556
             selector:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
+              app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
               app.kubernetes.io/part-of: numaflow
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-server{{.InstanceID}}
+            name: numaflow-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           spec:
             ports:
             - port: 8443
@@ -558,7 +558,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-controller{{.InstanceID}}
+            name: numaflow-controller{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           spec:
             replicas: 1
             selector:
@@ -587,37 +587,37 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_DISABLED
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.disabled
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.duration
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.deadline
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.period
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -650,27 +650,27 @@ data:
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-sa{{.InstanceID}}
+                serviceAccountName: numaflow-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                 volumes:
                 - configMap:
-                    name: numaflow-controller-config{{.InstanceID}}
+                    name: numaflow-controller-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   name: controller-config-volume
           ---
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-dex-server{{.InstanceID}}
+            name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           spec:
             selector:
               matchLabels:
                 app.kubernetes.io/component: dex-server
-                app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
+                app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                 app.kubernetes.io/part-of: numaflow
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: dex-server
-                  app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
+                  app.kubernetes.io/name: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   app.kubernetes.io/part-of: numaflow
               spec:
                 containers:
@@ -683,12 +683,12 @@ data:
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-id
-                        name: numaflow-dex-secrets{{.InstanceID}}
+                        name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   - name: GITHUB_CLIENT_SECRET
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-secret
-                        name: numaflow-dex-secrets{{.InstanceID}}
+                        name: numaflow-dex-secrets{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   image: dexidp/dex:v2.37.0
                   imagePullPolicy: Always
                   name: dex
@@ -712,13 +712,13 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -730,13 +730,13 @@ data:
                     name: tls
                   - mountPath: /tmp
                     name: generated-dex-config
-                serviceAccountName: numaflow-dex-server{{.InstanceID}}
+                serviceAccountName: numaflow-dex-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                 volumes:
                 - configMap:
                     items:
                     - key: config.yaml
                       path: config.yaml
-                    name: numaflow-dex-server-config{{.InstanceID}}
+                    name: numaflow-dex-server-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   name: connector-config
                 - emptyDir: {}
                   name: tls
@@ -746,7 +746,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-server{{.InstanceID}}
+            name: numaflow-server{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
           spec:
             replicas: 1
             selector:
@@ -773,67 +773,67 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.insecure
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_PORT_NUMBER
                     valueFrom:
                       configMapKeyRef:
                         key: server.port
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_NAMESPACED
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_READONLY
                     valueFrom:
                       configMapKeyRef:
                         key: server.readonly
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DISABLE_AUTH
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DEX_SERVER_ADDR
                     valueFrom:
                       configMapKeyRef:
                         key: server.dex.server
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_ADDRESS
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_CORS_ALLOWED_ORIGINS
                     valueFrom:
                       configMapKeyRef:
                         key: server.cors.allowed.origins
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   - name: NUMAFLOW_SERVER_DAEMON_CLIENT_PROTOCOL
                     valueFrom:
                       configMapKeyRef:
                         key: server.daemon.client.protocol
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -869,7 +869,7 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -888,7 +888,7 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config{{.InstanceID}}
+                        name: numaflow-cmd-params-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -896,10 +896,10 @@ data:
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-server-sa{{.InstanceID}}
+                serviceAccountName: numaflow-server-sa{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                 volumes:
                 - emptyDir: {}
                   name: env-volume
                 - configMap:
-                    name: numaflow-server-rbac-config{{.InstanceID}}
+                    name: numaflow-server-rbac-config{{ if .InstanceID }}-{{.InstanceID}}{{ end }}
                   name: rbac-config

--- a/tests/manifests/default/controller_def_1.3.3.yaml
+++ b/tests/manifests/default/controller_def_1.3.3.yaml
@@ -13,26 +13,26 @@ data:
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-sa
+            name: numaflow-sa{{.InstanceID}}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
-            name: numaflow-server-sa
+            name: numaflow-server-sa{{.InstanceID}}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server
+              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           rules:
           - apiGroups:
             - ""
@@ -51,7 +51,7 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role
+            name: numaflow-role{{.InstanceID}}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -158,7 +158,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-role
+            name: numaflow-server-role{{.InstanceID}}
           rules:
           - apiGroups:
             - numaflow.numaproj.io
@@ -224,7 +224,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-role
+            name: numaflow-server-secrets-role{{.InstanceID}}
           rules:
           - apiGroups:
             - ""
@@ -241,16 +241,16 @@ data:
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server
+              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -259,14 +259,14 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-role-binding
+            name: numaflow-role-binding{{.InstanceID}}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-role
+            name: numaflow-role{{.InstanceID}}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-sa
+            name: numaflow-sa{{.InstanceID}}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -275,14 +275,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-binding
+            name: numaflow-server-binding{{.InstanceID}}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-role
+            name: numaflow-server-role{{.InstanceID}}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa
+            name: numaflow-server-sa{{.InstanceID}}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
@@ -291,14 +291,14 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-            name: numaflow-server-secrets-binding
+            name: numaflow-server-secrets-binding{{.InstanceID}}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: numaflow-server-secrets-role
+            name: numaflow-server-secrets-role{{.InstanceID}}
           subjects:
           - kind: ServiceAccount
-            name: numaflow-server-sa
+            name: numaflow-server-sa{{.InstanceID}}
           ---
           apiVersion: v1
           data:
@@ -306,7 +306,7 @@ data:
             server.disable.auth: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-cmd-params-config
+            name: numaflow-cmd-params-config{{.InstanceID}}
           ---
           apiVersion: v1
           data:
@@ -464,7 +464,7 @@ data:
                     startCommand: /nats-server
           kind: ConfigMap
           metadata:
-            name: numaflow-controller-config
+            name: numaflow-controller-config{{.InstanceID}}
           ---
           apiVersion: v1
           data:
@@ -484,14 +484,14 @@ data:
                     - readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-dex-server-config
+            name: numaflow-dex-server-config{{.InstanceID}}
           ---
           apiVersion: v1
           data:
             admin.enabled: "true"
           kind: ConfigMap
           metadata:
-            name: numaflow-server-local-user-config
+            name: numaflow-server-local-user-config{{.InstanceID}}
           ---
           apiVersion: v1
           data:
@@ -512,12 +512,12 @@ data:
               # g, my-github-org:my-github-team, role:readonly
           kind: ConfigMap
           metadata:
-            name: numaflow-server-rbac-config
+            name: numaflow-server-rbac-config{{.InstanceID}}
           ---
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-dex-secrets
+            name: numaflow-dex-secrets{{.InstanceID}}
           stringData:
             dex-github-client-id: <GITHUB_CLIENT_ID>
             dex-github-client-secret: <GITHUB_CLIENT_SECRET>
@@ -525,26 +525,26 @@ data:
           apiVersion: v1
           kind: Secret
           metadata:
-            name: numaflow-server-secrets
+            name: numaflow-server-secrets{{.InstanceID}}
           type: Opaque
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           spec:
             ports:
             - port: 5556
               targetPort: 5556
             selector:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server
+              app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
               app.kubernetes.io/part-of: numaflow
           ---
           apiVersion: v1
           kind: Service
           metadata:
-            name: numaflow-server
+            name: numaflow-server{{.InstanceID}}
           spec:
             ports:
             - port: 8443
@@ -558,7 +558,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-controller
+            name: numaflow-controller{{.InstanceID}}
           spec:
             replicas: 1
             selector:
@@ -587,37 +587,37 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_DISABLED
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.disabled
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.duration
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.deadline
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
                     valueFrom:
                       configMapKeyRef:
                         key: controller.leader.election.lease.renew.period
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -650,27 +650,27 @@ data:
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-sa
+                serviceAccountName: numaflow-sa{{.InstanceID}}
                 volumes:
                 - configMap:
-                    name: numaflow-controller-config
+                    name: numaflow-controller-config{{.InstanceID}}
                   name: controller-config-volume
           ---
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-dex-server
+            name: numaflow-dex-server{{.InstanceID}}
           spec:
             selector:
               matchLabels:
                 app.kubernetes.io/component: dex-server
-                app.kubernetes.io/name: numaflow-dex-server
+                app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
                 app.kubernetes.io/part-of: numaflow
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: dex-server
-                  app.kubernetes.io/name: numaflow-dex-server
+                  app.kubernetes.io/name: numaflow-dex-server{{.InstanceID}}
                   app.kubernetes.io/part-of: numaflow
               spec:
                 containers:
@@ -683,12 +683,12 @@ data:
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-id
-                        name: numaflow-dex-secrets
+                        name: numaflow-dex-secrets{{.InstanceID}}
                   - name: GITHUB_CLIENT_SECRET
                     valueFrom:
                       secretKeyRef:
                         key: dex-github-client-secret
-                        name: numaflow-dex-secrets
+                        name: numaflow-dex-secrets{{.InstanceID}}
                   image: dexidp/dex:v2.37.0
                   imagePullPolicy: Always
                   name: dex
@@ -712,13 +712,13 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -730,13 +730,13 @@ data:
                     name: tls
                   - mountPath: /tmp
                     name: generated-dex-config
-                serviceAccountName: numaflow-dex-server
+                serviceAccountName: numaflow-dex-server{{.InstanceID}}
                 volumes:
                 - configMap:
                     items:
                     - key: config.yaml
                       path: config.yaml
-                    name: numaflow-dex-server-config
+                    name: numaflow-dex-server-config{{.InstanceID}}
                   name: connector-config
                 - emptyDir: {}
                   name: tls
@@ -746,7 +746,7 @@ data:
           apiVersion: apps/v1
           kind: Deployment
           metadata:
-            name: numaflow-server
+            name: numaflow-server{{.InstanceID}}
           spec:
             replicas: 1
             selector:
@@ -773,67 +773,67 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.insecure
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_PORT_NUMBER
                     valueFrom:
                       configMapKeyRef:
                         key: server.port
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_NAMESPACED
                     valueFrom:
                       configMapKeyRef:
                         key: namespaced
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_MANAGED_NAMESPACE
                     valueFrom:
                       configMapKeyRef:
                         key: managed.namespace
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_BASE_HREF
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_READONLY
                     valueFrom:
                       configMapKeyRef:
                         key: server.readonly
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_DISABLE_AUTH
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_DEX_SERVER_ADDR
                     valueFrom:
                       configMapKeyRef:
                         key: server.dex.server
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_ADDRESS
                     valueFrom:
                       configMapKeyRef:
                         key: server.address
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_CORS_ALLOWED_ORIGINS
                     valueFrom:
                       configMapKeyRef:
                         key: server.cors.allowed.origins
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   - name: NUMAFLOW_SERVER_DAEMON_CLIENT_PROTOCOL
                     valueFrom:
                       configMapKeyRef:
                         key: server.daemon.client.protocol
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -869,7 +869,7 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.base.href
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -888,7 +888,7 @@ data:
                     valueFrom:
                       configMapKeyRef:
                         key: server.disable.auth
-                        name: numaflow-cmd-params-config
+                        name: numaflow-cmd-params-config{{.InstanceID}}
                         optional: true
                   image: quay.io/numaproj/numaflow:v1.3.3
                   imagePullPolicy: Always
@@ -896,10 +896,10 @@ data:
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
-                serviceAccountName: numaflow-server-sa
+                serviceAccountName: numaflow-server-sa{{.InstanceID}}
                 volumes:
                 - emptyDir: {}
                   name: env-volume
                 - configMap:
-                    name: numaflow-server-rbac-config
+                    name: numaflow-server-rbac-config{{.InstanceID}}
                   name: rbac-config


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Added instanceID to the NumaflowControllerRollout spec and templated the definitions config to include the instanceID.

### Verification

Manually tested that multiple instances are deployed and "tagged" (resource name suffixed) by the instanceID defined in the NumaflowControllerRollout spec. Added unit tests for func `resolveManifestTemplate`.
