### PR TITLE
fix: Metrics rename

### DIFF
--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -175,7 +175,7 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// generate metrics for ISB Service.
-	r.customMetrics.IncISBServiceMetrics(isbServiceRollout.Name, isbServiceRollout.Namespace)
+	r.customMetrics.IncISBServiceRollouts(isbServiceRollout.Name, isbServiceRollout.Namespace)
 	r.recorder.Eventf(isbServiceRollout, corev1.EventTypeNormal, "ReconcilationSuccessful", "Reconciliation successful")
 	numaLogger.Debug("reconciliation successful")
 
@@ -206,7 +206,7 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 			controllerutil.RemoveFinalizer(isbServiceRollout, finalizerName)
 		}
 		// generate metrics for ISB Service deletion.
-		r.customMetrics.DecISBServiceMetrics(isbServiceRollout.Name, isbServiceRollout.Namespace)
+		r.customMetrics.DecISBServiceRollouts(isbServiceRollout.Name, isbServiceRollout.Namespace)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerISBSVCRollout, "delete").Observe(time.Since(startTime).Seconds())
 		r.customMetrics.ISBServicesRolloutHealth.DeleteLabelValues(isbServiceRollout.Namespace, isbServiceRollout.Name)
 		return ctrl.Result{}, nil

--- a/internal/controller/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout_controller.go
@@ -120,7 +120,7 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	numaLogger := logger.GetBaseLogger().WithName("isbservicerollout-reconciler").WithValues("isbservicerollout", req.NamespacedName)
 	// update the context with this Logger so downstream users can incorporate these values in the logs
 	ctx = logger.WithLogger(ctx, numaLogger)
