### PR TITLE
chore: ignore mvtx replicas if it exists

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
@@ -2,7 +2,6 @@ apiVersion: numaplane.numaproj.io/v1alpha1
 kind: MonoVertexRollout
 metadata:
   name: my-monovertex
-  namespace: example-namespace
 spec:
   monoVertex:
     spec:
@@ -10,6 +9,9 @@ spec:
         udsource:
           container:
             image: quay.io/numaio/numaflow-java/source-simple-source:stable
+            env:
+              - name: aaaa
+                value: bb
         # transformer is an optional container to do any transformation to the incoming data before passing to the sink
         transformer:
           container:

--- a/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
@@ -18,4 +18,3 @@ spec:
         udsink:
           container:
             image: quay.io/numaio/numaflow-java/simple-sink:stable
-

--- a/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
@@ -18,3 +18,4 @@ spec:
         udsink:
           container:
             image: quay.io/numaio/numaflow-java/simple-sink:stable
+

--- a/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
@@ -2,6 +2,7 @@ apiVersion: numaplane.numaproj.io/v1alpha1
 kind: MonoVertexRollout
 metadata:
   name: my-monovertex
+  namespace: example-namespace
 spec:
   monoVertex:
     spec:
@@ -9,9 +10,6 @@ spec:
         udsource:
           container:
             image: quay.io/numaio/numaflow-java/source-simple-source:stable
-            env:
-              - name: aaaa
-                value: bb
         # transformer is an optional container to do any transformation to the incoming data before passing to the sink
         transformer:
           container:

--- a/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
@@ -2,6 +2,7 @@ apiVersion: numaplane.numaproj.io/v1alpha1
 kind: NumaflowControllerRollout
 metadata:
   name: numaflow-controller # The Only support name is: numaflow-controller, to prevent having more than one controller in a namespace.
+  namespace: example-namespace
 spec:
   controller:
     version: "1.3.3" 

--- a/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
@@ -2,7 +2,6 @@ apiVersion: numaplane.numaproj.io/v1alpha1
 kind: NumaflowControllerRollout
 metadata:
   name: numaflow-controller # The Only support name is: numaflow-controller, to prevent having more than one controller in a namespace.
-  namespace: example-namespace
 spec:
   controller:
     version: "1.3.3" 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #353

### Modifications

When reconciling a MonoVertexRollout object, use the `replicas` from existing MonoVertex object if it has.

### Verification

Created a MonoVertexRollout object, manually scaled the orchestrated MonoVertex replicas, the numaplane controller did reconcile the watched notification, but the `replicas` value in the MonoVertex object remained unchanged.