### PR TITLE
feat: generate a templated Numaflow controller definition manifest based on the latest version of the Numaflow numaspace-install manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,11 @@ GCFLAGS="all=-N -l"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.28.0
 
-TEST_MANIFEST_DIR ?= tests/manifests/default
+TEST_MANIFEST_DIR_DEFAULT ?= tests/manifests/default
 TEST_PPND_MANIFEST_DIR ?= tests/manifests/special-cases/ppnd
 TEST_PROGRESSIVE_MANIFEST_DIR ?= tests/manifests/special-cases/progressive
+
+TEST_MANIFEST_DIR := $(TEST_MANIFEST_DIR_DEFAULT)
 
 ifeq ($(PPND), true)
 TEST_MANIFEST_DIR := $(TEST_PPND_MANIFEST_DIR)
@@ -195,8 +197,8 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: start
 start: image
 	./hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
-	$(KUBECTL) apply -f $(TEST_MANIFEST_DIR)/numaplane-ns.yaml
-	$(KUBECTL) kustomize $(TEST_MANIFEST_DIR)  | sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/$(IMG):$(BASE_VERSION)/$(IMG):$(VERSION)/' | $(KUBECTL) apply -f -
+	$(KUBECTL) apply -f $(TEST_MANIFEST_DIR_DEFAULT)/numaplane-ns.yaml
+	$(KUBECTL) kustomize $(TEST_MANIFEST_DIR) | sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/$(IMG):$(BASE_VERSION)/$(IMG):$(VERSION)/' | $(KUBECTL) apply -f -
 
 
 ##@ Build Dependencies

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,8 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 
 .PHONY: start
 start: image
-	$(KUBECTL) apply -f tests/manifests/default/numaplane-ns.yaml
+	./hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
+	$(KUBECTL) apply -f $(TEST_MANIFEST_DIR)/numaplane-ns.yaml
 	$(KUBECTL) kustomize $(TEST_MANIFEST_DIR)  | sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/$(IMG):$(BASE_VERSION)/$(IMG):$(VERSION)/' | $(KUBECTL) apply -f -
 
 

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ GCFLAGS="all=-N -l"
 ENVTEST_K8S_VERSION = 1.28.0
 
 TEST_MANIFEST_DIR ?= tests/manifests/default
-TEST_PPND_MANIFEST_DIR ?= tests/manifests/special-cases/ppnd 
-TEST_PROGRESSIVE_MANIFEST_DIR ?= tests/manifests/special-cases/progressive 
+TEST_PPND_MANIFEST_DIR ?= tests/manifests/special-cases/ppnd
+TEST_PROGRESSIVE_MANIFEST_DIR ?= tests/manifests/special-cases/progressive
 
 ifeq ($(PPND), true)
 TEST_MANIFEST_DIR := $(TEST_PPND_MANIFEST_DIR)

--- a/hack/numaflow-controller-def-generator/def-configmap.yaml
+++ b/hack/numaflow-controller-def-generator/def-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: numaflow-controller-definitions-$TMP_NFC_DEF_GEN_NUMAFLOW_VERSION
+  namespace: numaplane-system
+  labels:
+    "numaplane.numaproj.io/config": numaflow-controller-definitions
+data:
+  controller_definitions.yaml: |
+    controllerDefinitions:
+      - version: "$TMP_NFC_DEF_GEN_NUMAFLOW_VERSION"
+        fullSpec: |

--- a/hack/numaflow-controller-def-generator/kustomization.yaml
+++ b/hack/numaflow-controller-def-generator/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app.kubernetes.io/instance: '{{ .InstanceID }}'
+nameSuffix: "{{ .InstanceSuffix }}"
+
+resources:
+- namespace-install.yaml
+
+patches:
+# Remove all CRDs
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: .*
+  patch: |-
+    $patch: delete
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: not-important

--- a/hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
+++ b/hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
@@ -44,7 +44,8 @@ fi
 # Use yq to modify/add the instance field of the string litteral yaml config of the numaflow-controller-config ConfigMap data field controller-config.yaml
 # This is not possible via Kustomize yet. Follow https://github.com/kubernetes-sigs/kustomize/issues/4517 and https://github.com/kubernetes-sigs/kustomize/pull/5679 for future Kustomize updates.
 export TMP_NFC_DEF_GEN=$(yq 'select(.kind == "ConfigMap" and .metadata.name == "numaflow-controller-config{{ .InstanceSuffix }}") | .data."controller-config.yaml" | fromyaml | .instance = "{{ .InstanceID }}"' $BASE_DIR/$OUTPUT_FILE)
-yq 'select(.kind == "ConfigMap" and .metadata.name == "numaflow-controller-config{{ .InstanceSuffix }}") |= .data."controller-config.yaml" = strenv(TMP_NFC_DEF_GEN)' $BASE_DIR/$OUTPUT_FILE > output.yaml
+yq 'select(.kind == "ConfigMap" and .metadata.name == "numaflow-controller-config{{ .InstanceSuffix }}") |= .data."controller-config.yaml" = strenv(TMP_NFC_DEF_GEN)' $BASE_DIR/$OUTPUT_FILE > tmp_output.yaml
+cat tmp_output.yaml > $BASE_DIR/$OUTPUT_FILE
 
 # TTODO: all the above spec must be inside the following:
 # apiVersion: v1