-	r.customMetrics.ISBServicesSynced.WithLabelValues().Inc()
+	r.customMetrics.ISBServiceROSyncs.WithLabelValues().Inc()
 
 	isbServiceRollout := &apiv1.ISBServiceRollout{}
 	if err := r.client.Get(ctx, req.NamespacedName, isbServiceRollout); err != nil {
@@ -649,7 +649,7 @@ func (r *ISBServiceRolloutReconciler) updateISBServiceRolloutStatusToFailed(ctx 
 }
 
 func (r *ISBServiceRolloutReconciler) ErrorHandler(isbServiceRollout *apiv1.ISBServiceRollout, err error, reason, msg string) {
-	r.customMetrics.ISBServicesSyncFailed.WithLabelValues().Inc()
+	r.customMetrics.ISBServicesROSyncErrors.WithLabelValues().Inc()
 	r.recorder.Eventf(isbServiceRollout, corev1.EventTypeWarning, reason, msg+" %v", err.Error())
 }
 

--- a/internal/controller/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout_controller_test.go
@@ -131,8 +131,8 @@ var _ = Describe("ISBServiceRollout Controller", Ordered, func() {
 
 		It("Should have the metrics updated", func() {
 			By("Verifying the ISBService metric")
-			Expect(testutil.ToFloat64(customMetrics.ISBServicesRunning.WithLabelValues(defaultNamespace))).Should(Equal(float64(1)))
-			Expect(testutil.ToFloat64(customMetrics.ISBServicesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
+			Expect(testutil.ToFloat64(customMetrics.ISBServiceRolloutsRunning.WithLabelValues(defaultNamespace))).Should(Equal(float64(1)))
+			Expect(testutil.ToFloat64(customMetrics.ISBServiceROSyncs.WithLabelValues())).Should(BeNumerically(">", 1))
 		})
 
 		It("Should update the ISBServiceRollout and InterStepBufferService", func() {

--- a/internal/controller/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout_controller.go
@@ -118,7 +118,7 @@ func (r *MonoVertexRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// update the context with this Logger
 	ctx = logger.WithLogger(ctx, numaLogger)
-	r.customMetrics.MonoVerticesSynced.WithLabelValues().Inc()
+	r.customMetrics.MonoVertexROSyncs.WithLabelValues().Inc()
 
 	monoVertexRollout := &apiv1.MonoVertexRollout{}
 	if err := r.client.Get(ctx, req.NamespacedName, monoVertexRollout); err != nil {
@@ -482,7 +482,7 @@ func (r *MonoVertexRolloutReconciler) updateMonoVertexRolloutStatusToFailed(ctx 
 }
 
 func (r *MonoVertexRolloutReconciler) ErrorHandler(monoVertexRollout *apiv1.MonoVertexRollout, err error, reason, msg string) {
-	r.customMetrics.MonoVerticesSyncFailed.WithLabelValues().Inc()
+	r.customMetrics.MonoVertexROSyncErrors.WithLabelValues().Inc()
 	r.recorder.Eventf(monoVertexRollout, corev1.EventTypeWarning, reason, msg+" %v", err.Error())
 }
 

--- a/internal/controller/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout_controller.go
@@ -171,7 +171,7 @@ func (r *MonoVertexRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// generate metrics for MonoVertex
-	r.customMetrics.IncMonoVertexMetrics(monoVertexRollout.Name, monoVertexRollout.Namespace)
+	r.customMetrics.IncMonoVertexRollouts(monoVertexRollout.Name, monoVertexRollout.Namespace)
 	r.recorder.Eventf(monoVertexRollout, corev1.EventTypeNormal, "ReconciliationSuccessful", "Reconciliation successful")
 	numaLogger.Debug("reconciliation successful")
 
@@ -198,7 +198,7 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 			controllerutil.RemoveFinalizer(monoVertexRollout, finalizerName)
 		}
 		// generate metrics for MonoVertex deletion
-		r.customMetrics.DecMonoVertexMetrics(monoVertexRollout.Name, monoVertexRollout.Namespace)
+		r.customMetrics.DecMonoVertexRollouts(monoVertexRollout.Name, monoVertexRollout.Namespace)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerMonoVertexRollout, "delete").Observe(time.Since(startTime).Seconds())
 		r.customMetrics.MonoVerticesRolloutHealth.DeleteLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name)
 		return ctrl.Result{}, nil

--- a/internal/controller/monovertexrollout_controller_test.go
+++ b/internal/controller/monovertexrollout_controller_test.go
@@ -127,8 +127,8 @@ var _ = Describe("MonoVertexRollout Controller", Ordered, func() {
 
 		It("Should have the metrics updated", func() {
 			By("Verifying the MonoVertex metrics")
-			Expect(testutil.ToFloat64(customMetrics.MonoVerticesRunning.WithLabelValues(namespace))).Should(Equal(float64(1)))
-			Expect(testutil.ToFloat64(customMetrics.MonoVerticesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
+			Expect(testutil.ToFloat64(customMetrics.MonoVertexRolloutsRunning.WithLabelValues(namespace))).Should(Equal(float64(1)))
+			Expect(testutil.ToFloat64(customMetrics.MonoVertexROSyncs.WithLabelValues())).Should(BeNumerically(">", 1))
 		})
 
 		It("Should update the MonoVertexRollout and MonoVertex", func() {

--- a/internal/controller/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout_controller.go
@@ -130,7 +130,7 @@ func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req
 	numaLogger := logger.GetBaseLogger().WithName("numaflowcontrollerrollout-reconciler").WithValues("numaflowcontrollerrollout", req.NamespacedName)
 	// update the context with this Logger so downstream users can incorporate these values in the logs
 	ctx = logger.WithLogger(ctx, numaLogger)
-	r.customMetrics.NumaflowControllersSynced.WithLabelValues().Inc()
+	r.customMetrics.NumaflowControllersROSyncs.WithLabelValues().Inc()
 
 	numaflowControllerRollout := &apiv1.NumaflowControllerRollout{}
 	if err := r.client.Get(ctx, req.NamespacedName, numaflowControllerRollout); err != nil {
@@ -198,7 +198,7 @@ func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// generate the metrics for the numaflow controller based on a numaflow version.
-	r.customMetrics.NumaflowControllerRunning.WithLabelValues(numaflowControllerRollout.Name, numaflowControllerRollout.Namespace, numaflowControllerRollout.Spec.Controller.Version).Set(1)
+	r.customMetrics.NumaflowControlleRORunning.WithLabelValues(numaflowControllerRollout.Name, numaflowControllerRollout.Namespace, numaflowControllerRollout.Spec.Controller.Version).Set(1)
 
 	numaLogger.Debug("reconciliation successful")
 	r.recorder.Eventf(numaflowControllerRollout, corev1.EventTypeNormal, "ReconcileSuccess", "Reconciliation successful")
@@ -245,7 +245,7 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 			controllerutil.RemoveFinalizer(controllerRollout, finalizerName)
 		}
 		// generate the metrics for the numaflow controller deletion based on a numaflow version.
-		r.customMetrics.NumaflowControllerRunning.DeleteLabelValues(controllerRollout.Name, controllerRollout.Namespace, controllerRollout.Spec.Controller.Version)
+		r.customMetrics.NumaflowControlleRORunning.DeleteLabelValues(controllerRollout.Name, controllerRollout.Namespace, controllerRollout.Spec.Controller.Version)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerNumaflowControllerRollout, "delete").Observe(time.Since(syncStartTime).Seconds())
 		r.customMetrics.NumaflowControllersRolloutHealth.DeleteLabelValues(controllerRollout.Namespace, controllerRollout.Name)
 		return ctrl.Result{}, nil
@@ -891,6 +891,6 @@ func (r *NumaflowControllerRolloutReconciler) updateNumaflowControllerRolloutSta
 }
 
 func (r *NumaflowControllerRolloutReconciler) ErrorHandler(numaflowControllerRollout *apiv1.NumaflowControllerRollout, err error, reason, msg string) {
-	r.customMetrics.NumaflowControllersSyncFailed.WithLabelValues().Inc()
+	r.customMetrics.NumaflowControllerROSyncErrors.WithLabelValues().Inc()
 	r.recorder.Eventf(numaflowControllerRollout, corev1.EventTypeWarning, reason, msg+" %v", err.Error())
 }

--- a/internal/controller/numaflowcontrollerrollout_controller_test.go
+++ b/internal/controller/numaflowcontrollerrollout_controller_test.go
@@ -152,7 +152,7 @@ var _ = Describe("NumaflowControllerRollout Controller", Ordered, func() {
 
 		It("Should have the metrics updated", func() {
 			By("Verifying the Numaflow Controller metric")
-			Expect(testutil.ToFloat64(customMetrics.NumaflowControllersSynced.WithLabelValues())).Should(BeNumerically(">", 1))
+			Expect(testutil.ToFloat64(customMetrics.NumaflowControllersROSyncs.WithLabelValues())).Should(BeNumerically(">", 1))
 			Expect(testutil.ToFloat64(customMetrics.NumaflowControllerKubectlExecutionCounter.WithLabelValues())).Should(BeNumerically(">", 1))
 		})
 

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -184,7 +184,7 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 	numaLogger := logger.FromContext(ctx).WithValues("pipelinerollout", namespacedName)
 	// update the context with this Logger so downstream users can incorporate these values in the logs
 	ctx = logger.WithLogger(ctx, numaLogger)
-	r.customMetrics.PipelinesSynced.WithLabelValues().Inc()
+	r.customMetrics.PipelineROSyncs.WithLabelValues().Inc()
 
 	// Get PipelineRollout CR
 	pipelineRollout := &apiv1.PipelineRollout{}
@@ -911,7 +911,7 @@ func getPipelineChildResourceHealth(conditions []metav1.Condition) (metav1.Condi
 }
 
 func (r *PipelineRolloutReconciler) ErrorHandler(pipelineRollout *apiv1.PipelineRollout, err error, reason, msg string) {
-	r.customMetrics.PipelinesSyncFailed.WithLabelValues().Inc()
+	r.customMetrics.PipelineROSyncErrors.WithLabelValues().Inc()
 	r.recorder.Eventf(pipelineRollout, corev1.EventTypeWarning, reason, msg+" %v", err.Error())
 }
 

--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -254,7 +254,7 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 	}
 
 	// generate the metrics for the Pipeline.
-	r.customMetrics.IncPipelinesRunningMetrics(pipelineRollout.Name, pipelineRollout.Namespace)
+	r.customMetrics.IncPipelineROsRunning(pipelineRollout.Name, pipelineRollout.Namespace)
 
 	if requeue {
 		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
@@ -369,7 +369,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 			controllerutil.RemoveFinalizer(pipelineRollout, finalizerName)
 		}
 		// generate the metrics for the Pipeline deletion.
-		r.customMetrics.DecPipelineMetrics(pipelineRollout.Name, pipelineRollout.Namespace)
+		r.customMetrics.DecPipelineROsRunning(pipelineRollout.Name, pipelineRollout.Namespace)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerPipelineRollout, "delete").Observe(time.Since(syncStartTime).Seconds())
 		r.customMetrics.PipelinesRolloutHealth.DeleteLabelValues(pipelineRollout.Namespace, pipelineRollout.Name)
 		return false, nil, nil

--- a/internal/controller/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout_controller_test.go
@@ -180,8 +180,8 @@ var _ = Describe("PipelineRollout Controller", Ordered, func() {
 
 		It("Should have the metrics updated", func() {
 			By("Verifying the PipelineRollout metric")
-			Expect(testutil.ToFloat64(customMetrics.PipelinesRunning.WithLabelValues(defaultNamespace))).Should(Equal(float64(1)))
-			Expect(testutil.ToFloat64(customMetrics.PipelinesSynced.WithLabelValues())).Should(BeNumerically(">", 1))
+			Expect(testutil.ToFloat64(customMetrics.PipelineRolloutsRunning.WithLabelValues(defaultNamespace))).Should(Equal(float64(1)))
+			Expect(testutil.ToFloat64(customMetrics.PipelineROSyncs.WithLabelValues())).Should(BeNumerically(">", 1))
 		})
 
 		Context("When applying a PipelineRollout spec where the Pipeline with same name already exists", func() {
@@ -219,7 +219,7 @@ var _ = Describe("PipelineRollout Controller", Ordered, func() {
 				}, timeout, interval).Should(BeTrue())
 
 				// Still expect the intermediate failed state trigger the metric
-				Expect(testutil.ToFloat64(customMetrics.PipelinesSyncFailed.WithLabelValues())).Should(BeNumerically(">", 1))
+				Expect(testutil.ToFloat64(customMetrics.PipelineROSyncErrors.WithLabelValues())).Should(BeNumerically(">", 1))
 			})
 		})
 

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -119,8 +119,8 @@ var (
 
 	// pipelineRolloutsRunning indicates the number of PipelineRollouts
 	pipelineRolloutsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "numaflow_pipeline_rollouts_running",
-		Help:        "Number of Numaflow pipeline rollouts running",
+		Name:        "pipeline_rollouts_running",
+		Help:        "Number of pipeline rollouts running",
 		ConstLabels: defaultLabels,
 	}, []string{LabelNamespace})
 

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -154,8 +154,8 @@ var (
 
 	// isbServiceRolloutsRunning is the gauge for the number of running ISBServiceRollouts.
 	isbServiceRolloutsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "numaflow_isb_service_rollouts_running",
-		Help:        "Number of Numaflow ISB Service Rollouts running",
+		Name:        "isb_service_rollouts_running",
+		Help:        "Number of ISB Service Rollouts running",
 		ConstLabels: defaultLabels,
 	}, []string{LabelNamespace})
 
@@ -182,8 +182,8 @@ var (
 
 	// monoVertexRolloutsRunning is the gauge for the number of MonoVertexRollouts.
 	monoVertexRolloutsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "numaflow_monovertex_rollouts_running",
-		Help:        "Number of Numaflow MonoVertexRollouts running",
+		Name:        "monovertex_rollouts_running",
+		Help:        "Number of MonoVertexRollouts running",
 		ConstLabels: defaultLabels,
 	}, []string{LabelNamespace})
 

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -203,7 +203,7 @@ var (
 
 	// numaflowControllerRORunning is the gauge for the number of running numaflow controllers.
 	numaflowControllerRORunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "numaflow_controller_rollout_running",
+		Name:        "numaflow_controller_rollouts_running",
 		Help:        "Number of NumaflowControllerRollouts",
 		ConstLabels: defaultLabels,
 	}, []string{LabelName, LabelNamespace, LabelVersion})

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -133,14 +133,14 @@ var (
 
 	// pipelineROSyncs Check the total number of pipeline rollout reconciliations
 	pipelineROSyncs = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        "pipeline_synced_total",
+		Name:        "pipeline_rollout_syncs_total",
 		Help:        "The total number of pipeline synced",
 		ConstLabels: defaultLabels,
 	}, []string{})
 
 	// pipelineROSyncErrors Check the total number of pipeline rollout reconciliation errors
 	pipelineROSyncErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        "pipeline_sync_failed_total",
+		Name:        "pipeline_rollout_sync_errors_total",
 		Help:        "The total number of pipeline sync failed",
 		ConstLabels: defaultLabels,
 	}, []string{})

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -11,43 +11,43 @@ import (
 type CustomMetrics struct {
 	// PipelinesRolloutHealth is the gauge for the health of pipelines.
 	PipelinesRolloutHealth *prometheus.GaugeVec
-	// PipelineRolloutsRunning is the gauge for the number of running pipelines.
+	// PipelineRolloutsRunning is the gauge for the number of running PipelineRollouts.
 	PipelineRolloutsRunning *prometheus.GaugeVec
-	// PipelineROCounterMap contains the information of all running pipelines.
+	// PipelineROCounterMap contains the information of all running PipelineRollouts.
 	PipelineROCounterMap map[string]map[string]struct{}
-	// PipelineROSyncErrors is the counter for the total number of failed synced.
+	// PipelineROSyncErrors is the counter for the total number of sync errors.
 	PipelineROSyncErrors *prometheus.CounterVec
 	// PipelineRolloutQueueLength is the gauge for the length of pipeline rollout queue.
 	PipelineRolloutQueueLength *prometheus.GaugeVec
-	// PipelineROSyncs is the counter for the total number of pipelines synced.
+	// PipelineROSyncs is the counter for the total number of PipelineRollout reconciliations
 	PipelineROSyncs *prometheus.CounterVec
-	// ISBServicesRolloutHealth is the gauge for the health of ISB services.
+	// ISBServicesRolloutHealth is the gauge for the health of ISBServiceRollouts.
 	ISBServicesRolloutHealth *prometheus.GaugeVec
-	// ISBServiceRolloutsRunning is the gauge for the number of running ISB services.
+	// ISBServiceRolloutsRunning is the gauge for the number of running ISBServiceRollouts.
 	ISBServiceRolloutsRunning *prometheus.GaugeVec
-	// ISBServiceROCounterMap contains the information of all running ISB services.
+	// ISBServiceROCounterMap contains the information of all running ISBServiceRollouts.
 	ISBServiceROCounterMap map[string]map[string]struct{}
-	// ISBServicesROSyncErrors is the counter for the total number of ISB service syncing failed.
+	// ISBServicesROSyncErrors is the counter for the total number of ISBServiceRollout reconciliation errors
 	ISBServicesROSyncErrors *prometheus.CounterVec
-	// ISBServiceROSyncs is the counter for the total number of ISB service synced.
+	// ISBServiceROSyncs is the counter for the total number of ISBServiceRollout reconciliations
 	ISBServiceROSyncs *prometheus.CounterVec
-	// MonoVerticesRolloutHealth is the gauge for the health of monovertices.
+	// MonoVerticesRolloutHealth is the gauge for the health of MonoVertexRollout.
 	MonoVerticesRolloutHealth *prometheus.GaugeVec
-	// MonoVertexRolloutsRunning is the gauge for the number of running monovertices.
+	// MonoVertexRolloutsRunning is the gauge for the number of running MonoVertexRollouts.
 	MonoVertexRolloutsRunning *prometheus.GaugeVec
-	// MonoVerticesCounterMap contains the information of all running monovertices.
+	// MonoVerticesCounterMap contains the information of all running MonoVertexRollouts.
 	MonoVerticesCounterMap map[string]map[string]struct{}
-	// MonoVertexROSyncErrors is the counter for the total number of monovertices syncing failed.
+	// MonoVertexROSyncErrors is the counter for the total number of MonoVertexRollout reconciliation errors
 	MonoVertexROSyncErrors *prometheus.CounterVec
-	// MonoVertexROSyncs is the counter for the total number of monovertices synced.
+	// MonoVertexROSyncs is the counter for the total number of MonoVertexRollout reconciliations
 	MonoVertexROSyncs *prometheus.CounterVec
-	// NumaflowControllersRolloutHealth is the gauge for the health of Numaflow controller.
+	// NumaflowControllersRolloutHealth is the gauge for the health of NumaflowControllerRollouts.
 	NumaflowControllersRolloutHealth *prometheus.GaugeVec
-	// NumaflowControlleRORunning is the gauge for the number of running numaflow controllers with a specific version.
+	// NumaflowControlleRORunning is the gauge for the number of running NumaflowControllerRollouts with a specific version.
 	NumaflowControlleRORunning *prometheus.GaugeVec
-	// NumaflowControllerROSyncErrors is the counter for the total number of Numaflow controller syncing failed.
+	// NumaflowControllerROSyncErrors is the counter for the total number of NumaflowControllerRollout reconciliation errors
 	NumaflowControllerROSyncErrors *prometheus.CounterVec
-	// NumaflowControllersROSyncs in the counter for the total number of Numaflow controllers synced.
+	// NumaflowControllersROSyncs in the counter for the total number of NumaflowControllerRollout reconciliations
 	NumaflowControllersROSyncs *prometheus.CounterVec
 	// ReconciliationDuration is the histogram for the duration of pipeline, isb service, monovertex and numaflow controller reconciliation.
 	ReconciliationDuration *prometheus.HistogramVec

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -11,44 +11,44 @@ import (
 type CustomMetrics struct {
 	// PipelinesRolloutHealth is the gauge for the health of pipelines.
 	PipelinesRolloutHealth *prometheus.GaugeVec
-	// PipelinesRunning is the gauge for the number of running pipelines.
-	PipelinesRunning *prometheus.GaugeVec
+	// PipelineRolloutsRunning is the gauge for the number of running pipelines.
+	PipelineRolloutsRunning *prometheus.GaugeVec
 	// PipelineCounterMap contains the information of all running pipelines.
 	PipelineCounterMap map[string]map[string]struct{}
-	// PipelinesSyncFailed is the counter for the total number of failed synced.
-	PipelinesSyncFailed *prometheus.CounterVec
+	// PipelineROSyncErrors is the counter for the total number of failed synced.
+	PipelineROSyncErrors *prometheus.CounterVec
 	// PipelineRolloutQueueLength is the gauge for the length of pipeline rollout queue.
 	PipelineRolloutQueueLength *prometheus.GaugeVec
-	// PipelinesSynced is the counter for the total number of pipelines synced.
-	PipelinesSynced *prometheus.CounterVec
+	// PipelineROSyncs is the counter for the total number of pipelines synced.
+	PipelineROSyncs *prometheus.CounterVec
 	// ISBServicesRolloutHealth is the gauge for the health of ISB services.
 	ISBServicesRolloutHealth *prometheus.GaugeVec
-	// ISBServicesRunning is the gauge for the number of running ISB services.
-	ISBServicesRunning *prometheus.GaugeVec
+	// ISBServiceRolloutsRunning is the gauge for the number of running ISB services.
+	ISBServiceRolloutsRunning *prometheus.GaugeVec
 	// ISBServiceCounterMap contains the information of all running ISB services.
 	ISBServiceCounterMap map[string]map[string]struct{}
-	// ISBServicesSyncFailed is the counter for the total number of ISB service syncing failed.
-	ISBServicesSyncFailed *prometheus.CounterVec
-	// ISBServicesSynced is the counter for the total number of ISB service synced.
-	ISBServicesSynced *prometheus.CounterVec
+	// ISBServicesROSyncErrors is the counter for the total number of ISB service syncing failed.
+	ISBServicesROSyncErrors *prometheus.CounterVec
+	// ISBServiceROSyncs is the counter for the total number of ISB service synced.
+	ISBServiceROSyncs *prometheus.CounterVec
 	// MonoVerticesRolloutHealth is the gauge for the health of monovertices.
 	MonoVerticesRolloutHealth *prometheus.GaugeVec
-	// MonoVerticesRunning is the gauge for the number of running monovertices.
-	MonoVerticesRunning *prometheus.GaugeVec
+	// MonoVertexRolloutsRunning is the gauge for the number of running monovertices.
+	MonoVertexRolloutsRunning *prometheus.GaugeVec
 	// MonoVerticesCounterMap contains the information of all running monovertices.
 	MonoVerticesCounterMap map[string]map[string]struct{}
-	// MonoVerticesSyncFailed is the counter for the total number of monovertices syncing failed.
-	MonoVerticesSyncFailed *prometheus.CounterVec
-	// MonoVerticesSynced is the counter for the total number of monovertices synced.
-	MonoVerticesSynced *prometheus.CounterVec
+	// MonoVertexROSyncErrors is the counter for the total number of monovertices syncing failed.
+	MonoVertexROSyncErrors *prometheus.CounterVec
+	// MonoVertexROSyncs is the counter for the total number of monovertices synced.
+	MonoVertexROSyncs *prometheus.CounterVec
 	// NumaflowControllersRolloutHealth is the gauge for the health of Numaflow controller.
 	NumaflowControllersRolloutHealth *prometheus.GaugeVec
-	// NumaflowControllerRunning is the gauge for the number of running numaflow controllers with a specific version.
-	NumaflowControllerRunning *prometheus.GaugeVec
-	// NumaflowControllersSyncFailed is the counter for the total number of Numaflow controller syncing failed.
-	NumaflowControllersSyncFailed *prometheus.CounterVec
-	// NumaflowControllersSynced in the counter for the total number of Numaflow controllers synced.
-	NumaflowControllersSynced *prometheus.CounterVec
+	// NumaflowControlleRORunning is the gauge for the number of running numaflow controllers with a specific version.
+	NumaflowControlleRORunning *prometheus.GaugeVec
+	// NumaflowControllerROSyncErrors is the counter for the total number of Numaflow controller syncing failed.
+	NumaflowControllerROSyncErrors *prometheus.CounterVec
+	// NumaflowControllersROSyncs in the counter for the total number of Numaflow controllers synced.
+	NumaflowControllersROSyncs *prometheus.CounterVec
 	// ReconciliationDuration is the histogram for the duration of pipeline, isb service, monovertex and numaflow controller reconciliation.
 	ReconciliationDuration *prometheus.HistogramVec
 	// NumaflowControllerKubectlExecutionCounter Count the number of kubectl executions during numaflow controller reconciliation
@@ -117,9 +117,9 @@ var (
 		ConstLabels: defaultLabels,
 	}, []string{LabelNamespace, LabelMonoVertex})
 
-	pipelinesRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "numaflow_pipelines_running",
-		Help:        "Number of Numaflow pipelines running",
+	pipelineRolloutsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        "numaflow_pipeline_rollouts_running",
+		Help:        "Number of Numaflow pipeline rollouts running",
 		ConstLabels: defaultLabels,
 	}, []string{LabelNamespace})
 
@@ -130,15 +130,15 @@ var (
 		ConstLabels: defaultLabels,
 	}, []string{LabelNamespace, LabelName})
 
-	// pipelinesSynced Check the total number of pipeline synced
-	pipelinesSynced = promauto.NewCounterVec(prometheus.CounterOpts{
+	// pipelineROSyncs Check the total number of pipeline rollout syncs
+	pipelineROSyncs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        "pipeline_synced_total",
 		Help:        "The total number of pipeline synced",
 		ConstLabels: defaultLabels,
 	}, []string{})
 
-	// pipelinesSyncFailed Check the total number of pipeline syncs failed
-	pipelinesSyncFailed = promauto.NewCounterVec(prometheus.CounterOpts{
+	// pipelineROSyncErrors Check the total number of pipeline rollout sync errors
+	pipelineROSyncErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        "pipeline_sync_failed_total",
 		Help:        "The total number of pipeline sync failed",
 		ConstLabels: defaultLabels,
@@ -151,23 +151,23 @@ var (
 		ConstLabels: defaultLabels,
 	}, []string{})
 
-	// isbServicesRunning is the gauge for the number of running ISB services.
-	isbServicesRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "numaflow_isb_services_running",
-		Help:        "Number of Numaflow ISB Service running",
+	// isbServiceRolloutsRunning is the gauge for the number of running ISBServiceRollouts.
+	isbServiceRolloutsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        "numaflow_isb_service_rollouts_running",
+		Help:        "Number of Numaflow ISB Service Rollouts running",
 		ConstLabels: defaultLabels,
 	}, []string{LabelNamespace})
 
-	// isbServicesSynced Check the total number of ISB services synced
-	isbServicesSynced = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        "isb_services_synced_total",
-		Help:        "The total number of ISB service synced",
+	// isbServiceROSyncs Check the total number of ISBServiceRollout syncs
+	isbServiceROSyncs = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        "isb_service_rollout_syncs_total",
+		Help:        "The total number of ISB service rollouts synced",
 		ConstLabels: defaultLabels,
 	}, []string{})
 
-	// isbServicesSyncFailed Check the total number of ISB service syncs failed
-	isbServicesSyncFailed = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        "isb_service_sync_failed_total",
+	// isbServiceROSyncErrors Check the total number of ISBServiceRollout sync errors
+	isbServiceROSyncErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        "isb_service_rollout_sync_errors_total",
 		Help:        "The total number of ISB service sync failed",
 		ConstLabels: defaultLabels,
 	}, []string{})
