### PR TITLE
feat: pause metrics distinguish between user and system requested pauses

### DIFF
--- a/internal/controller/pipelinerollout_ppnd.go
+++ b/internal/controller/pipelinerollout_ppnd.go
@@ -78,7 +78,7 @@ func (r *PipelineRolloutReconciler) processExistingPipelineWithPPND(ctx context.
 	doneWithPPND := !shouldBePaused
 
 	// but if the PipelineRollout says to pause and we're Paused (or won't pause), stop doing PPND in that case too
-	specBasedPause := newPipelineSpec.Lifecycle.DesiredPhase == string(numaflowv1.PipelinePhasePaused) || newPipelineSpec.Lifecycle.DesiredPhase == string(numaflowv1.PipelinePhasePausing)
+	specBasedPause := r.isSpecBasedPause(newPipelineSpec)
 	if specBasedPause && isPipelinePausedOrWontPause(ctx, existingPipelineDef, pipelineRollout) {
 		doneWithPPND = true
 	}
@@ -113,7 +113,7 @@ func (r *PipelineRolloutReconciler) shouldBePaused(ctx context.Context, pipeline
 	}
 
 	// check to see if the PipelineRollout spec itself says to Pause
-	specBasedPause := (newPipelineSpec.Lifecycle.DesiredPhase == string(numaflowv1.PipelinePhasePaused) || newPipelineSpec.Lifecycle.DesiredPhase == string(numaflowv1.PipelinePhasePausing))
+	specBasedPause := r.isSpecBasedPause(newPipelineSpec)
 
 	wontPause := checkIfPipelineWontPause(ctx, existingPipelineDef, pipelineRollout)
 
@@ -162,6 +162,10 @@ func (r *PipelineRolloutReconciler) needPPND(ctx context.Context, pipelineRollou
 	}
 
 	return &needPPND, nil
+}
+
+func (r *PipelineRolloutReconciler) isSpecBasedPause(pipelineSpec PipelineSpec) bool {
+	return (pipelineSpec.Lifecycle.DesiredPhase == string(numaflowv1.PipelinePhasePaused) || pipelineSpec.Lifecycle.DesiredPhase == string(numaflowv1.PipelinePhasePausing))
 }
 
 // check for all pause requests for this Pipeline (i.e. both from Numaflow Controller and ISBService)

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -81,6 +81,7 @@ const (
 	LabelISBService         = "isbservice"
 	LabelNumaflowController = "numaflowcontroller"
 	LabelMonoVertex         = "monovertex"
+	LabelPauseType          = "pause_type"
 )
 
 var (
@@ -128,7 +129,7 @@ var (
 		Name:        "numaflow_pipeline_paused_seconds",
 		Help:        "Duration a pipeline was paused for",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelName})
+	}, []string{LabelNamespace, LabelName, LabelPauseType})
 
 	// pipelinesSynced Check the total number of pipeline synced
 	pipelinesSynced = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #240 

### Modifications

Modifies the pipelinePausedSeconds metric to distinguish between if the pause is user or system requested.

Refactors logic used in PPND logic for Pipeline to determine if the pause is spec based or not.

### Verification

Tested locally by pausing two different rollouts with a spec based pause and an update that would cause PPND.

Verified that the metrics updated properly for the right case.

```
# TYPE numaflow_pipeline_paused_seconds gauge
numaflow_pipeline_paused_seconds{intuit_alert="true",name="my-pipeline",namespace="example-namespace",pause_type="user_pause"} 2.265524783
numaflow_pipeline_paused_seconds{intuit_alert="true",name="other-pipeline",namespace="example-namespace",pause_type="system_pause"} 2.224975533
```