### PR TITLE
feat: distinguish pause metrics between Paused and Pausing phases

### DIFF
--- a/internal/controller/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout_controller.go
@@ -646,32 +646,41 @@ func (r *PipelineRolloutReconciler) setChildResourcesPauseCondition(pipelineRoll
 		}
 		reason := fmt.Sprintf("Pipeline%s", string(pipelinePhase))
 		msg := fmt.Sprintf("Pipeline %s", strings.ToLower(string(pipelinePhase)))
-		r.updatePauseMetric(pipelineRollout)
+		r.updatePauseMetric(pipelineRollout, pipelinePhase)
 		pipelineRollout.Status.MarkPipelinePausingOrPaused(reason, msg, pipelineRollout.Generation)
 	} else {
 		// only set EndTime if BeginTime has been previously set AND EndTime is before/equal to BeginTime
 		// EndTime is either just initialized or the end of a previous pause which is why it will be before the new BeginTime
 		if (pipelineRollout.Status.PauseStatus.LastPauseBeginTime != metav1.NewTime(initTime)) && !pipelineRollout.Status.PauseStatus.LastPauseEndTime.After(pipelineRollout.Status.PauseStatus.LastPauseBeginTime.Time) {
 			pipelineRollout.Status.PauseStatus.LastPauseEndTime = metav1.NewTime(time.Now())
-			r.updatePauseMetric(pipelineRollout)
+			r.updatePauseMetric(pipelineRollout, pipelinePhase)
 		}
 		pipelineRollout.Status.MarkPipelineUnpaused(pipelineRollout.Generation)
 	}
 
 }
 