@@ -179,45 +179,45 @@ var (
 		ConstLabels: defaultLabels,
 	}, []string{LabelName})
 
-	// monoVerticesRunning is the gauge for the number of running monovertices.
-	monoVerticesRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "numaflow_monovertices_running",
-		Help:        "Number of Numaflow monovertices running",
+	// monoVertexRolloutsRunning is the gauge for the number of MonoVertexRollouts.
+	monoVertexRolloutsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        "numaflow_monovertex_rollouts_running",
+		Help:        "Number of Numaflow MonoVertexRollouts running",
 		ConstLabels: defaultLabels,
 	}, []string{LabelNamespace})
 
-	// monoVerticesSynced Check the total number of monovertices synced
-	monoVerticesSynced = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        "monovertices_synced_total",
+	// monoVertexROSyncs Check the total number of MonoVertexRollout reconciliations
+	monoVertexROSyncs = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        "monovertex_rollout_syncs_total",
 		Help:        "The total number of monovertices synced",
 		ConstLabels: defaultLabels,
 	}, []string{})
 
-	// monoVerticesSyncFailed Check the total number of monovertices syncs failed
-	monoVerticesSyncFailed = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        "monovertices_sync_failed_total",
+	// monoVertexROSyncErrors Check the total number of MonoVertexRollout sync errors
+	monoVertexROSyncErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        "monovertex_rollout_sync_errors_total",
 		Help:        "The total number of monovertices sync failed",
 		ConstLabels: defaultLabels,
 	}, []string{})
 
