### PR TITLE
chore: print message when configmaps change; remove outdated fields from configmap that's run locally

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -95,6 +95,8 @@ func (cm *NumaflowControllerDefinitionsManager) UpdateNumaflowControllerDefiniti
 	// Add or update the controller definition config based on a version
 	for _, controller := range config.ControllerDefinitions {
 		cm.rolloutConfig[controller.Version] = controller.FullSpec
+
+		fmt.Printf("Added/Updated Controller definition Config, version: %s\n", controller.Version)
 	}
 }
 
@@ -104,6 +106,8 @@ func (cm *NumaflowControllerDefinitionsManager) RemoveNumaflowControllerDefiniti
 
 	for _, controller := range config.ControllerDefinitions {
 		delete(cm.rolloutConfig, controller.Version)
+
+		fmt.Printf("Removed Controller definition Config, version: %s\n", controller.Version)
 	}
 }
 
@@ -163,6 +167,7 @@ func (cm *ConfigManager) loadGlobalConfig(
 			onErrorReloading(err)
 		}
 		cm.config = &newConfig
+		fmt.Printf("Global Config update: %+v\n", newConfig) // due to cyclical dependency, we can't call logger
 
 		// call any registered callbacks
 		for _, f := range cm.callbacks {
@@ -199,6 +204,7 @@ func (cm *ConfigManager) UpdateNamespaceConfig(namespace string, config Namespac
 	defer cm.namespaceConfigMapLock.Unlock()
 
 	cm.namespaceConfigMap[namespace] = config
+	fmt.Printf("Added Namespace ConfigMap for namespace %s\n", namespace)
 }
 
 func (cm *ConfigManager) UnsetNamespaceConfig(namespace string) {

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -212,6 +212,7 @@ func (cm *ConfigManager) UnsetNamespaceConfig(namespace string) {
 	defer cm.namespaceConfigMapLock.Unlock()
 
 	delete(cm.namespaceConfigMap, namespace)
+	fmt.Printf("Deleted Namespace ConfigMap for namespace %s\n", namespace)
 }
 
 func (cm *ConfigManager) GetNamespaceConfig(namespace string) *NamespaceConfig {

--- a/internal/controller/config/usde_config.go
+++ b/internal/controller/config/usde_config.go
@@ -23,6 +23,8 @@ func (cm *ConfigManager) UnsetUSDEConfig() {
 	defer cm.usdeConfigLock.Unlock()
 
 	cm.usdeConfig = USDEConfig{}
+
+	fmt.Println("USDE Config unset") // due to cyclical dependency, we can't call logger
 }
 
 func (cm *ConfigManager) GetUSDEConfig() USDEConfig {

--- a/internal/controller/config/usde_config.go
+++ b/internal/controller/config/usde_config.go
@@ -1,5 +1,7 @@
 package config
 
+import "fmt"
+
 type USDEConfig struct {
 	// If user's config doesn't exist or doesn't specify strategy, this is the default
 	DefaultUpgradeStrategy      USDEUserStrategy `json:"defaultUpgradeStrategy" mapstructure:"defaultUpgradeStrategy"`
@@ -12,6 +14,8 @@ func (cm *ConfigManager) UpdateUSDEConfig(config USDEConfig) {
 	defer cm.usdeConfigLock.Unlock()
 
 	cm.usdeConfig = config
+
+	fmt.Printf("USDE Config update: %+v\n", config) // due to cyclical dependency, we can't call logger
 }
 
 func (cm *ConfigManager) UnsetUSDEConfig() {

--- a/tests/manifests/default/config.yaml
+++ b/tests/manifests/default/config.yaml
@@ -1,7 +1,4 @@
 logLevel: 4
-clusterName: "staging-usw2-k8s"
-syncTimeIntervalMs: 30000
-cascadeDeletion: false
 numaflowControllerImageNames:
   - numaflow
   - numaflow-rc


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

I noticed we weren't printing anything when the configmaps change. I'm guessing people decided not to because there's a cyclical dependency caused if you try to use the logger, which depends on the `config` module. I decided to just add `fmt.Printf` statements in that case.

Second, I also noticed there were some outdated fields in the configmap we're applying when we run `make start` (from original Numaplane), so I removed them.

### Verification

Updated ConfigMaps and verified I saw the changes reflected in the log.