-func (r *PipelineRolloutReconciler) updatePauseMetric(pipelineRollout *apiv1.PipelineRollout) {
+func (r *PipelineRolloutReconciler) updatePauseMetric(pipelineRollout *apiv1.PipelineRollout, pipelinePhase numaflowv1.PipelinePhase) {
 
 	var pipelineSpec PipelineSpec
 	_ = json.Unmarshal(pipelineRollout.Spec.Pipeline.Spec.Raw, &pipelineSpec)
 
 	timeElapsed := time.Since(pipelineRollout.Status.PauseStatus.LastPauseBeginTime.Time)
 	if r.isSpecBasedPause(pipelineSpec) {
-		r.customMetrics.PipelinePausedSeconds.WithLabelValues(pipelineRollout.Namespace, pipelineRollout.Name, "user_pause").Set(timeElapsed.Seconds())
+		r.setMetric(pipelineRollout.Namespace, pipelineRollout.Name, float64(0), float64(0))
+	} else if pipelinePhase == numaflowv1.PipelinePhasePaused {
+		r.setMetric(pipelineRollout.Namespace, pipelineRollout.Name, timeElapsed.Seconds(), float64(0))
+	} else if pipelinePhase == numaflowv1.PipelinePhasePausing {
+		r.setMetric(pipelineRollout.Namespace, pipelineRollout.Name, float64(0), timeElapsed.Seconds())
 	} else {
-		r.customMetrics.PipelinePausedSeconds.WithLabelValues(pipelineRollout.Namespace, pipelineRollout.Name, "system_pause").Set(timeElapsed.Seconds())
+		r.setMetric(pipelineRollout.Namespace, pipelineRollout.Name, float64(0), float64(0))
 	}
 
+}
+
+func (r *PipelineRolloutReconciler) setMetric(namespace, name string, pausedVal, pausingVal float64) {
+	r.customMetrics.PipelinePausedSeconds.WithLabelValues(namespace, name).Set(pausedVal)
+	r.customMetrics.PipelinePausingSeconds.WithLabelValues(namespace, name).Set(pausingVal)
 }
 
 func (r *PipelineRolloutReconciler) needsUpdate(old, new *apiv1.PipelineRollout) bool {

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -63,6 +63,8 @@ type CustomMetrics struct {
 	ClusterCacheError *prometheus.CounterVec
 	// PipelinePausedSeconds counts the total time a Pipeline was paused.
 	PipelinePausedSeconds *prometheus.GaugeVec
+	// PipelinePausingSeconds counts the total time a Pipeline was pausing.
+	PipelinePausingSeconds *prometheus.GaugeVec
 	// ISBServicePausedSeconds counts the total time an ISBService requested resources be paused.
 	ISBServicePausedSeconds *prometheus.GaugeVec
 	// NumaflowControllerPausedSeconds counts the total time a Numaflow controller requested resources be paused.
@@ -81,7 +83,6 @@ const (
 	LabelISBService         = "isbservice"
 	LabelNumaflowController = "numaflowcontroller"
 	LabelMonoVertex         = "monovertex"
-	LabelPauseType          = "pause_type"
 )
 
 var (
@@ -127,10 +128,17 @@ var (
 
 	// pipelinePausedSeconds Check the total time a pipeline was paused
 	pipelinePausedSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "numaflow_pipeline_paused_seconds",
-		Help:        "Duration a pipeline was paused for",
+		Name:        "numaflow_pipeline_system_paused_seconds",
+		Help:        "Duration a pipeline is paused for",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelName, LabelPauseType})
+	}, []string{LabelNamespace, LabelName})
+
+	// pipelinePausingSeconds Check the total time a pipeline was pausing
+	pipelinePausingSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        "numaflow_pipeline_system_pausing_seconds",
+		Help:        "Duration a pipeline is pausing for",
+		ConstLabels: defaultLabels,
+	}, []string{LabelNamespace, LabelName})
 
 	// pipelineROSyncs Check the total number of pipeline rollout reconciliations
 	pipelineROSyncs = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -280,7 +288,7 @@ func RegisterCustomMetrics() *CustomMetrics {
 		monoVerticesRolloutHealth, monoVertexRolloutsRunning, monoVertexROSyncs, monoVertexROSyncErrors,
 		numaflowControllersRolloutHealth, numaflowControllerRORunning, numaflowControllerROSyncs, numaflowControllerROSyncErrors, reconciliationDuration, kubeRequestCounter,
 		numaflowControllerKubectlExecutionCounter, kubeResourceCacheMonitored, kubeResourceCache, clusterCacheError,
-		pipelinePausedSeconds, isbServicePausedSeconds, numaflowControllerPausedSeconds)
+		pipelinePausedSeconds, pipelinePausingSeconds, isbServicePausedSeconds, numaflowControllerPausedSeconds)
 
 	return &CustomMetrics{
 		PipelinesRolloutHealth:                    pipelinesRolloutHealth,
@@ -310,6 +318,7 @@ func RegisterCustomMetrics() *CustomMetrics {
 		KubeResourceCache:                         kubeResourceCache,
 		ClusterCacheError:                         clusterCacheError,
 		PipelinePausedSeconds:                     pipelinePausedSeconds,
+		PipelinePausingSeconds:                    pipelinePausingSeconds,
 		ISBServicePausedSeconds:                   isbServicePausedSeconds,
 		NumaflowControllerPausedSeconds:           numaflowControllerPausedSeconds,
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #307 

### Modifications

Splits the current PipelinesPausing metric into two separate metrics: one for when the Pipeline is in the Pausing phase and another for when it in the Paused phase. By splitting these metrics, we will be able to accurately track if a Pipeline is stuck in a certain phase and an issue may be occurring as opposed to just being in the Paused state like we assume.

We also now only track system pauses as opposed to differentiating between user and system pauses. For user pauses, we expect to not to have to alert on users leaving their Pipelines paused. By tracking system pauses, we will be able to see errors occurring with the PPND strategy.

Within discussion for this implementation, we also will not add MonoVertex pausing metrics as there is no PPND strategy for the CRD at this time.

```
# HELP numaflow_pipeline_system_paused_seconds Duration a pipeline is paused for
# TYPE numaflow_pipeline_system_paused_seconds gauge
numaflow_pipeline_system_paused_seconds{intuit_alert="true",name="my-pipeline",namespace="example-namespace"} 0
# HELP numaflow_pipeline_system_pausing_seconds Duration a pipeline is pausing for
# TYPE numaflow_pipeline_system_pausing_seconds gauge
numaflow_pipeline_system_pausing_seconds{intuit_alert="true",name="my-pipeline",namespace="example-namespace"} 0
```

### Verification

Testing locally with PPND causing changes to a PipelineRollout and changing the desiredPhase to show user pausing.