-	// numaflowControllerRunning is the gauge for the number of running numaflow controllers.
-	numaflowControllerRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "numaflow_controller_running",
-		Help:        "Number of Numaflow controller running",
+	// numaflowControllerRORunning is the gauge for the number of running numaflow controllers.
+	numaflowControllerRORunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        "numaflow_controller_rollout_running",
+		Help:        "Number of NumaflowControllerRollouts",
 		ConstLabels: defaultLabels,
 	}, []string{LabelName, LabelNamespace, LabelVersion})
 
-	// numaflowControllersSynced Check the total number of Numaflow controllers synced
-	numaflowControllersSynced = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        "numaflow_controller_synced_total",
-		Help:        "The total number of Numaflow controller synced",
+	// numaflowControllerROSyncs Check the total number of NumaflowControllerRollout reconciliations
+	numaflowControllerROSyncs = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        "numaflow_controller_rollout_syncs_total",
+		Help:        "The total number of NumaflowControllerRollout syncs",
 		ConstLabels: defaultLabels,
 	}, []string{})
 
-	// numaflowControllersSyncFailed Check the total number of Numaflow controller syncs failed
-	numaflowControllersSyncFailed = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        "numaflow_controller_sync_failed_total",
-		Help:        "The total number of Numaflow controller sync failed",
+	// numaflowControllerROSyncErrors Check the total number of NumaflowControllerRollout reconciliation errors
+	numaflowControllerROSyncErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:        "numaflow_controller_rollout_sync_errors_total",
+		Help:        "The total number of Numaflow controller sync errors",
 		ConstLabels: defaultLabels,
 	}, []string{})
 
