### PR TITLE
fix: added instanceID to configmap and created instance labels

### DIFF
--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -471,8 +471,10 @@ func resolveManifestTemplate(manifest string, rollout *apiv1.NumaflowControllerR
 
 	data := struct {
 		InstanceSuffix string
+		InstanceID     string
 	}{
 		InstanceSuffix: instanceSuffix,
+		InstanceID:     instanceID,
 	}
 
 	var buf bytes.Buffer

--- a/internal/controller/numaflowcontrollerrollout_controller_test.go
+++ b/internal/controller/numaflowcontrollerrollout_controller_test.go
@@ -382,7 +382,7 @@ func Test_resolveManifestTemplate(t *testing.T) {
 			manifest:         "this is {{.Invalid}} invalid",
 			rollout:          defaultRollout,
 			expectedManifest: "",
-			expectedError:    fmt.Errorf("unable to apply information to manifest: template: manifest:1:10: executing \"manifest\" at <.Invalid>: can't evaluate field Invalid in type struct { InstanceSuffix string }"),
+			expectedError:    fmt.Errorf("unable to apply information to manifest: template: manifest:1:10: executing \"manifest\" at <.Invalid>: can't evaluate field Invalid in type struct { InstanceSuffix string; InstanceID string }"),
 		}, {
 			name:     "manifest with valid template and rollout without instanceID",
 			manifest: "valid-template-no-id{{.InstanceSuffix}}",

--- a/tests/manifests/default/controller_def_1.3.3-copy1.yaml
+++ b/tests/manifests/default/controller_def_1.3.3-copy1.yaml
@@ -32,6 +32,7 @@ data:
               app.kubernetes.io/component: dex-server
               app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-dex-server{{ .InstanceSuffix }}
           rules:
           - apiGroups:
@@ -51,6 +52,7 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
@@ -158,6 +160,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
@@ -224,6 +227,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-secrets-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
@@ -243,6 +247,7 @@ data:
               app.kubernetes.io/component: dex-server
               app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-dex-server{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
@@ -259,6 +264,7 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-role-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
@@ -275,6 +281,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
@@ -291,6 +298,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-secrets-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
@@ -541,6 +549,7 @@ data:
               app.kubernetes.io/component: dex-server
               app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
           ---
           apiVersion: v1
           kind: Service
@@ -554,6 +563,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             type: ClusterIP
           ---
           apiVersion: apps/v1
@@ -567,12 +577,14 @@ data:
                 app.kubernetes.io/component: controller-manager
                 app.kubernetes.io/name: controller-manager
                 app.kubernetes.io/part-of: numaflow
+                app.kubernetes.io/instance: "{{ .InstanceID }}"
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: controller-manager
                   app.kubernetes.io/name: controller-manager
                   app.kubernetes.io/part-of: numaflow
+                  app.kubernetes.io/instance: "{{ .InstanceID }}"
               spec:
                 containers:
                 - args:
@@ -667,12 +679,14 @@ data:
                 app.kubernetes.io/component: dex-server
                 app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
                 app.kubernetes.io/part-of: numaflow
+                app.kubernetes.io/instance: "{{ .InstanceID }}"
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: dex-server
                   app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
                   app.kubernetes.io/part-of: numaflow
+                  app.kubernetes.io/instance: "{{ .InstanceID }}"
               spec:
                 containers:
                 - command:
@@ -755,12 +769,14 @@ data:
                 app.kubernetes.io/component: numaflow-ux
                 app.kubernetes.io/name: numaflow-ux
                 app.kubernetes.io/part-of: numaflow
+                app.kubernetes.io/instance: "{{ .InstanceID }}"
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: numaflow-ux
                   app.kubernetes.io/name: numaflow-ux
                   app.kubernetes.io/part-of: numaflow
+                  app.kubernetes.io/instance: "{{ .InstanceID }}"
               spec:
                 containers:
                 - args:

--- a/tests/manifests/default/controller_def_1.3.3-copy1.yaml
+++ b/tests/manifests/default/controller_def_1.3.3-copy1.yaml
@@ -311,6 +311,7 @@ data:
           apiVersion: v1
           data:
             controller-config.yaml: |
+              instance: "{{ .InstanceID }}"
               defaults:
                 containerResources: |
                   requests:

--- a/tests/manifests/default/controller_def_1.3.3.yaml
+++ b/tests/manifests/default/controller_def_1.3.3.yaml
@@ -32,6 +32,7 @@ data:
               app.kubernetes.io/component: dex-server
               app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-dex-server{{ .InstanceSuffix }}
           rules:
           - apiGroups:
@@ -51,6 +52,7 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
@@ -158,6 +160,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
@@ -224,6 +227,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-secrets-role{{ .InstanceSuffix }}
           rules:
           - apiGroups:
@@ -243,6 +247,7 @@ data:
               app.kubernetes.io/component: dex-server
               app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-dex-server{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
@@ -259,6 +264,7 @@ data:
               app.kubernetes.io/component: controller-manager
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-role-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
@@ -275,6 +281,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
@@ -291,6 +298,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-secrets-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
@@ -541,6 +549,7 @@ data:
               app.kubernetes.io/component: dex-server
               app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
           ---
           apiVersion: v1
           kind: Service
@@ -554,6 +563,7 @@ data:
               app.kubernetes.io/component: numaflow-ux
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
+              app.kubernetes.io/instance: "{{ .InstanceID }}"
             type: ClusterIP
           ---
           apiVersion: apps/v1
@@ -567,12 +577,14 @@ data:
                 app.kubernetes.io/component: controller-manager
                 app.kubernetes.io/name: controller-manager
                 app.kubernetes.io/part-of: numaflow
+                app.kubernetes.io/instance: "{{ .InstanceID }}"
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: controller-manager
                   app.kubernetes.io/name: controller-manager
                   app.kubernetes.io/part-of: numaflow
+                  app.kubernetes.io/instance: "{{ .InstanceID }}"
               spec:
                 containers:
                 - args:
@@ -667,12 +679,14 @@ data:
                 app.kubernetes.io/component: dex-server
                 app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
                 app.kubernetes.io/part-of: numaflow
+                app.kubernetes.io/instance: "{{ .InstanceID }}"
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: dex-server
                   app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
                   app.kubernetes.io/part-of: numaflow
+                  app.kubernetes.io/instance: "{{ .InstanceID }}"
               spec:
                 containers:
                 - command:
@@ -755,12 +769,14 @@ data:
                 app.kubernetes.io/component: numaflow-ux
                 app.kubernetes.io/name: numaflow-ux
                 app.kubernetes.io/part-of: numaflow
+                app.kubernetes.io/instance: "{{ .InstanceID }}"
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: numaflow-ux
                   app.kubernetes.io/name: numaflow-ux
                   app.kubernetes.io/part-of: numaflow
+                  app.kubernetes.io/instance: "{{ .InstanceID }}"
               spec:
                 containers:
                 - args:

--- a/tests/manifests/default/controller_def_1.3.3.yaml
+++ b/tests/manifests/default/controller_def_1.3.3.yaml
@@ -311,6 +311,7 @@ data:
           apiVersion: v1
           data:
             controller-config.yaml: |
+              instance: "{{ .InstanceID }}"
               defaults:
                 containerResources: |
                   requests:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Added instanceID to configmap and created instance labels.

### Verification

Manual tests:
1. create 2 NumaflowControllerRollout resources with different instanceIDs
2. create 1 ISBServiceRollout resource with annotation `numaflow.numaproj.io/instance: "1"` linking it to the instance 1 of the NumaflowController
3. verify that NFC instance 1 reconciles the ISBSvc while the other instance skips reconciliation (seen by enabling debug logs).