### PR TITLE
feat: add option to override defaultStrategy with noStrategy

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1466,7 +1466,9 @@ metadata:
 ---
 apiVersion: v1
 data:
-  defaultUpgradeStrategy: ""
+  defaultUpgradeStrategy: pause-and-drain
+  isbServiceSpecExcludedPaths: |
+    - "jetstream.containerTemplate.resources.limits"
   pipelineSpecExcludedPaths: |
     - "lifecycle"
     - "limits"

--- a/config/manager/usde-config.yaml
+++ b/config/manager/usde-config.yaml
@@ -5,8 +5,10 @@ metadata:
   labels:
     numaplane.numaproj.io/config: usde-config
 data:
-  defaultUpgradeStrategy: ""
+  defaultUpgradeStrategy: "pause-and-drain"
   pipelineSpecExcludedPaths: |
     - "lifecycle"
     - "limits"
     - "watermark"
+  isbServiceSpecExcludedPaths: |
+    - "jetstream.containerTemplate.resources.limits"

--- a/internal/controller/config/user_config.go
+++ b/internal/controller/config/user_config.go
@@ -10,7 +10,7 @@ type USDEUserStrategy string
 const (
 	ProgressiveStrategyID USDEUserStrategy = "progressive"
 	PPNDStrategyID        USDEUserStrategy = "pause-and-drain"
-	NoStrategyID          USDEUserStrategy = ""
+	NoStrategyID          USDEUserStrategy = "no-strategy"
 )
 
 func (s *USDEUserStrategy) UnmarshalJSON(data []byte) (err error) {
@@ -22,7 +22,7 @@ func (s *USDEUserStrategy) UnmarshalJSON(data []byte) (err error) {
 	allowedValues := map[USDEUserStrategy]struct{}{
 		ProgressiveStrategyID: {},
 		PPNDStrategyID:        {},
-		NoStrategyID:          {}} // TODO: this will no longer be allowed in the future
+		NoStrategyID:          {}}
 
 	// Make sure the string is one of the possible strategy values
 	_, found := allowedValues[USDEUserStrategy(usdeUserStrategyStr)]
@@ -40,6 +40,8 @@ func (s USDEUserStrategy) IsValid() bool {
 	case ProgressiveStrategyID:
 		return true
 	case PPNDStrategyID:
+		return true
+	case NoStrategyID:
 		return true
 	default:
 		return false

--- a/internal/usde/usde.go
+++ b/internal/usde/usde.go
@@ -190,7 +190,7 @@ func getDataLossUpggradeStrategy(ctx context.Context, namespace string) (apiv1.U
 		return apiv1.UpgradeStrategyPPND, nil
 	case config.ProgressiveStrategyID:
 		return apiv1.UpgradeStrategyProgressive, nil
-	case config.NoStrategyID:
+	case config.NoStrategyID, "":
 		return apiv1.UpgradeStrategyApply, nil
 	default:
 		return apiv1.UpgradeStrategyError, fmt.Errorf("invalid Upgrade Strategy: %v", userUpgradeStrategy)
@@ -203,6 +203,9 @@ func GetUserStrategy(ctx context.Context, namespace string) (config.USDEUserStra
 	namespaceConfig := config.GetConfigManagerInstance().GetNamespaceConfig(namespace)
 
 	var userUpgradeStrategy config.USDEUserStrategy = config.GetConfigManagerInstance().GetUSDEConfig().DefaultUpgradeStrategy
+	if userUpgradeStrategy == "" {
+		userUpgradeStrategy = config.NoStrategyID
+	}
 	if namespaceConfig != nil {
 		if !namespaceConfig.UpgradeStrategy.IsValid() {
 			numaLogger.WithValues("upgrade strategy", namespaceConfig.UpgradeStrategy).Warnf("invalid Upgrade strategy for namespace %s", namespace)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #386 

### Modifications

Allows user to specify `no-strategy` as a valid option for upgrade strategy in the user namespace config.

Previously we viewed empty string as specifying no-strategy but now we look for this to be specifically to override the current setting.

### Verification

Running `PPND=true make start` and testing with a namespace config that says `no-strategy`

Watched that the Pipeline we updated did not pause when changes were applied to the rollout.