@@ -231,7 +231,7 @@ var (
 	// numaflowControllerPausedSeconds Check the total time a Numaflow controller requested resources be paused
 	numaflowControllerPausedSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "numaflow_controller_paused_seconds",
-		Help:        "Duration a Numaflow controller paused resources for",
+		Help:        "Duration a Numaflow controller paused pipelines for",
 		ConstLabels: defaultLabels,
 	}, []string{LabelName})
 
@@ -273,34 +273,34 @@ var (
 
 // RegisterCustomMetrics registers the custom metrics to the existing global prometheus registry for pipelines, ISB service and numaflow controller
 func RegisterCustomMetrics() *CustomMetrics {
-	metrics.Registry.MustRegister(pipelinesRolloutHealth, pipelinesRunning, pipelinesSynced, pipelinesSyncFailed, pipelineRolloutQueueLength,
-		isbServicesRolloutHealth, isbServicesRunning, isbServicesSynced, isbServicesSyncFailed,
-		monoVerticesRolloutHealth, monoVerticesRunning, monoVerticesSynced, monoVerticesSyncFailed,
-		numaflowControllersRolloutHealth, numaflowControllerRunning, numaflowControllersSynced, numaflowControllersSyncFailed, reconciliationDuration, kubeRequestCounter,
+	metrics.Registry.MustRegister(pipelinesRolloutHealth, pipelineRolloutsRunning, pipelineROSyncs, pipelineROSyncErrors, pipelineRolloutQueueLength,
+		isbServicesRolloutHealth, isbServiceRolloutsRunning, isbServiceROSyncs, isbServiceROSyncErrors,
+		monoVerticesRolloutHealth, monoVertexRolloutsRunning, monoVertexROSyncs, monoVertexROSyncErrors,
+		numaflowControllersRolloutHealth, numaflowControllerRORunning, numaflowControllerROSyncs, numaflowControllerROSyncErrors, reconciliationDuration, kubeRequestCounter,
 		numaflowControllerKubectlExecutionCounter, kubeResourceCacheMonitored, kubeResourceCache, clusterCacheError,
 		pipelinePausedSeconds, isbServicePausedSeconds, numaflowControllerPausedSeconds)
 
 	return &CustomMetrics{
 		PipelinesRolloutHealth:                    pipelinesRolloutHealth,
-		PipelinesRunning:                          pipelinesRunning,
+		PipelineRolloutsRunning:                   pipelineRolloutsRunning,
 		PipelineCounterMap:                        make(map[string]map[string]struct{}),
-		PipelinesSynced:                           pipelinesSynced,
-		PipelinesSyncFailed:                       pipelinesSyncFailed,
+		PipelineROSyncs:                           pipelineROSyncs,
+		PipelineROSyncErrors:                      pipelineROSyncErrors,
 		PipelineRolloutQueueLength:                pipelineRolloutQueueLength,
 		ISBServicesRolloutHealth:                  isbServicesRolloutHealth,
-		ISBServicesRunning:                        isbServicesRunning,
+		ISBServiceRolloutsRunning:                 isbServiceRolloutsRunning,
 		ISBServiceCounterMap:                      make(map[string]map[string]struct{}),
-		ISBServicesSynced:                         isbServicesSynced,
-		ISBServicesSyncFailed:                     isbServicesSyncFailed,
+		ISBServiceROSyncs:                         isbServiceROSyncs,
+		ISBServicesROSyncErrors:                   isbServiceROSyncErrors,
 		MonoVerticesRolloutHealth:                 monoVerticesRolloutHealth,
-		MonoVerticesRunning:                       monoVerticesRunning,
+		MonoVertexRolloutsRunning:                 monoVertexRolloutsRunning,
 		MonoVerticesCounterMap:                    make(map[string]map[string]struct{}),
-		MonoVerticesSynced:                        monoVerticesSynced,
-		MonoVerticesSyncFailed:                    monoVerticesSyncFailed,
+		MonoVertexROSyncs:                         monoVertexROSyncs,
+		MonoVertexROSyncErrors:                    monoVertexROSyncErrors,
 		NumaflowControllersRolloutHealth:          numaflowControllersRolloutHealth,
-		NumaflowControllerRunning:                 numaflowControllerRunning,
-		NumaflowControllersSynced:                 numaflowControllersSynced,
-		NumaflowControllersSyncFailed:             numaflowControllersSyncFailed,
+		NumaflowControlleRORunning:                numaflowControllerRORunning,
+		NumaflowControllersROSyncs:                numaflowControllerROSyncs,
+		NumaflowControllerROSyncErrors:            numaflowControllerROSyncErrors,
 		KubeRequestCounter:                        kubeRequestCounter,
 		NumaflowControllerKubectlExecutionCounter: numaflowControllerKubectlExecutionCounter,
 		ReconciliationDuration:                    reconciliationDuration,
@@ -322,7 +322,7 @@ func (m *CustomMetrics) IncPipelinesRunningMetrics(name, namespace string) {
 	}
 	m.PipelineCounterMap[namespace][name] = struct{}{}
 	for ns, pipelines := range m.PipelineCounterMap {
-		m.PipelinesRunning.WithLabelValues(ns).Set(float64(len(pipelines)))
+		m.PipelineRolloutsRunning.WithLabelValues(ns).Set(float64(len(pipelines)))
 	}
 }
 
@@ -332,7 +332,7 @@ func (m *CustomMetrics) DecPipelineMetrics(name, namespace string) {
 	defer pipelineLock.Unlock()
 	delete(m.PipelineCounterMap[namespace], name)
 	for ns, pipelines := range m.PipelineCounterMap {
-		m.PipelinesRunning.WithLabelValues(ns).Set(float64(len(pipelines)))
+		m.PipelineRolloutsRunning.WithLabelValues(ns).Set(float64(len(pipelines)))
 	}
 }
 
@@ -345,7 +345,7 @@ func (m *CustomMetrics) IncISBServiceMetrics(name, namespace string) {
 	}
 	m.ISBServiceCounterMap[namespace][name] = struct{}{}
 	for ns, isbServices := range m.ISBServiceCounterMap {
-		m.ISBServicesRunning.WithLabelValues(ns).Set(float64(len(isbServices)))
+		m.ISBServiceRolloutsRunning.WithLabelValues(ns).Set(float64(len(isbServices)))
 	}
 }
 
@@ -355,7 +355,7 @@ func (m *CustomMetrics) DecISBServiceMetrics(name, namespace string) {
 	defer isbServiceLock.Unlock()
 	delete(m.ISBServiceCounterMap[namespace], name)
 	for ns, isbServices := range m.ISBServiceCounterMap {
-		m.ISBServicesRunning.WithLabelValues(ns).Set(float64(len(isbServices)))
+		m.ISBServiceRolloutsRunning.WithLabelValues(ns).Set(float64(len(isbServices)))
 	}
 }
 
@@ -368,7 +368,7 @@ func (m *CustomMetrics) IncMonoVertexMetrics(name, namespace string) {
 	}
 	m.MonoVerticesCounterMap[namespace][name] = struct{}{}
 	for ns, monoVertices := range m.MonoVerticesCounterMap {
-		m.MonoVerticesRunning.WithLabelValues(ns).Set(float64(len(monoVertices)))
+		m.MonoVertexRolloutsRunning.WithLabelValues(ns).Set(float64(len(monoVertices)))
 	}
 }
 
@@ -378,6 +378,6 @@ func (m *CustomMetrics) DecMonoVertexMetrics(name, namespace string) {
 	defer monoVertexLock.Unlock()
 	delete(m.MonoVerticesCounterMap[namespace], name)
 	for ns, monoVertices := range m.MonoVerticesCounterMap {
-		m.MonoVerticesRunning.WithLabelValues(ns).Set(float64(len(monoVertices)))
+		m.MonoVertexRolloutsRunning.WithLabelValues(ns).Set(float64(len(monoVertices)))
 	}
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

Renamed the names used in the code as well as the metric names for a few things:
- our counters were named after the child (i.e. `pipeline`) when in the code they really seemed to represent the counts of Rollouts
- changed the names of the counters representing "syncs" and "sync errors" to better describe what they represent


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->