### PR TITLE
feat: Incorporate metadata into the USDE check

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -67,6 +67,9 @@ const (
 	// LabelValueUpgradeRecyclable is the label value indicating that the resource managed by a NumaRollout is recyclable
 	// after an upgrade.
 	LabelValueUpgradeRecyclable UpgradeState = "recyclable"
+
+	// AnnotationKeyNumaflowInstanceID is the annotation passed to Numaflow Controller so it knows whether it should reconcile the resource
+	AnnotationKeyNumaflowInstanceID = "numaflow.numaproj.io/instance"
 )
 
 var (

--- a/internal/usde/usde.go
+++ b/internal/usde/usde.go
@@ -11,13 +11,32 @@ import (
 	"github.com/numaproj/numaplane/internal/util/logger"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaplane/internal/common"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
 // ResourceNeedsUpdating calculates the upgrade strategy to use during the
 // resource reconciliation process based on configuration and user preference (see design doc for details).
 // It returns the strategy to use and a boolean pointer indicating if the specs are different (if the specs were not compared, then nil will be returned).
-func ResourceNeedsUpdating(ctx context.Context, newSpec *kubernetes.GenericObject, existingSpec *kubernetes.GenericObject) (bool, apiv1.UpgradeStrategy, error) {
+func ResourceNeedsUpdating(ctx context.Context, newDef *kubernetes.GenericObject, existingDef *kubernetes.GenericObject) (bool, apiv1.UpgradeStrategy, error) {
+
+	metadataNeedsUpdating, metadataUpgradeStrategy, err := resourceMetadataNeedsUpdating(ctx, newDef, existingDef)
+	if err != nil {
+		return false, apiv1.UpgradeStrategyError, err
+	}
+
+	specNeedsUpdating, specUpgradeStrategy, err := resourceSpecNeedsUpdating(ctx, newDef, existingDef)
+	if err != nil {
+		return false, apiv1.UpgradeStrategyError, err
+	}
+	if !metadataNeedsUpdating && !specNeedsUpdating {
+		return false, apiv1.UpgradeStrategyNoOp, nil
+	}
+	return true, getMostConservativeStrategy([]apiv1.UpgradeStrategy{metadataUpgradeStrategy, specUpgradeStrategy}), nil
+
+}
+
+func resourceSpecNeedsUpdating(ctx context.Context, newDef *kubernetes.GenericObject, existingDef *kubernetes.GenericObject) (bool, apiv1.UpgradeStrategy, error) {
 
 	numaLogger := logger.FromContext(ctx)
 
@@ -26,16 +45,16 @@ func ResourceNeedsUpdating(ctx context.Context, newSpec *kubernetes.GenericObjec
 
 	// Get apply paths based on the spec type (Pipeline, ISBS)
 	applyPaths := []string{}
-	if reflect.DeepEqual(newSpec.GroupVersionKind(), numaflowv1.PipelineGroupVersionKind) {
+	if reflect.DeepEqual(newDef.GroupVersionKind(), numaflowv1.PipelineGroupVersionKind) {
 		applyPaths = usdeConfig.PipelineSpecExcludedPaths
-	} else if reflect.DeepEqual(newSpec.GroupVersionKind(), numaflowv1.ISBGroupVersionKind) {
+	} else if reflect.DeepEqual(newDef.GroupVersionKind(), numaflowv1.ISBGroupVersionKind) {
 		applyPaths = usdeConfig.ISBServiceSpecExcludedPaths
 	}
 
 	numaLogger.WithValues("usdeConfig", usdeConfig, "applyPaths", applyPaths).Debug("started deriving upgrade strategy")
 
-	// Split newSpec
-	newSpecOnlyApplyPaths, newSpecWithoutApplyPaths, err := util.SplitObject(newSpec.Spec.Raw, applyPaths, []string{}, ".")
+	// Split newDef
+	newSpecOnlyApplyPaths, newSpecWithoutApplyPaths, err := util.SplitObject(newDef.Spec.Raw, applyPaths, []string{}, ".")
 	if err != nil {
 		return false, apiv1.UpgradeStrategyError, err
 	}
@@ -45,8 +64,8 @@ func ResourceNeedsUpdating(ctx context.Context, newSpec *kubernetes.GenericObjec
 		"newSpecWithoutApplyPaths", newSpecWithoutApplyPaths,
 	).Debug("split new spec")
 
-	// Split existingSpec
-	existingSpecOnlyApplyPaths, existingSpecWithoutApplyPaths, err := util.SplitObject(existingSpec.Spec.Raw, applyPaths, []string{}, ".")
+	// Split existingDef
+	existingSpecOnlyApplyPaths, existingSpecWithoutApplyPaths, err := util.SplitObject(existingDef.Spec.Raw, applyPaths, []string{}, ".")
 	if err != nil {
 		return false, apiv1.UpgradeStrategyError, err
 	}
@@ -58,27 +77,18 @@ func ResourceNeedsUpdating(ctx context.Context, newSpec *kubernetes.GenericObjec
 
 	// Compare specs without the apply fields and check user's strategy to return their preferred strategy
 	if !reflect.DeepEqual(newSpecWithoutApplyPaths, existingSpecWithoutApplyPaths) {
-		userUpgradeStrategy, err := GetUserStrategy(ctx, newSpec.Namespace)
+		upgradeStrategy, err := getDataLossUpggradeStrategy(ctx, newDef.Namespace)
 		if err != nil {
 			return false, apiv1.UpgradeStrategyError, err
 		}
 
 		numaLogger.WithValues(
-			"userUpgradeStrategy", userUpgradeStrategy,
+			"upgradeStrategy", upgradeStrategy,
 			"newSpecWithoutApplyPaths", newSpecWithoutApplyPaths,
 			"existingSpecWithoutApplyPaths", existingSpecWithoutApplyPaths,
 		).Debug("the specs without the 'apply' paths are different")
 
-		switch userUpgradeStrategy {
-		case config.PPNDStrategyID:
-			return true, apiv1.UpgradeStrategyPPND, nil
-		case config.ProgressiveStrategyID:
-			return true, apiv1.UpgradeStrategyProgressive, nil
-		case config.NoStrategyID:
-			return true, apiv1.UpgradeStrategyApply, nil
-		default:
-			return false, apiv1.UpgradeStrategyError, fmt.Errorf("invalid Upgrade Strategy: %v", userUpgradeStrategy)
-		}
+		return true, upgradeStrategy, nil
 	}
 
 	// Compare specs with the apply fields
@@ -95,6 +105,66 @@ func ResourceNeedsUpdating(ctx context.Context, newSpec *kubernetes.GenericObjec
 
 	// Return NoOp if no differences were found between the new and existing specs
 	return false, apiv1.UpgradeStrategyNoOp, nil
+
+}
+
+func getMostConservativeStrategy(strategies []apiv1.UpgradeStrategy) apiv1.UpgradeStrategy {
+	strategy := apiv1.UpgradeStrategyNoOp
+	for _, s := range strategies {
+		if strategyRating[s] > strategyRating[strategy] {
+			strategy = s
+		}
+	}
+	return strategy
+}
+
+var (
+	strategyRating map[apiv1.UpgradeStrategy]int = map[apiv1.UpgradeStrategy]int{
+		apiv1.UpgradeStrategyNoOp:        0,
+		apiv1.UpgradeStrategyApply:       1,
+		apiv1.UpgradeStrategyPPND:        2,
+		apiv1.UpgradeStrategyProgressive: 2,
+	}
+)
+
+func resourceMetadataNeedsUpdating(ctx context.Context, newDef *kubernetes.GenericObject, existingDef *kubernetes.GenericObject) (bool, apiv1.UpgradeStrategy, error) {
+	upgradeStrategy, err := getDataLossUpggradeStrategy(ctx, newDef.Namespace)
+	if err != nil {
+		return false, apiv1.UpgradeStrategyError, err
+	}
+
+	// First look for Label or Annotation changes that require PPND or Progressive strategy
+	// TODO: make this configurable to look for particular Labels and Annotations rather than this specific one
+	instanceIDNew := newDef.Annotations[common.AnnotationKeyNumaflowInstanceID]
+	instanceIDExisting := existingDef.Annotations[common.AnnotationKeyNumaflowInstanceID]
+	if instanceIDNew != instanceIDExisting {
+		return true, upgradeStrategy, nil
+	}
+
+	// now see if any Labels or Annotations changed at all
+	if !reflect.DeepEqual(newDef.Labels, existingDef.Labels) || !reflect.DeepEqual(newDef.Annotations, existingDef.Annotations) {
+		return true, apiv1.UpgradeStrategyApply, nil
+	}
+	return false, apiv1.UpgradeStrategyNoOp, nil
+}
+
+// return the upgrade strategy that represents what the user prefers to do when there's a concern for data loss
+func getDataLossUpggradeStrategy(ctx context.Context, namespace string) (apiv1.UpgradeStrategy, error) {
+	userUpgradeStrategy, err := GetUserStrategy(ctx, namespace)
+	if err != nil {
+		return apiv1.UpgradeStrategyError, err
+	}
+
+	switch userUpgradeStrategy {
+	case config.PPNDStrategyID:
+		return apiv1.UpgradeStrategyPPND, nil
+	case config.ProgressiveStrategyID:
+		return apiv1.UpgradeStrategyProgressive, nil
+	case config.NoStrategyID:
+		return apiv1.UpgradeStrategyApply, nil
+	default:
+		return apiv1.UpgradeStrategyError, fmt.Errorf("invalid Upgrade Strategy: %v", userUpgradeStrategy)
+	}
 }
 
 func GetUserStrategy(ctx context.Context, namespace string) (config.USDEUserStrategy, error) {

--- a/internal/usde/usde.go
+++ b/internal/usde/usde.go
@@ -17,7 +17,7 @@ import (
 
 // ResourceNeedsUpdating calculates the upgrade strategy to use during the
 // resource reconciliation process based on configuration and user preference (see design doc for details).
-// It returns the strategy to use and a boolean pointer indicating if the specs are different (if the specs were not compared, then nil will be returned).
+// It returns whether an update is needed and the strategy to use
 func ResourceNeedsUpdating(ctx context.Context, newDef *kubernetes.GenericObject, existingDef *kubernetes.GenericObject) (bool, apiv1.UpgradeStrategy, error) {
 
 	metadataNeedsUpdating, metadataUpgradeStrategy, err := resourceMetadataNeedsUpdating(ctx, newDef, existingDef)

--- a/internal/usde/usde_test.go
+++ b/internal/usde/usde_test.go
@@ -149,7 +149,7 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 		expectedStrategy      apiv1.UpgradeStrategy
 	}{
 		{
-			name: "empty pipeline spec excluded paths",
+			name: "NoOp: empty pipeline spec excluded paths, and equivalent metadata",
 			newDefinition: func() kubernetes.GenericObject {
 				pipelineDef := pipelineDefn
 				pipelineDef.Annotations = map[string]string{"something": "a"}

--- a/internal/usde/usde_test.go
+++ b/internal/usde/usde_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/stretchr/testify/assert"
@@ -140,17 +141,17 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 
 	testCases := []struct {
 		name                  string
-		newSpec               kubernetes.GenericObject
-		existingSpec          kubernetes.GenericObject
+		newDefinition         kubernetes.GenericObject
+		existingDefinition    kubernetes.GenericObject
 		usdeConfig            config.USDEConfig
 		namespaceConfig       *config.NamespaceConfig
 		expectedNeedsUpdating bool
 		expectedStrategy      apiv1.UpgradeStrategy
 	}{
 		{
-			name:         "empty pipeline spec excluded paths",
-			newSpec:      pipelineDefn,
-			existingSpec: pipelineDefn,
+			name:               "empty pipeline spec excluded paths",
+			newDefinition:      pipelineDefn,
+			existingDefinition: pipelineDefn,
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
 				PipelineSpecExcludedPaths: []string{},
@@ -160,12 +161,12 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyNoOp,
 		},
 		{
-			name:    "empty pipeline spec excluded paths and change interStepBufferServiceName field",
-			newSpec: pipelineDefn,
-			existingSpec: func() kubernetes.GenericObject {
-				newPipelineSpec := defaultPipelineSpec.DeepCopy()
-				newPipelineSpec.InterStepBufferServiceName = "changed-isbsvc"
-				return makePipelineDefinition(*newPipelineSpec)
+			name:          "empty pipeline spec excluded paths and change interStepBufferServiceName field",
+			newDefinition: pipelineDefn,
+			existingDefinition: func() kubernetes.GenericObject {
+				newPipelineDef := defaultPipelineSpec.DeepCopy()
+				newPipelineDef.InterStepBufferServiceName = "changed-isbsvc"
+				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
@@ -176,12 +177,12 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyPPND,
 		},
 		{
-			name:    "only exclude interStepBufferServiceName field (changed)",
-			newSpec: pipelineDefn,
-			existingSpec: func() kubernetes.GenericObject {
-				newPipelineSpec := defaultPipelineSpec.DeepCopy()
-				newPipelineSpec.InterStepBufferServiceName = "changed-isbsvc"
-				return makePipelineDefinition(*newPipelineSpec)
+			name:          "only exclude interStepBufferServiceName field (changed)",
+			newDefinition: pipelineDefn,
+			existingDefinition: func() kubernetes.GenericObject {
+				newPipelineDef := defaultPipelineSpec.DeepCopy()
+				newPipelineDef.InterStepBufferServiceName = "changed-isbsvc"
+				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
@@ -192,9 +193,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyApply,
 		},
 		{
-			name:         "only exclude interStepBufferServiceName field (NOT changed)",
-			newSpec:      pipelineDefn,
-			existingSpec: pipelineDefn,
+			name:               "only exclude interStepBufferServiceName field (NOT changed)",
+			newDefinition:      pipelineDefn,
+			existingDefinition: pipelineDefn,
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
 				PipelineSpecExcludedPaths: []string{"interStepBufferServiceName"},
@@ -204,12 +205,12 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyNoOp,
 		},
 		{
-			name:    "only exclude interStepBufferServiceName field and change some other field (no user strategy)",
-			newSpec: pipelineDefn,
-			existingSpec: func() kubernetes.GenericObject {
-				newPipelineSpec := defaultPipelineSpec.DeepCopy()
-				newPipelineSpec.Vertices[0].Name = "new-vtx-name"
-				return makePipelineDefinition(*newPipelineSpec)
+			name:          "only exclude interStepBufferServiceName field and change some other field (no user strategy)",
+			newDefinition: pipelineDefn,
+			existingDefinition: func() kubernetes.GenericObject {
+				newPipelineDef := defaultPipelineSpec.DeepCopy()
+				newPipelineDef.Vertices[0].Name = "new-vtx-name"
+				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
@@ -220,12 +221,12 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyPPND,
 		},
 		{
-			name:    "only exclude interStepBufferServiceName field and change some other field (with invalid user strategy)",
-			newSpec: pipelineDefn,
-			existingSpec: func() kubernetes.GenericObject {
-				newPipelineSpec := defaultPipelineSpec.DeepCopy()
-				newPipelineSpec.Vertices[0].Name = "new-vtx-name"
-				return makePipelineDefinition(*newPipelineSpec)
+			name:          "only exclude interStepBufferServiceName field and change some other field (with invalid user strategy)",
+			newDefinition: pipelineDefn,
+			existingDefinition: func() kubernetes.GenericObject {
+				newPipelineDef := defaultPipelineSpec.DeepCopy()
+				newPipelineDef.Vertices[0].Name = "new-vtx-name"
+				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
@@ -236,12 +237,12 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyPPND,
 		},
 		{
-			name:    "only exclude interStepBufferServiceName field and change some other field (with valid user strategy)",
-			newSpec: pipelineDefn,
-			existingSpec: func() kubernetes.GenericObject {
-				newPipelineSpec := defaultPipelineSpec.DeepCopy()
-				newPipelineSpec.Vertices[0].Name = "new-vtx-name"
-				return makePipelineDefinition(*newPipelineSpec)
+			name:          "only exclude interStepBufferServiceName field and change some other field (with valid user strategy)",
+			newDefinition: pipelineDefn,
+			existingDefinition: func() kubernetes.GenericObject {
+				newPipelineDef := defaultPipelineSpec.DeepCopy()
+				newPipelineDef.Vertices[0].Name = "new-vtx-name"
+				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
@@ -252,14 +253,14 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyPPND,
 		},
 		{
-			name:    "with changes in array deep map but excluded",
-			newSpec: pipelineDefn,
-			existingSpec: func() kubernetes.GenericObject {
+			name:          "with changes in array deep map but excluded",
+			newDefinition: pipelineDefn,
+			existingDefinition: func() kubernetes.GenericObject {
 				newRPU := int64(10)
-				newPipelineSpec := defaultPipelineSpec.DeepCopy()
-				newPipelineSpec.InterStepBufferServiceName = "changed-isbsvc"
-				newPipelineSpec.Vertices[0].Source.Generator.RPU = &newRPU
-				return makePipelineDefinition(*newPipelineSpec)
+				newPipelineDef := defaultPipelineSpec.DeepCopy()
+				newPipelineDef.InterStepBufferServiceName = "changed-isbsvc"
+				newPipelineDef.Vertices[0].Source.Generator.RPU = &newRPU
+				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
@@ -270,14 +271,14 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyApply,
 		},
 		{
-			name:    "with changes in array deep map but excluded parent",
-			newSpec: pipelineDefn,
-			existingSpec: func() kubernetes.GenericObject {
+			name:          "with changes in array deep map but excluded parent",
+			newDefinition: pipelineDefn,
+			existingDefinition: func() kubernetes.GenericObject {
 				newRPU := int64(10)
-				newPipelineSpec := defaultPipelineSpec.DeepCopy()
-				newPipelineSpec.InterStepBufferServiceName = "changed-isbsvc"
-				newPipelineSpec.Vertices[0].Source.Generator.RPU = &newRPU
-				return makePipelineDefinition(*newPipelineSpec)
+				newPipelineDef := defaultPipelineSpec.DeepCopy()
+				newPipelineDef.InterStepBufferServiceName = "changed-isbsvc"
+				newPipelineDef.Vertices[0].Source.Generator.RPU = &newRPU
+				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
@@ -288,15 +289,15 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyApply,
 		},
 		{
-			name:    "with changes in array deep map but one is NOT excluded",
-			newSpec: pipelineDefn,
-			existingSpec: func() kubernetes.GenericObject {
+			name:          "with changes in array deep map but one is NOT excluded",
+			newDefinition: pipelineDefn,
+			existingDefinition: func() kubernetes.GenericObject {
 				newRPU := int64(10)
-				newPipelineSpec := defaultPipelineSpec.DeepCopy()
-				newPipelineSpec.Vertices[0].Name = "new-vtx-name"
-				newPipelineSpec.InterStepBufferServiceName = "changed-isbsvc"
-				newPipelineSpec.Vertices[0].Source.Generator.RPU = &newRPU
-				return makePipelineDefinition(*newPipelineSpec)
+				newPipelineDef := defaultPipelineSpec.DeepCopy()
+				newPipelineDef.Vertices[0].Name = "new-vtx-name"
+				newPipelineDef.InterStepBufferServiceName = "changed-isbsvc"
+				newPipelineDef.Vertices[0].Source.Generator.RPU = &newRPU
+				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
@@ -307,13 +308,13 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyPPND,
 		},
 		{
-			name:    "with changes in array deep map - detect pointer fields",
-			newSpec: pipelineDefn,
-			existingSpec: func() kubernetes.GenericObject {
-				newPipelineSpec := defaultPipelineSpec.DeepCopy()
-				newPipelineSpec.Vertices[2].Sink.Log = nil
-				newPipelineSpec.Vertices[2].Sink.Blackhole = &numaflowv1.Blackhole{}
-				return makePipelineDefinition(*newPipelineSpec)
+			name:          "with changes in array deep map - detect pointer fields",
+			newDefinition: pipelineDefn,
+			existingDefinition: func() kubernetes.GenericObject {
+				newPipelineDef := defaultPipelineSpec.DeepCopy()
+				newPipelineDef.Vertices[2].Sink.Log = nil
+				newPipelineDef.Vertices[2].Sink.Blackhole = &numaflowv1.Blackhole{}
+				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
@@ -324,13 +325,13 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyPPND,
 		},
 		{
-			name:    "with changes in array deep map - detect pointer fields - parent field is excluded",
-			newSpec: pipelineDefn,
-			existingSpec: func() kubernetes.GenericObject {
-				newPipelineSpec := defaultPipelineSpec.DeepCopy()
-				newPipelineSpec.Vertices[2].Sink.Log = nil
-				newPipelineSpec.Vertices[2].Sink.Blackhole = &numaflowv1.Blackhole{}
-				return makePipelineDefinition(*newPipelineSpec)
+			name:          "with changes in array deep map - detect pointer fields - parent field is excluded",
+			newDefinition: pipelineDefn,
+			existingDefinition: func() kubernetes.GenericObject {
+				newPipelineDef := defaultPipelineSpec.DeepCopy()
+				newPipelineDef.Vertices[2].Sink.Log = nil
+				newPipelineDef.Vertices[2].Sink.Blackhole = &numaflowv1.Blackhole{}
+				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
@@ -341,9 +342,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyApply,
 		},
 		{
-			name:         "excluded paths not found",
-			newSpec:      pipelineDefn,
-			existingSpec: pipelineDefn,
+			name:               "excluded paths not found",
+			newDefinition:      pipelineDefn,
+			existingDefinition: pipelineDefn,
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
 				PipelineSpecExcludedPaths: []string{"vertices.source.something"},
@@ -353,9 +354,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyNoOp,
 		},
 		{
-			name:    "isb test",
-			newSpec: isbServiceDefn,
-			existingSpec: func() kubernetes.GenericObject {
+			name:          "isb test",
+			newDefinition: isbServiceDefn,
+			existingDefinition: func() kubernetes.GenericObject {
 				newISBServiceSpec := defaultISBServiceSpec.DeepCopy()
 				newISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits = v1.ResourceList{v1.ResourceMemory: newMemLimit}
 				return makeISBServiceDefinition(*newISBServiceSpec)
@@ -369,6 +370,24 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedNeedsUpdating: true,
 			expectedStrategy:      apiv1.UpgradeStrategyApply,
 		},
+		{
+			name:          "test Annotation change plus spec change resulting in Direct Apply",
+			newDefinition: pipelineDefn,
+			existingDefinition: func() kubernetes.GenericObject {
+				newPipelineSpec := defaultPipelineSpec.DeepCopy()
+				newPipelineSpec.InterStepBufferServiceName = "changed-isbsvc"
+				pipelineDef := makePipelineDefinition(*newPipelineSpec)
+				pipelineDef.Annotations = map[string]string{common.AnnotationKeyNumaflowInstanceID: "1"}
+				return pipelineDef
+			}(),
+			usdeConfig: config.USDEConfig{
+				DefaultUpgradeStrategy:    config.ProgressiveStrategyID,
+				PipelineSpecExcludedPaths: []string{"interStepBufferServiceName"},
+			},
+			namespaceConfig:       nil,
+			expectedNeedsUpdating: true,
+			expectedStrategy:      apiv1.UpgradeStrategyProgressive,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -380,10 +399,48 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				configManager.UnsetNamespaceConfig(defaultNamespace)
 			}
 
-			needsUpdating, strategy, err := ResourceNeedsUpdating(ctx, &tc.newSpec, &tc.existingSpec)
+			needsUpdating, strategy, err := ResourceNeedsUpdating(ctx, &tc.newDefinition, &tc.existingDefinition)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedNeedsUpdating, needsUpdating)
 			assert.Equal(t, tc.expectedStrategy, strategy)
+		})
+	}
+}
+
+func TestGetMostConservativeStrategy(t *testing.T) {
+	tests := []struct {
+		name                   string
+		strategies             []apiv1.UpgradeStrategy
+		expectedStrategyRating int
+	}{
+		{
+			name: "Multiple Strategies",
+			strategies: []apiv1.UpgradeStrategy{
+				apiv1.UpgradeStrategyNoOp,
+				apiv1.UpgradeStrategyApply,
+				apiv1.UpgradeStrategyPPND,
+			},
+			expectedStrategyRating: 2,
+		},
+		{
+			name:                   "Empty List",
+			strategies:             []apiv1.UpgradeStrategy{},
+			expectedStrategyRating: 0,
+		},
+		{
+			name: "Same Rating",
+			strategies: []apiv1.UpgradeStrategy{
+				apiv1.UpgradeStrategyPPND,
+				apiv1.UpgradeStrategyProgressive,
+			},
+			expectedStrategyRating: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getMostConservativeStrategy(tt.strategies)
+			assert.Equal(t, tt.expectedStrategyRating, strategyRating[result])
 		})
 	}
 }

--- a/internal/usde/usde_test.go
+++ b/internal/usde/usde_test.go
@@ -149,9 +149,19 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 		expectedStrategy      apiv1.UpgradeStrategy
 	}{
 		{
-			name:               "empty pipeline spec excluded paths",
-			newDefinition:      pipelineDefn,
-			existingDefinition: pipelineDefn,
+			name: "empty pipeline spec excluded paths",
+			newDefinition: func() kubernetes.GenericObject {
+				pipelineDef := pipelineDefn
+				pipelineDef.Annotations = map[string]string{"something": "a"}
+				pipelineDef.Labels = map[string]string{"something": "a"}
+				return pipelineDef
+			}(),
+			existingDefinition: func() kubernetes.GenericObject {
+				pipelineDef := pipelineDefn
+				pipelineDef.Annotations = map[string]string{"something": "a"}
+				pipelineDef.Labels = map[string]string{"something": "a"}
+				return pipelineDef
+			}(),
 			usdeConfig: config.USDEConfig{
 				DefaultUpgradeStrategy:    config.PPNDStrategyID,
 				PipelineSpecExcludedPaths: []string{},
@@ -371,13 +381,39 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			expectedStrategy:      apiv1.UpgradeStrategyApply,
 		},
 		{
-			name:          "test Annotation change plus spec change resulting in Direct Apply",
-			newDefinition: pipelineDefn,
+			name: "test Annotation changes resulting in Direct Apply",
+			newDefinition: func() kubernetes.GenericObject {
+				pipelineDef := pipelineDefn
+				pipelineDef.Annotations = map[string]string{"something": "a"}
+				return pipelineDef
+			}(),
+			existingDefinition: func() kubernetes.GenericObject {
+				pipelineDef := pipelineDefn
+				pipelineDef.Annotations = map[string]string{"something": "b"}
+				return pipelineDef
+			}(),
+			usdeConfig: config.USDEConfig{
+				DefaultUpgradeStrategy:    config.PPNDStrategyID,
+				PipelineSpecExcludedPaths: []string{},
+			},
+			namespaceConfig:       nil,
+			expectedNeedsUpdating: true,
+			expectedStrategy:      apiv1.UpgradeStrategyApply,
+		},
+		{
+			name: "test Annotation change which requires Progressive update, overriding spec change resulting in Direct Apply",
+			newDefinition: func() kubernetes.GenericObject {
+				pipelineDef := pipelineDefn
+				pipelineDef.Annotations = map[string]string{common.AnnotationKeyNumaflowInstanceID: "0"}
+				pipelineDef.Labels = map[string]string{"something": "a"}
+				return pipelineDef
+			}(),
 			existingDefinition: func() kubernetes.GenericObject {
 				newPipelineSpec := defaultPipelineSpec.DeepCopy()
 				newPipelineSpec.InterStepBufferServiceName = "changed-isbsvc"
 				pipelineDef := makePipelineDefinition(*newPipelineSpec)
 				pipelineDef.Annotations = map[string]string{common.AnnotationKeyNumaflowInstanceID: "1"}
+				pipelineDef.Labels = map[string]string{"something": "b"}
 				return pipelineDef
 			}(),
 			usdeConfig: config.USDEConfig{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

This updates the USDE `ResourceNeedsUpdating()` call to compare not just specs but also metadata (Labels and Annotations).

Note that this code will be improved later, but for now what it does is:
- consider just the "Instance" annotation as one which requires PPND or Progressive (I think PPND and Progressive both apply if you're changing which Controller to use)
- if any other Label or Annotation changes, return DirectApply

Then take the most conservative strategy returned from comparing `Metadata` and from comparing `Spec`.

Note that the caller merges the new and existing child definitions together to create the updated "new definition" (i.e. existing Labels/Annotations with overriding Labels/Annotations coming from the Rollout definition). Therefore, it should work to compare that "new definition" with the existing definition from Kubernetes.


### Verification

I've tested this through unit test only. Once Dillen incorporates the Labels and Annotations from the Rollout specs, this can be tested more thoroughly.