@@ -64,4 +65,4 @@ yq 'select(.kind == "ConfigMap" and .metadata.name == "numaflow-controller-confi
 echo "Generated file $OUTPUT_FILE"
 
 # Cleanup
-rm namespace-install.yaml
+rm -f namespace-install.yaml tmp_output.yaml

--- a/hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
+++ b/hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
@@ -12,6 +12,9 @@ echo "Getting the latest Numaflow version tag..."
 NUMAFLOW_VERSION=$(git ls-remote --tags https://github.com/numaproj/numaflow | grep -v '{}' | tail -1 | sed 's/.*\///' | sed 's/^v//')
 
 OUTPUT_FILE=$TEST_MANIFEST_DIR/controller_def_$NUMAFLOW_VERSION.yaml
+if [ ! -z "$1" ]; then
+  OUTPUT_FILE=$1
+fi
 
 # Check if the latest version of the Numaflow Controller definitions is already available and, if so, skip the generation process
 if [ -f "$BASE_DIR/$OUTPUT_FILE" ]; then

--- a/hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
+++ b/hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
+BASE_DIR=../..
 TEST_MANIFEST_DIR=tests/manifests/default
 SCRIPT_DIR=$(dirname "$0")
-BASE_DIR=$(pwd)
 
 # Change working directory
 cd $SCRIPT_DIR
@@ -11,27 +11,35 @@ cd $SCRIPT_DIR
 echo "Getting the latest Numaflow version tag..."
 NUMAFLOW_VERSION=$(git ls-remote --tags https://github.com/numaproj/numaflow | grep -v '{}' | tail -1 | sed 's/.*\///' | sed 's/^v//')
 
-# TTODO: check first if we already have the latest version, if so, skip this process
+# Check if the latest version of the Numaflow Controller definitions is already available and, if so, skip the generation process
+if [ -f "$BASE_DIR/$TEST_MANIFEST_DIR/controller_def_$NUMAFLOW_VERSION.yaml" ]; then
+  echo "The latest version of the Numaflow Controller definitions already exists, skipping generation"
+  exit 0
+fi
 
 # Download namespace-install.yaml for the Numaflow version NUMAFLOW_VERSION
 echo "Downloading Numaflow v$NUMAFLOW_VERSION numaspace-install.yaml file..."
-wget https://raw.githubusercontent.com/numaproj/numaflow/refs/tags/v$NUMAFLOW_VERSION/config/namespace-install.yaml
+wget -nv https://raw.githubusercontent.com/numaproj/numaflow/refs/tags/v$NUMAFLOW_VERSION/config/namespace-install.yaml
+
+if [ $? -ne 0 ]; then
+  echo "Unable to download the Numaflow v$NUMAFLOW_VERSION numaspace-install.yaml file"
+  exit 1
+fi
 
 echo "Generating Numaflow Controller definition file for Numaflow version v$NUMAFLOW_VERSION..."
 
 # Run kustomization to generate the new Numaflow controller definition file for the above NUMAFLOW_VERSION
 kubectl kustomize . > $BASE_DIR/$TEST_MANIFEST_DIR/controller_def_$NUMAFLOW_VERSION.yaml
 
-echo "Generated file $BASE_DIR/$TEST_MANIFEST_DIR/controller_def_$NUMAFLOW_VERSION.yaml"
+# Install yq if not present
+if ! command -v yq 2>&1 >/dev/null
+then
+  echo "yq not found, installing it..."
+  go install github.com/mikefarah/yq/v4@latest
+  echo "yq installed"
+fi
 
-# Cleanup
-rm namespace-install.yaml
-cd $BASE_DIR
 
-
-
-# TTODO: Install yq
-#go install github.com/mikefarah/yq/v4@latest
 
 # TTODO: ...
 # confwinstance=$(yq 'select(.kind == "ConfigMap" and .metadata.name == "numaflow-controller-config") | .data."controller-config.yaml" | fromyaml | .instance = "{{ .InstanceID }}"' namespace-install.yaml) yq 'select(.kind == "ConfigMap" and .metadata.name == "numaflow-controller-config") |= .data."controller-config.yaml" = strenv(confwinstance)' namespace-install.yaml > output.yaml
@@ -50,3 +58,20 @@ cd $BASE_DIR
 #       - version: "1.3.3"
 #         fullSpec: |
 #           ...<spec goes here>...
+
+
+
+
+
+
+
+
+
+
+echo "Generated file $TEST_MANIFEST_DIR/controller_def_$NUMAFLOW_VERSION.yaml"
+
+# Cleanup
+rm namespace-install.yaml
+
+
+

--- a/hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
+++ b/hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+TEST_MANIFEST_DIR=tests/manifests/default
+SCRIPT_DIR=$(dirname "$0")
+BASE_DIR=$(pwd)
+
+# Change working directory
+cd $SCRIPT_DIR
+
+# Get the latest Numaflow Version from the remote repository
+echo "Getting the latest Numaflow version tag..."
+NUMAFLOW_VERSION=$(git ls-remote --tags https://github.com/numaproj/numaflow | grep -v '{}' | tail -1 | sed 's/.*\///' | sed 's/^v//')
+
+# TTODO: check first if we already have the latest version, if so, skip this process
+
+# Download namespace-install.yaml for the Numaflow version NUMAFLOW_VERSION
+echo "Downloading Numaflow v$NUMAFLOW_VERSION numaspace-install.yaml file..."
+wget https://raw.githubusercontent.com/numaproj/numaflow/refs/tags/v$NUMAFLOW_VERSION/config/namespace-install.yaml
+
+echo "Generating Numaflow Controller definition file for Numaflow version v$NUMAFLOW_VERSION..."
+
+# Run kustomization to generate the new Numaflow controller definition file for the above NUMAFLOW_VERSION
+kubectl kustomize . > $BASE_DIR/$TEST_MANIFEST_DIR/controller_def_$NUMAFLOW_VERSION.yaml
+
+echo "Generated file $BASE_DIR/$TEST_MANIFEST_DIR/controller_def_$NUMAFLOW_VERSION.yaml"
+
+# Cleanup
+rm namespace-install.yaml
+cd $BASE_DIR
+
+
+
+# TTODO: Install yq
+#go install github.com/mikefarah/yq/v4@latest
+
+# TTODO: ...
+# confwinstance=$(yq 'select(.kind == "ConfigMap" and .metadata.name == "numaflow-controller-config") | .data."controller-config.yaml" | fromyaml | .instance = "{{ .InstanceID }}"' namespace-install.yaml) yq 'select(.kind == "ConfigMap" and .metadata.name == "numaflow-controller-config") |= .data."controller-config.yaml" = strenv(confwinstance)' namespace-install.yaml > output.yaml
+
+# TTODO: all the above spec must be inside the following:
+# apiVersion: v1
+# kind: ConfigMap
+# metadata:
+#   name: numaflow-controller-definitions-1.3.3 
+#   namespace: numaplane-system
+#   labels:
+#     "numaplane.numaproj.io/config": numaflow-controller-definitions
+# data:
+#   controller_definitions.yaml: |
+#     controllerDefinitions:
+#       - version: "1.3.3"
+#         fullSpec: |
+#           ...<spec goes here>...

--- a/hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
+++ b/hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# This script uses Kustomize and yq to generate a templated Numaflow Controller definition manifest 
+# based on the latest version of the Numaflow numaspace-install manifest. The script can be called 
+# without arguments which will generate a file in the tests/manifests/default directory, or it 
+# can be called passing as argument a file path which will be used as the final output yaml.
+
 BASE_DIR=../..
 TEST_MANIFEST_DIR=tests/manifests/default
 SCRIPT_DIR=$(dirname "$0")

--- a/tests/manifests/default/controller_def_1.3.3.yaml
+++ b/tests/manifests/default/controller_def_1.3.3.yaml
@@ -1,28 +1,34 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: numaflow-controller-definitions-1.3.3 
+  name: numaflow-controller-definitions-1.3.3
   namespace: numaplane-system
   labels:
     "numaplane.numaproj.io/config": numaflow-controller-definitions
 data:
-  controller_definitions.yaml: |
+  controller_definitions.yaml: |-
     controllerDefinitions:
       - version: "1.3.3"
-        fullSpec: |
+        fullSpec: |-
           apiVersion: v1
           kind: ServiceAccount
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-dex-server{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-sa{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           kind: ServiceAccount
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-server-sa{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
@@ -30,283 +36,283 @@ data:
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-dex-server
               app.kubernetes.io/part-of: numaflow
-              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-dex-server{{ .InstanceSuffix }}
           rules:
-          - apiGroups:
-            - ""
-            resources:
-            - secrets
-            - configmaps
-            verbs:
-            - get
-            - list
-            - watch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           metadata:
             labels:
               app.kubernetes.io/component: controller-manager
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-role{{ .InstanceSuffix }}
           rules:
-          - apiGroups:
-            - numaflow.numaproj.io
-            resources:
-            - interstepbufferservices
-            - interstepbufferservices/finalizers
-            - interstepbufferservices/status
-            - pipelines
-            - pipelines/finalizers
-            - pipelines/status
-            - vertices
-            - vertices/finalizers
-            - vertices/status
-            - vertices/scale
-            - monovertices
-            - monovertices/finalizers
-            - monovertices/status
-            - monovertices/scale
-            verbs:
-            - create
-            - delete
-            - deletecollection
-            - get
-            - list
-            - patch
-            - update
-            - watch
-          - apiGroups:
-            - coordination.k8s.io
-            resources:
-            - leases
-            verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-          - apiGroups:
-            - ""
-            resources:
-            - events
-            verbs:
-            - create
-            - patch
-          - apiGroups:
-            - ""
-            resources:
-            - pods
-            - pods/exec
-            - configmaps
-            - services
-            - persistentvolumeclaims
-            verbs:
-            - create
-            - get
-            - list
-            - watch
-            - update
-            - patch
-            - delete
-          - apiGroups:
-            - ""
-            resources:
-            - secrets
-            verbs:
-            - create
-            - get
-            - list
-            - update
-            - patch
-            - delete
-          - apiGroups:
-            - apps
-            resources:
-            - deployments
-            - statefulsets
-            verbs:
-            - create
-            - get
-            - list
-            - watch
-            - update
-            - patch
-            - delete
-          - apiGroups:
-            - batch
-            resources:
-            - jobs
-            verbs:
-            - create
-            - get
-            - list
-            - watch
-            - update
-            - patch
-            - delete
+            - apiGroups:
+                - numaflow.numaproj.io
+              resources:
+                - interstepbufferservices
+                - interstepbufferservices/finalizers
+                - interstepbufferservices/status
+                - pipelines
+                - pipelines/finalizers
+                - pipelines/status
+                - vertices
+                - vertices/finalizers
+                - vertices/status
+                - vertices/scale
+                - monovertices
+                - monovertices/finalizers
+                - monovertices/status
+                - monovertices/scale
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - pods/exec
+                - configmaps
+                - services
+                - persistentvolumeclaims
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - statefulsets
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - update
+                - patch
+                - delete
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           metadata:
             labels:
               app.kubernetes.io/component: numaflow-ux
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-role{{ .InstanceSuffix }}
           rules:
-          - apiGroups:
-            - numaflow.numaproj.io
-            resources:
-            - interstepbufferservices
-            - interstepbufferservices/finalizers
-            - interstepbufferservices/status
-            - pipelines
-            - pipelines/finalizers
-            - pipelines/status
-            - vertices
-            - vertices/finalizers
-            - vertices/status
-            - vertices/scale
-            - monovertices
-            - monovertices/finalizers
-            - monovertices/status
-            - monovertices/scale
-            verbs:
-            - create
-            - delete
-            - deletecollection
-            - get
-            - list
-            - patch
-            - update
-            - watch
-          - apiGroups:
-            - ""
-            resources:
-            - events
-            - pods
-            - pods/log
-            - configmaps
-            - services
-            - persistentvolumeclaims
-            verbs:
-            - get
-            - list
-            - watch
-          - apiGroups:
-            - apps
-            resources:
-            - deployments
-            - statefulsets
-            verbs:
-            - get
-            - list
-            - watch
-          - apiGroups:
-            - metrics.k8s.io
-            resources:
-            - pods
-            verbs:
-            - get
-            - list
-            - watch
+            - apiGroups:
+                - numaflow.numaproj.io
+              resources:
+                - interstepbufferservices
+                - interstepbufferservices/finalizers
+                - interstepbufferservices/status
+                - pipelines
+                - pipelines/finalizers
+                - pipelines/status
+                - vertices
+                - vertices/finalizers
+                - vertices/status
+                - vertices/scale
+                - monovertices
+                - monovertices/finalizers
+                - monovertices/status
+                - monovertices/scale
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+                - pods
+                - pods/log
+                - configmaps
+                - services
+                - persistentvolumeclaims
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - statefulsets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - metrics.k8s.io
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           metadata:
             labels:
               app.kubernetes.io/component: numaflow-ux
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-secrets-role{{ .InstanceSuffix }}
           rules:
-          - apiGroups:
-            - ""
-            resources:
-            - secrets
-            verbs:
-            - get
-            - list
-            - watch
-            - update
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+                - update
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
           metadata:
             labels:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-dex-server
               app.kubernetes.io/part-of: numaflow
-              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-dex-server{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
             name: numaflow-dex-server{{ .InstanceSuffix }}
           subjects:
-          - kind: ServiceAccount
-            name: numaflow-dex-server{{ .InstanceSuffix }}
+            - kind: ServiceAccount
+              name: numaflow-dex-server{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
           metadata:
             labels:
               app.kubernetes.io/component: controller-manager
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
               app.kubernetes.io/name: numaflow-controller-manager
               app.kubernetes.io/part-of: numaflow
-              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-role-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
             name: numaflow-role{{ .InstanceSuffix }}
           subjects:
-          - kind: ServiceAccount
-            name: numaflow-sa{{ .InstanceSuffix }}
+            - kind: ServiceAccount
+              name: numaflow-sa{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
           metadata:
             labels:
               app.kubernetes.io/component: numaflow-ux
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
             name: numaflow-server-role{{ .InstanceSuffix }}
           subjects:
-          - kind: ServiceAccount
-            name: numaflow-server-sa{{ .InstanceSuffix }}
+            - kind: ServiceAccount
+              name: numaflow-server-sa{{ .InstanceSuffix }}
           ---
           apiVersion: rbac.authorization.k8s.io/v1
           kind: RoleBinding
           metadata:
             labels:
               app.kubernetes.io/component: numaflow-ux
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-              app.kubernetes.io/instance: "{{ .InstanceID }}"
             name: numaflow-server-secrets-binding{{ .InstanceSuffix }}
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
             name: numaflow-server-secrets-role{{ .InstanceSuffix }}
           subjects:
-          - kind: ServiceAccount
-            name: numaflow-server-sa{{ .InstanceSuffix }}
+            - kind: ServiceAccount
+              name: numaflow-server-sa{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
@@ -314,12 +320,13 @@ data:
             server.disable.auth: "true"
           kind: ConfigMap
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-cmd-params-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           data:
-            controller-config.yaml: |
-              instance: "{{ .InstanceID }}"
+            controller-config.yaml: |-
               defaults:
                 containerResources: |
                   requests:
@@ -350,16 +357,16 @@ data:
                       sentinel failover-timeout mymaster 2000
                       sentinel parallel-syncs mymaster 1
                   versions:
-                  - version: 7.0.11
-                    redisImage: bitnami/redis:7.0.11-debian-11-r3
-                    sentinelImage: bitnami/redis-sentinel:7.0.11-debian-11-r3
-                    redisExporterImage: bitnami/redis-exporter:1.50.0-debian-11-r4
-                    initContainerImage: debian:latest
-                  - version: 7.0.15
-                    redisImage: bitnami/redis:7.0.15-debian-11-r2
-                    sentinelImage: bitnami/redis-sentinel:7.0.15-debian-11-r2
-                    redisExporterImage: bitnami/redis-exporter:1.56.0-debian-11-r2
-                    initContainerImage: debian:latest
+                    - version: 7.0.11
+                      redisImage: bitnami/redis:7.0.11-debian-11-r3
+                      sentinelImage: bitnami/redis-sentinel:7.0.11-debian-11-r3
+                      redisExporterImage: bitnami/redis-exporter:1.50.0-debian-11-r4
+                      initContainerImage: debian:latest
+                    - version: 7.0.15
+                      redisImage: bitnami/redis:7.0.15-debian-11-r2
+                      sentinelImage: bitnami/redis-sentinel:7.0.15-debian-11-r2
+                      redisExporterImage: bitnami/redis-exporter:1.56.0-debian-11-r2
+                      initContainerImage: debian:latest
                 jetstream:
                   # Default JetStream settings, could be overridden by InterStepBufferService specs
                   settings: |
@@ -406,73 +413,76 @@ data:
                       storage: 0
                       replicas: 3
                   versions:
-                  - version: latest
-                    natsImage: nats:2.10.17
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: /nats-server
-                  - version: 2.8.1
-                    natsImage: nats:2.8.1
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: /nats-server
-                  - version: 2.8.1-alpine
-                    natsImage: nats:2.8.1-alpine
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: nats-server
-                  - version: 2.8.3
-                    natsImage: nats:2.8.3
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: /nats-server
-                  - version: 2.8.3-alpine
-                    natsImage: nats:2.8.3-alpine
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: nats-server
-                  - version: 2.9.0
-                    natsImage: nats:2.9.0
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: /nats-server
-                  - version: 2.9.0-alpine
-                    natsImage: nats:2.9.0-alpine
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: nats-server
-                  - version: 2.9.6
-                    natsImage: nats:2.9.6
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: /nats-server
-                  - version: 2.9.8
-                    natsImage: nats:2.9.8
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: /nats-server
-                  - version: 2.9.15
-                    natsImage: nats:2.9.15
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: /nats-server
-                  - version: 2.10.3
-                    natsImage: nats:2.10.3
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: /nats-server
-                  - version: 2.10.11
-                    natsImage: nats:2.10.11
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: /nats-server
-                  - version: 2.10.17
-                    natsImage: nats:2.10.17
-                    metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
-                    configReloaderImage: natsio/nats-server-config-reloader:0.7.0
-                    startCommand: /nats-server
+                    - version: latest
+                      natsImage: nats:2.10.17
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.8.1
+                      natsImage: nats:2.8.1
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.8.1-alpine
+                      natsImage: nats:2.8.1-alpine
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: nats-server
+                    - version: 2.8.3
+                      natsImage: nats:2.8.3
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.8.3-alpine
+                      natsImage: nats:2.8.3-alpine
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: nats-server
+                    - version: 2.9.0
+                      natsImage: nats:2.9.0
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.9.0-alpine
+                      natsImage: nats:2.9.0-alpine
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: nats-server
+                    - version: 2.9.6
+                      natsImage: nats:2.9.6
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.9.8
+                      natsImage: nats:2.9.8
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.9.15
+                      natsImage: nats:2.9.15
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.10.3
+                      natsImage: nats:2.10.3
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.10.11
+                      natsImage: nats:2.10.11
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.10.17
+                      natsImage: nats:2.10.17
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+              instance: '{{ .InstanceID }}'
           kind: ConfigMap
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-controller-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
@@ -493,6 +503,8 @@ data:
                     - readonly
           kind: ConfigMap
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-dex-server-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
@@ -500,6 +512,8 @@ data:
             admin.enabled: "true"
           kind: ConfigMap
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-server-local-user-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
@@ -521,11 +535,15 @@ data:
               # g, my-github-org:my-github-team, role:readonly
           kind: ConfigMap
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-server-rbac-config{{ .InstanceSuffix }}
           ---
           apiVersion: v1
           kind: Secret
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-dex-secrets{{ .InstanceSuffix }}
           stringData:
             dex-github-client-id: <GITHUB_CLIENT_ID>
@@ -534,389 +552,401 @@ data:
           apiVersion: v1
           kind: Secret
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-server-secrets{{ .InstanceSuffix }}
           type: Opaque
           ---
           apiVersion: v1
           kind: Service
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-dex-server{{ .InstanceSuffix }}
           spec:
             ports:
-            - port: 5556
-              targetPort: 5556
+              - port: 5556
+                targetPort: 5556
             selector:
               app.kubernetes.io/component: dex-server
-              app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-dex-server
               app.kubernetes.io/part-of: numaflow
-              app.kubernetes.io/instance: "{{ .InstanceID }}"
           ---
           apiVersion: v1
           kind: Service
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-server{{ .InstanceSuffix }}
           spec:
             ports:
-            - port: 8443
-              targetPort: 8443
+              - port: 8443
+                targetPort: 8443
             selector:
               app.kubernetes.io/component: numaflow-ux
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
               app.kubernetes.io/name: numaflow-ux
               app.kubernetes.io/part-of: numaflow
-              app.kubernetes.io/instance: "{{ .InstanceID }}"
             type: ClusterIP
           ---
           apiVersion: apps/v1
           kind: Deployment
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-controller{{ .InstanceSuffix }}
           spec:
             replicas: 1
             selector:
               matchLabels:
                 app.kubernetes.io/component: controller-manager
+                app.kubernetes.io/instance: '{{ .InstanceID }}'
                 app.kubernetes.io/name: controller-manager
                 app.kubernetes.io/part-of: numaflow
-                app.kubernetes.io/instance: "{{ .InstanceID }}"
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: controller-manager
+                  app.kubernetes.io/instance: '{{ .InstanceID }}'
                   app.kubernetes.io/name: controller-manager
                   app.kubernetes.io/part-of: numaflow
-                  app.kubernetes.io/instance: "{{ .InstanceID }}"
               spec:
                 containers:
-                - args:
-                  - controller
-                  env:
-                  - name: NUMAFLOW_IMAGE
-                    value: quay.io/numaproj/numaflow:v1.3.3
-                  - name: NAMESPACE
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.namespace
-                  - name: NUMAFLOW_CONTROLLER_NAMESPACED
-                    valueFrom:
-                      configMapKeyRef:
-                        key: namespaced
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
-                    valueFrom:
-                      configMapKeyRef:
-                        key: managed.namespace
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_LEADER_ELECTION_DISABLED
-                    valueFrom:
-                      configMapKeyRef:
-                        key: controller.leader.election.disabled
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
-                    valueFrom:
-                      configMapKeyRef:
-                        key: controller.leader.election.lease.duration
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
-                    valueFrom:
-                      configMapKeyRef:
-                        key: controller.leader.election.lease.renew.deadline
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
-                    valueFrom:
-                      configMapKeyRef:
-                        key: controller.leader.election.lease.renew.period
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  image: quay.io/numaproj/numaflow:v1.3.3
-                  imagePullPolicy: Always
-                  livenessProbe:
-                    httpGet:
-                      path: /healthz
-                      port: 8081
-                    initialDelaySeconds: 3
-                    periodSeconds: 3
-                  name: controller-manager
-                  ports:
-                  - containerPort: 9090
-                    name: metrics
-                  readinessProbe:
-                    httpGet:
-                      path: /readyz
-                      port: 8081
-                    initialDelaySeconds: 3
-                    periodSeconds: 3
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 1024Mi
-                    requests:
-                      cpu: 100m
-                      memory: 200Mi
-                  volumeMounts:
-                  - mountPath: /etc/numaflow
-                    name: controller-config-volume
+                  - args:
+                      - controller
+                    env:
+                      - name: NUMAFLOW_IMAGE
+                        value: quay.io/numaproj/numaflow:v1.3.3
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: NUMAFLOW_CONTROLLER_NAMESPACED
+                        valueFrom:
+                          configMapKeyRef:
+                            key: namespaced
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
+                        valueFrom:
+                          configMapKeyRef:
+                            key: managed.namespace
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_LEADER_ELECTION_DISABLED
+                        valueFrom:
+                          configMapKeyRef:
+                            key: controller.leader.election.disabled
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
+                        valueFrom:
+                          configMapKeyRef:
+                            key: controller.leader.election.lease.duration
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
+                        valueFrom:
+                          configMapKeyRef:
+                            key: controller.leader.election.lease.renew.deadline
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
+                        valueFrom:
+                          configMapKeyRef:
+                            key: controller.leader.election.lease.renew.period
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                    image: quay.io/numaproj/numaflow:v1.3.3
+                    imagePullPolicy: Always
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 3
+                      periodSeconds: 3
+                    name: controller-manager
+                    ports:
+                      - containerPort: 9090
+                        name: metrics
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 3
+                      periodSeconds: 3
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1024Mi
+                      requests:
+                        cpu: 100m
+                        memory: 200Mi
+                    volumeMounts:
+                      - mountPath: /etc/numaflow
+                        name: controller-config-volume
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
                 serviceAccountName: numaflow-sa{{ .InstanceSuffix }}
                 volumes:
-                - configMap:
-                    name: numaflow-controller-config{{ .InstanceSuffix }}
-                  name: controller-config-volume
+                  - configMap:
+                      name: numaflow-controller-config{{ .InstanceSuffix }}
+                    name: controller-config-volume
           ---
           apiVersion: apps/v1
           kind: Deployment
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-dex-server{{ .InstanceSuffix }}
           spec:
             selector:
               matchLabels:
                 app.kubernetes.io/component: dex-server
-                app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
+                app.kubernetes.io/instance: '{{ .InstanceID }}'
+                app.kubernetes.io/name: numaflow-dex-server
                 app.kubernetes.io/part-of: numaflow
-                app.kubernetes.io/instance: "{{ .InstanceID }}"
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: dex-server
-                  app.kubernetes.io/name: numaflow-dex-server{{ .InstanceSuffix }}
+                  app.kubernetes.io/instance: '{{ .InstanceID }}'
+                  app.kubernetes.io/name: numaflow-dex-server
                   app.kubernetes.io/part-of: numaflow
-                  app.kubernetes.io/instance: "{{ .InstanceID }}"
               spec:
                 containers:
-                - command:
-                  - /usr/local/bin/dex
-                  - serve
-                  - /etc/numaflow/dex/cfg/config.yaml
-                  env:
-                  - name: GITHUB_CLIENT_ID
-                    valueFrom:
-                      secretKeyRef:
-                        key: dex-github-client-id
-                        name: numaflow-dex-secrets{{ .InstanceSuffix }}
-                  - name: GITHUB_CLIENT_SECRET
-                    valueFrom:
-                      secretKeyRef:
-                        key: dex-github-client-secret
-                        name: numaflow-dex-secrets{{ .InstanceSuffix }}
-                  image: dexidp/dex:v2.37.0
-                  imagePullPolicy: Always
-                  name: dex
-                  ports:
-                  - containerPort: 5556
-                  volumeMounts:
-                  - mountPath: /etc/numaflow/dex/cfg/config.yaml
-                    name: generated-dex-config
-                    subPath: config.yaml
-                  - mountPath: /etc/numaflow/dex/tls/tls.crt
-                    name: tls
-                    subPath: tls.crt
-                  - mountPath: /etc/numaflow/dex/tls/tls.key
-                    name: tls
-                    subPath: tls.key
+                  - command:
+                      - /usr/local/bin/dex
+                      - serve
+                      - /etc/numaflow/dex/cfg/config.yaml
+                    env:
+                      - name: GITHUB_CLIENT_ID
+                        valueFrom:
+                          secretKeyRef:
+                            key: dex-github-client-id
+                            name: numaflow-dex-secrets{{ .InstanceSuffix }}
+                      - name: GITHUB_CLIENT_SECRET
+                        valueFrom:
+                          secretKeyRef:
+                            key: dex-github-client-secret
+                            name: numaflow-dex-secrets{{ .InstanceSuffix }}
+                    image: dexidp/dex:v2.37.0
+                    imagePullPolicy: Always
+                    name: dex
+                    ports:
+                      - containerPort: 5556
+                    volumeMounts:
+                      - mountPath: /etc/numaflow/dex/cfg/config.yaml
+                        name: generated-dex-config
+                        subPath: config.yaml
+                      - mountPath: /etc/numaflow/dex/tls/tls.crt
+                        name: tls
+                        subPath: tls.crt
+                      - mountPath: /etc/numaflow/dex/tls/tls.key
+                        name: tls
+                        subPath: tls.key
                 initContainers:
-                - args:
-                  - dex-server-init
-                  env:
-                  - name: NUMAFLOW_SERVER_ADDRESS
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.address
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_SERVER_BASE_HREF
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.base.href
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  image: quay.io/numaproj/numaflow:v1.3.3
-                  imagePullPolicy: Always
-                  name: dex-init
-                  volumeMounts:
-                  - mountPath: /cfg
-                    name: connector-config
-                  - mountPath: /tls
-                    name: tls
-                  - mountPath: /tmp
-                    name: generated-dex-config
+                  - args:
+                      - dex-server-init
+                    env:
+                      - name: NUMAFLOW_SERVER_ADDRESS
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.address
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_BASE_HREF
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.base.href
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                    image: quay.io/numaproj/numaflow:v1.3.3
+                    imagePullPolicy: Always
+                    name: dex-init
+                    volumeMounts:
+                      - mountPath: /cfg
+                        name: connector-config
+                      - mountPath: /tls
+                        name: tls
+                      - mountPath: /tmp
+                        name: generated-dex-config
                 serviceAccountName: numaflow-dex-server{{ .InstanceSuffix }}
                 volumes:
-                - configMap:
-                    items:
-                    - key: config.yaml
-                      path: config.yaml
-                    name: numaflow-dex-server-config{{ .InstanceSuffix }}
-                  name: connector-config
-                - emptyDir: {}
-                  name: tls
-                - emptyDir: {}
-                  name: generated-dex-config
+                  - configMap:
+                      items:
+                        - key: config.yaml
+                          path: config.yaml
+                      name: numaflow-dex-server-config{{ .InstanceSuffix }}
+                    name: connector-config
+                  - emptyDir: {}
+                    name: tls
+                  - emptyDir: {}
+                    name: generated-dex-config
           ---
           apiVersion: apps/v1
           kind: Deployment
           metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
             name: numaflow-server{{ .InstanceSuffix }}
           spec:
             replicas: 1
             selector:
               matchLabels:
                 app.kubernetes.io/component: numaflow-ux
+                app.kubernetes.io/instance: '{{ .InstanceID }}'
                 app.kubernetes.io/name: numaflow-ux
                 app.kubernetes.io/part-of: numaflow
-                app.kubernetes.io/instance: "{{ .InstanceID }}"
             template:
               metadata:
                 labels:
                   app.kubernetes.io/component: numaflow-ux
+                  app.kubernetes.io/instance: '{{ .InstanceID }}'
                   app.kubernetes.io/name: numaflow-ux
                   app.kubernetes.io/part-of: numaflow
-                  app.kubernetes.io/instance: "{{ .InstanceID }}"
               spec:
                 containers:
-                - args:
-                  - server
-                  env:
-                  - name: NAMESPACE
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.namespace
-                  - name: NUMAFLOW_SERVER_INSECURE
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.insecure
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_SERVER_PORT_NUMBER
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.port
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_SERVER_NAMESPACED
-                    valueFrom:
-                      configMapKeyRef:
-                        key: namespaced
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_SERVER_MANAGED_NAMESPACE
-                    valueFrom:
-                      configMapKeyRef:
-                        key: managed.namespace
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_SERVER_BASE_HREF
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.base.href
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_SERVER_READONLY
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.readonly
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_SERVER_DISABLE_AUTH
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.disable.auth
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_SERVER_DEX_SERVER_ADDR
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.dex.server
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_SERVER_ADDRESS
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.address
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_SERVER_CORS_ALLOWED_ORIGINS
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.cors.allowed.origins
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  - name: NUMAFLOW_SERVER_DAEMON_CLIENT_PROTOCOL
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.daemon.client.protocol
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  image: quay.io/numaproj/numaflow:v1.3.3
-                  imagePullPolicy: Always
-                  livenessProbe:
-                    httpGet:
-                      path: /livez
-                      port: 8443
-                      scheme: HTTPS
-                    initialDelaySeconds: 3
-                    periodSeconds: 3
-                  name: main
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 1024Mi
-                    requests:
-                      cpu: 100m
-                      memory: 200Mi
-                  volumeMounts:
-                  - mountPath: /ui/build/runtime-env.js
-                    name: env-volume
-                    subPath: runtime-env.js
-                  - mountPath: /ui/build/index.html
-                    name: env-volume
-                    subPath: index.html
-                  - mountPath: /etc/numaflow
-                    name: rbac-config
+                  - args:
+                      - server
+                    env:
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: NUMAFLOW_SERVER_INSECURE
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.insecure
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_PORT_NUMBER
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.port
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_NAMESPACED
+                        valueFrom:
+                          configMapKeyRef:
+                            key: namespaced
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_MANAGED_NAMESPACE
+                        valueFrom:
+                          configMapKeyRef:
+                            key: managed.namespace
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_BASE_HREF
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.base.href
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_READONLY
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.readonly
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_DISABLE_AUTH
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.disable.auth
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_DEX_SERVER_ADDR
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.dex.server
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_ADDRESS
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.address
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_CORS_ALLOWED_ORIGINS
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.cors.allowed.origins
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_DAEMON_CLIENT_PROTOCOL
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.daemon.client.protocol
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                    image: quay.io/numaproj/numaflow:v1.3.3
+                    imagePullPolicy: Always
+                    livenessProbe:
+                      httpGet:
+                        path: /livez
+                        port: 8443
+                        scheme: HTTPS
+                      initialDelaySeconds: 3
+                      periodSeconds: 3
+                    name: main
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1024Mi
+                      requests:
+                        cpu: 100m
+                        memory: 200Mi
+                    volumeMounts:
+                      - mountPath: /ui/build/runtime-env.js
+                        name: env-volume
+                        subPath: runtime-env.js
+                      - mountPath: /ui/build/index.html
+                        name: env-volume
+                        subPath: index.html
+                      - mountPath: /etc/numaflow
+                        name: rbac-config
                 initContainers:
-                - args:
-                  - server-init
-                  env:
-                  - name: NUMAFLOW_SERVER_BASE_HREF
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.base.href
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  image: quay.io/numaproj/numaflow:v1.3.3
-                  imagePullPolicy: Always
-                  name: server-init
-                  volumeMounts:
-                  - mountPath: /opt/numaflow
-                    name: env-volume
-                - args:
-                  - server-secrets-init
-                  env:
-                  - name: NAMESPACE
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.namespace
-                  - name: NUMAFLOW_SERVER_DISABLE_AUTH
-                    valueFrom:
-                      configMapKeyRef:
-                        key: server.disable.auth
-                        name: numaflow-cmd-params-config{{ .InstanceSuffix }}
-                        optional: true
-                  image: quay.io/numaproj/numaflow:v1.3.3
-                  imagePullPolicy: Always
-                  name: server-secrets-init
+                  - args:
+                      - server-init
+                    env:
+                      - name: NUMAFLOW_SERVER_BASE_HREF
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.base.href
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                    image: quay.io/numaproj/numaflow:v1.3.3
+                    imagePullPolicy: Always
+                    name: server-init
+                    volumeMounts:
+                      - mountPath: /opt/numaflow
+                        name: env-volume
+                  - args:
+                      - server-secrets-init
+                    env:
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: NUMAFLOW_SERVER_DISABLE_AUTH
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.disable.auth
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                    image: quay.io/numaproj/numaflow:v1.3.3
+                    imagePullPolicy: Always
+                    name: server-secrets-init
                 securityContext:
                   runAsNonRoot: true
                   runAsUser: 9737
                 serviceAccountName: numaflow-server-sa{{ .InstanceSuffix }}
                 volumes:
-                - emptyDir: {}
-                  name: env-volume
-                - configMap:
-                    name: numaflow-server-rbac-config{{ .InstanceSuffix }}
-                  name: rbac-config
+                  - emptyDir: {}
+                    name: env-volume
+                  - configMap:
+                      name: numaflow-server-rbac-config{{ .InstanceSuffix }}
+                    name: rbac-config


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #373 

### Modifications

Created a script that uses kustomize and yq to generate a templated Numaflow controller definition manifest based on the latest version of the Numaflow numaspace-install manifest. The script can be called with an argument to generate a specified file or without an argument to generate the yaml file in the default controller definitions manifest directory (generated via `make start`).

### Verification

Manual tests performed on the script (both with and without argument) and tested the generated yaml in a cluster to validate the generated configmap.