### PR TITLE
fix: reverse use of "key" and "val" naming in map traversal

### DIFF
--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -291,11 +291,11 @@ func mergeISBService(existingISBService, newISBService *kubernetes.GenericObject
 	resultISBService := existingISBService.DeepCopy()
 	resultISBService.Spec = *newISBService.Spec.DeepCopy()
 
-	for val, key := range newISBService.Annotations {
-		resultISBService.Annotations[val] = key
+	for key, val := range newISBService.Annotations {
+		resultISBService.Annotations[key] = val
 	}
-	for val, key := range newISBService.Labels {
-		resultISBService.Labels[val] = key
+	for key, val := range newISBService.Labels {
+		resultISBService.Labels[key] = val
 	}
 
 	return resultISBService

--- a/internal/controller/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout_controller.go
@@ -255,11 +255,11 @@ func mergeMonoVertex(existingMonoVertex *kubernetes.GenericObject, newMonoVertex
 	resultMonoVertex := existingMonoVertex.DeepCopy()
 	resultMonoVertex.Spec = *newMonoVertex.Spec.DeepCopy()
 
-	for val, key := range newMonoVertex.Annotations {
-		resultMonoVertex.Annotations[val] = key
+	for key, val := range newMonoVertex.Annotations {
+		resultMonoVertex.Annotations[key] = val
 	}
-	for val, key := range newMonoVertex.Labels {
-		resultMonoVertex.Labels[val] = key
+	for key, val := range newMonoVertex.Labels {
+		resultMonoVertex.Labels[key] = val
 	}
 
 	return resultMonoVertex


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

The names `key` and `val` were reversed


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->