### PR TITLE
chore: use Numaflow v1.4.0 in e2e testing

### DIFF
--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -42,8 +42,8 @@ const (
 	pipelineName                     = "test-pipeline-rollout-0"
 	monoVertexRolloutName            = "test-monovertex-rollout"
 	monoVertexName                   = "test-monovertex-rollout-0"
-	initialNumaflowControllerVersion = "1.3.3"
-	updatedNumaflowControllerVersion = "1.4.0"
+	initialNumaflowControllerVersion = "1.4.0"
+	updatedNumaflowControllerVersion = "1.4.0-copy"
 	initialJetstreamVersion          = "2.9.6"
 	updatedJetstreamVersion          = "2.9.8"
 )

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -557,7 +557,8 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		verifyNumaflowControllerDeployment(Namespace, func(d appsv1.Deployment) bool {
 			colon := strings.Index(d.Spec.Template.Spec.Containers[0].Image, ":")
-			return colon != -1 && d.Spec.Template.Spec.Containers[0].Image[colon+1:] == "v"+updatedNumaflowControllerVersion
+			// change to updatedNumaflowControllerVersion when we stop using copy
+			return colon != -1 && d.Spec.Template.Spec.Containers[0].Image[colon+1:] == "v"+initialNumaflowControllerVersion
 		})
 
 		verifyNumaflowControllerRolloutReady()

--- a/tests/manifests/default/controller_def_1.4.0-copy.yaml
+++ b/tests/manifests/default/controller_def_1.4.0-copy.yaml
@@ -1,0 +1,1015 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: numaflow-controller-definitions-1.4.0-copy
+  namespace: numaplane-system
+  labels:
+    "numaplane.numaproj.io/config": numaflow-controller-definitions
+data:
+  controller_definitions.yaml: |-
+    controllerDefinitions:
+      - version: "1.4.0-copy"
+        fullSpec: |-
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-dex-server{{ .InstanceSuffix }}
+          ---
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-sa{{ .InstanceSuffix }}
+          ---
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-server-sa{{ .InstanceSuffix }}
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            labels:
+              app.kubernetes.io/component: dex-server
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-dex-server
+              app.kubernetes.io/part-of: numaflow
+            name: numaflow-dex-server{{ .InstanceSuffix }}
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            labels:
+              app.kubernetes.io/component: controller-manager
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-controller-manager
+              app.kubernetes.io/part-of: numaflow
+            name: numaflow-role{{ .InstanceSuffix }}
+          rules:
+            - apiGroups:
+                - numaflow.numaproj.io
+              resources:
+                - interstepbufferservices
+                - interstepbufferservices/finalizers
+                - interstepbufferservices/status
+                - pipelines
+                - pipelines/finalizers
+                - pipelines/status
+                - vertices
+                - vertices/finalizers
+                - vertices/status
+                - vertices/scale
+                - monovertices
+                - monovertices/finalizers
+                - monovertices/status
+                - monovertices/scale
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - pods/exec
+                - configmaps
+                - services
+                - persistentvolumeclaims
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - statefulsets
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - update
+                - patch
+                - delete
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            labels:
+              app.kubernetes.io/component: numaflow-ux
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-ux
+              app.kubernetes.io/part-of: numaflow
+            name: numaflow-server-role{{ .InstanceSuffix }}
+          rules:
+            - apiGroups:
+                - numaflow.numaproj.io
+              resources:
+                - interstepbufferservices
+                - interstepbufferservices/finalizers
+                - interstepbufferservices/status
+                - pipelines
+                - pipelines/finalizers
+                - pipelines/status
+                - vertices
+                - vertices/finalizers
+                - vertices/status
+                - vertices/scale
+                - monovertices
+                - monovertices/finalizers
+                - monovertices/status
+                - monovertices/scale
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+                - pods
+                - pods/log
+                - configmaps
+                - services
+                - persistentvolumeclaims
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - statefulsets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - metrics.k8s.io
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            labels:
+              app.kubernetes.io/component: numaflow-ux
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-ux
+              app.kubernetes.io/part-of: numaflow
+            name: numaflow-server-secrets-role{{ .InstanceSuffix }}
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            labels:
+              app.kubernetes.io/component: dex-server
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-dex-server
+              app.kubernetes.io/part-of: numaflow
+            name: numaflow-dex-server{{ .InstanceSuffix }}
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: numaflow-dex-server{{ .InstanceSuffix }}
+          subjects:
+            - kind: ServiceAccount
+              name: numaflow-dex-server{{ .InstanceSuffix }}
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            labels:
+              app.kubernetes.io/component: controller-manager
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-controller-manager
+              app.kubernetes.io/part-of: numaflow
+            name: numaflow-role-binding{{ .InstanceSuffix }}
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: numaflow-role{{ .InstanceSuffix }}
+          subjects:
+            - kind: ServiceAccount
+              name: numaflow-sa{{ .InstanceSuffix }}
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            labels:
+              app.kubernetes.io/component: numaflow-ux
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-ux
+              app.kubernetes.io/part-of: numaflow
+            name: numaflow-server-binding{{ .InstanceSuffix }}
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: numaflow-server-role{{ .InstanceSuffix }}
+          subjects:
+            - kind: ServiceAccount
+              name: numaflow-server-sa{{ .InstanceSuffix }}
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            labels:
+              app.kubernetes.io/component: numaflow-ux
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-ux
+              app.kubernetes.io/part-of: numaflow
+            name: numaflow-server-secrets-binding{{ .InstanceSuffix }}
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: numaflow-server-secrets-role{{ .InstanceSuffix }}
+          subjects:
+            - kind: ServiceAccount
+              name: numaflow-server-sa{{ .InstanceSuffix }}
+          ---
+          apiVersion: v1
+          data:
+            namespaced: "true"
+            server.disable.auth: "true"
+          kind: ConfigMap
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+          ---
+          apiVersion: v1
+          data:
+            controller-config.yaml: |-
+              # "instance" configuration can be used to run multiple Numaflow controllers, check details at https://numaflow.numaproj.io/operations/installation/#multiple-controllers
+              instance: "{{ .InstanceID }}"
+              defaults:
+                containerResources: |
+                  requests:
+                    memory: "128Mi"
+                    cpu: "100m"
+              isbsvc:
+                redis:
+                  # Default Redis settings, could be overridden by InterStepBufferService specs
+                  settings:
+                    # Redis config shared by both master and replicas
+                    redis: |
+                      min-replicas-to-write 1
+                      # Disable RDB persistence, AOF persistence already enabled.
+                      save ""
+                      # Enable AOF https://redis.io/topics/persistence#append-only-file
+                      appendonly yes
+                      auto-aof-rewrite-percentage 100
+                      auto-aof-rewrite-min-size 64mb
+                      maxmemory 512mb
+                      maxmemory-policy allkeys-lru
+                    # Special config only used by master
+                    master: ""
+                    # Special config only used by replicas
+                    replica: ""
+                    # Sentinel config
+                    sentinel: |
+                      sentinel down-after-milliseconds mymaster 10000
+                      sentinel failover-timeout mymaster 2000
+                      sentinel parallel-syncs mymaster 1
+                  versions:
+                    - version: 7.0.11
+                      redisImage: bitnami/redis:7.0.11-debian-11-r3
+                      sentinelImage: bitnami/redis-sentinel:7.0.11-debian-11-r3
+                      redisExporterImage: bitnami/redis-exporter:1.50.0-debian-11-r4
+                      initContainerImage: debian:latest
+                    - version: 7.0.15
+                      redisImage: bitnami/redis:7.0.15-debian-11-r2
+                      sentinelImage: bitnami/redis-sentinel:7.0.15-debian-11-r2
+                      redisExporterImage: bitnami/redis-exporter:1.56.0-debian-11-r2
+                      initContainerImage: debian:latest
+                jetstream:
+                  # Default JetStream settings, could be overridden by InterStepBufferService specs
+                  settings: |
+                    # https://docs.nats.io/running-a-nats-service/configuration#limits
+                    # Only support to configure "max_payload".
+                    # Max payload size in bytes, defaults to 1 MB. It is not recommended to use values over 8MB but max_payload can be set up to 64MB.
+                    max_payload: 1048576
+                    # https://docs.nats.io/running-a-nats-service/configuration#jetstream
+                    # Only configure "max_memory_store" or "max_file_store", do not set "store_dir" as it has been hardcoded.
+                    # e.g. 1G. -1 means no limit, up to 75% of available memory. This only take effect for streams created using memory storage.
+                    max_memory_store: -1
+                    # e.g. 20G. -1 means no limit, Up to 1TB if available
+                    max_file_store: 1TB
+                  bufferConfig: |
+                    # The default properties of the buffers (streams) to be created in this JetStream service
+                    stream:
+                      # 0: Limits, 1: Interest, 2: WorkQueue
+                      retention: 0
+                      maxMsgs: 100000
+                      maxAge: 72h
+                      maxBytes: -1
+                      # 0: File, 1: Memory
+                      storage: 0
+                      replicas: 3
+                      duplicates: 60s
+                    # The default consumer properties for the created streams
+                    consumer:
+                      ackWait: 60s
+                      maxAckPending: 25000
+                    otBucket:
+                      maxValueSize: 0
+                      history: 1
+                      ttl: 3h
+                      maxBytes: 0
+                      # 0: File, 1: Memory
+                      storage: 0
+                      replicas: 3
+                    procBucket:
+                      maxValueSize: 0
+                      history: 1
+                      ttl: 72h
+                      maxBytes: 0
+                      # 0: File, 1: Memory
+                      storage: 0
+                      replicas: 3
+                  versions:
+                    - version: latest
+                      natsImage: nats:2.10.17
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.8.1
+                      natsImage: nats:2.8.1
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.8.1-alpine
+                      natsImage: nats:2.8.1-alpine
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: nats-server
+                    - version: 2.8.3
+                      natsImage: nats:2.8.3
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.8.3-alpine
+                      natsImage: nats:2.8.3-alpine
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: nats-server
+                    - version: 2.9.0
+                      natsImage: nats:2.9.0
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.9.0-alpine
+                      natsImage: nats:2.9.0-alpine
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: nats-server
+                    - version: 2.9.6
+                      natsImage: nats:2.9.6
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.9.8
+                      natsImage: nats:2.9.8
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.9.15
+                      natsImage: nats:2.9.15
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.10.3
+                      natsImage: nats:2.10.3
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.10.11
+                      natsImage: nats:2.10.11
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+                    - version: 2.10.17
+                      natsImage: nats:2.10.17
+                      metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+                      configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+                      startCommand: /nats-server
+          kind: ConfigMap
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-controller-config{{ .InstanceSuffix }}
+          ---
+          apiVersion: v1
+          data:
+            config.yaml: |-
+              connectors:
+              - type: github
+                # https://dexidp.io/docs/connectors/github/
+                id: github
+                name: GitHub
+                config:
+                  clientID: $GITHUB_CLIENT_ID
+                  clientSecret: $GITHUB_CLIENT_SECRET
+                  orgs:
+                  - name: <ORG_NAME>
+                    teams:
+                    - admin
+                    - readonly
+          kind: ConfigMap
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-dex-server-config{{ .InstanceSuffix }}
+          ---
+          apiVersion: v1
+          data:
+            admin.enabled: "true"
+          kind: ConfigMap
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-server-local-user-config{{ .InstanceSuffix }}
+          ---
+          apiVersion: v1
+          data:
+            config.yaml: |
+              # url is a required field, it should be the url of the service to which the metrics proxy will connect
+              # url: service_name + "." + service_namespace + ".svc.cluster.local" + ":" + port
+              # example for local prometheus service
+              # url: http://prometheus-operated.monitoring.svc.cluster.local:9090
+              patterns:
+              - name: mono_vertex_histogram
+                object: mono-vertex
+                title: Processing Time Latency
+                description: This query pattern is for P99,P90 and P50 quantiles for a mono-vertex across different dimensions
+                expr: |
+                  histogram_quantile($quantile, sum by($dimension,le) (rate($metric_name{$filters}[$duration])))
+                params:
+                  - name: quantile
+                    required: true
+                  - name: duration
+                    required: true
+                  - name: start_time
+                    required: false
+                  - name: end_time
+                    required: false
+                metrics:
+                  - metric_name: monovtx_processing_time_bucket
+                    required_filters:
+                      - namespace
+                      - mvtx_name
+                    dimensions:
+                      - name: pod
+                        # expr: optional expression for prometheus query
+                        # overrides the default expression
+                        filters:
+                          - name: pod
+                            required: false
+                      - name: mono-vertex
+                        # expr: optional expression for prometheus query
+                        # overrides the default expression
+                  # Add histogram metrics similar to the pattern above
+                  #- metric_name: monovtx_sink_time_bucket
+                  #  required_filters:
+                  #    - namespace
+                  #    - mvtx_name
+                  #  dimensions:
+                  #    - name: pod
+                  #      #expr: optional
+                  #      filters:
+                  #        - name: pod
+                  #          required: false
+                  #    - name: mono-vertex
+                  #      #expr: optional
+          kind: ConfigMap
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-server-metrics-proxy-config{{ .InstanceSuffix }}
+          ---
+          apiVersion: v1
+          data:
+            rbac-conf.yaml: |
+              policy.default: role:readonly
+              # The scopes field controls which authentication scopes to examine during rbac enforcement.
+              # We can have multiple scopes, and the first scope that matches with the policy will be used.
+              # The default value is "groups", which means that the groups field of the user's token will be examined
+              # The other possible value is "email", which means that the email field of the user's token will be examined
+              # It can be provided as a comma-separated list, e.g "groups,email,username"
+              policy.scopes: groups,email,username
+            rbac-policy.csv: |
+              # Policies go here
+              p, role:admin, *, *, *
+              p, role:readonly, *, *, GET
+              # Groups go here
+              # g, admin, role:admin
+              # g, my-github-org:my-github-team, role:readonly
+          kind: ConfigMap
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-server-rbac-config{{ .InstanceSuffix }}
+          ---
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-dex-secrets{{ .InstanceSuffix }}
+          stringData:
+            dex-github-client-id: <GITHUB_CLIENT_ID>
+            dex-github-client-secret: <GITHUB_CLIENT_SECRET>
+          ---
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-server-secrets{{ .InstanceSuffix }}
+          type: Opaque
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-dex-server{{ .InstanceSuffix }}
+          spec:
+            ports:
+              - port: 5556
+                targetPort: 5556
+            selector:
+              app.kubernetes.io/component: dex-server
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-dex-server
+              app.kubernetes.io/part-of: numaflow
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-server{{ .InstanceSuffix }}
+          spec:
+            ports:
+              - port: 8443
+                targetPort: 8443
+            selector:
+              app.kubernetes.io/component: numaflow-ux
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+              app.kubernetes.io/name: numaflow-ux
+              app.kubernetes.io/part-of: numaflow
+            type: ClusterIP
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-controller{{ .InstanceSuffix }}
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: controller-manager
+                app.kubernetes.io/instance: '{{ .InstanceID }}'
+                app.kubernetes.io/name: controller-manager
+                app.kubernetes.io/part-of: numaflow
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/component: controller-manager
+                  app.kubernetes.io/instance: '{{ .InstanceID }}'
+                  app.kubernetes.io/name: controller-manager
+                  app.kubernetes.io/part-of: numaflow
+              spec:
+                containers:
+                  - args:
+                      - controller
+                    env:
+                      - name: NUMAFLOW_IMAGE
+                        value: quay.io/numaproj/numaflow:v1.4.0
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: NUMAFLOW_CONTROLLER_NAMESPACED
+                        valueFrom:
+                          configMapKeyRef:
+                            key: namespaced
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_CONTROLLER_MANAGED_NAMESPACE
+                        valueFrom:
+                          configMapKeyRef:
+                            key: managed.namespace
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_LEADER_ELECTION_DISABLED
+                        valueFrom:
+                          configMapKeyRef:
+                            key: controller.leader.election.disabled
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_LEADER_ELECTION_LEASE_DURATION
+                        valueFrom:
+                          configMapKeyRef:
+                            key: controller.leader.election.lease.duration
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_DEADLINE
+                        valueFrom:
+                          configMapKeyRef:
+                            key: controller.leader.election.lease.renew.deadline
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_LEADER_ELECTION_LEASE_RENEW_PERIOD
+                        valueFrom:
+                          configMapKeyRef:
+                            key: controller.leader.election.lease.renew.period
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                    image: quay.io/numaproj/numaflow:v1.4.0
+                    imagePullPolicy: Always
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 3
+                      periodSeconds: 3
+                    name: controller-manager
+                    ports:
+                      - containerPort: 9090
+                        name: metrics
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 3
+                      periodSeconds: 3
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1024Mi
+                      requests:
+                        cpu: 100m
+                        memory: 200Mi
+                    volumeMounts:
+                      - mountPath: /etc/numaflow
+                        name: controller-config-volume
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 9737
+                serviceAccountName: numaflow-sa{{ .InstanceSuffix }}
+                volumes:
+                  - configMap:
+                      name: numaflow-controller-config{{ .InstanceSuffix }}
+                    name: controller-config-volume
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-dex-server{{ .InstanceSuffix }}
+          spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: dex-server
+                app.kubernetes.io/instance: '{{ .InstanceID }}'
+                app.kubernetes.io/name: numaflow-dex-server
+                app.kubernetes.io/part-of: numaflow
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/component: dex-server
+                  app.kubernetes.io/instance: '{{ .InstanceID }}'
+                  app.kubernetes.io/name: numaflow-dex-server
+                  app.kubernetes.io/part-of: numaflow
+              spec:
+                containers:
+                  - command:
+                      - /usr/local/bin/dex
+                      - serve
+                      - /etc/numaflow/dex/cfg/config.yaml
+                    env:
+                      - name: GITHUB_CLIENT_ID
+                        valueFrom:
+                          secretKeyRef:
+                            key: dex-github-client-id
+                            name: numaflow-dex-secrets{{ .InstanceSuffix }}
+                      - name: GITHUB_CLIENT_SECRET
+                        valueFrom:
+                          secretKeyRef:
+                            key: dex-github-client-secret
+                            name: numaflow-dex-secrets{{ .InstanceSuffix }}
+                    image: dexidp/dex:v2.37.0
+                    imagePullPolicy: Always
+                    name: dex
+                    ports:
+                      - containerPort: 5556
+                    volumeMounts:
+                      - mountPath: /etc/numaflow/dex/cfg/config.yaml
+                        name: generated-dex-config
+                        subPath: config.yaml
+                      - mountPath: /etc/numaflow/dex/tls/tls.crt
+                        name: tls
+                        subPath: tls.crt
+                      - mountPath: /etc/numaflow/dex/tls/tls.key
+                        name: tls
+                        subPath: tls.key
+                initContainers:
+                  - args:
+                      - dex-server-init
+                    env:
+                      - name: NUMAFLOW_SERVER_ADDRESS
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.address
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_BASE_HREF
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.base.href
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                    image: quay.io/numaproj/numaflow:v1.4.0
+                    imagePullPolicy: Always
+                    name: dex-init
+                    volumeMounts:
+                      - mountPath: /cfg
+                        name: connector-config
+                      - mountPath: /tls
+                        name: tls
+                      - mountPath: /tmp
+                        name: generated-dex-config
+                serviceAccountName: numaflow-dex-server{{ .InstanceSuffix }}
+                volumes:
+                  - configMap:
+                      items:
+                        - key: config.yaml
+                          path: config.yaml
+                      name: numaflow-dex-server-config{{ .InstanceSuffix }}
+                    name: connector-config
+                  - emptyDir: {}
+                    name: tls
+                  - emptyDir: {}
+                    name: generated-dex-config
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            labels:
+              app.kubernetes.io/instance: '{{ .InstanceID }}'
+            name: numaflow-server{{ .InstanceSuffix }}
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: numaflow-ux
+                app.kubernetes.io/instance: '{{ .InstanceID }}'
+                app.kubernetes.io/name: numaflow-ux
+                app.kubernetes.io/part-of: numaflow
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/component: numaflow-ux
+                  app.kubernetes.io/instance: '{{ .InstanceID }}'
+                  app.kubernetes.io/name: numaflow-ux
+                  app.kubernetes.io/part-of: numaflow
+              spec:
+                containers:
+                  - args:
+                      - server
+                    env:
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: NUMAFLOW_SERVER_INSECURE
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.insecure
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_PORT_NUMBER
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.port
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_NAMESPACED
+                        valueFrom:
+                          configMapKeyRef:
+                            key: namespaced
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_MANAGED_NAMESPACE
+                        valueFrom:
+                          configMapKeyRef:
+                            key: managed.namespace
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_BASE_HREF
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.base.href
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_READONLY
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.readonly
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_DISABLE_AUTH
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.disable.auth
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_DEX_SERVER_ADDR
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.dex.server
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_ADDRESS
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.address
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_CORS_ALLOWED_ORIGINS
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.cors.allowed.origins
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                      - name: NUMAFLOW_SERVER_DAEMON_CLIENT_PROTOCOL
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.daemon.client.protocol
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                    image: quay.io/numaproj/numaflow:v1.4.0
+                    imagePullPolicy: Always
+                    livenessProbe:
+                      httpGet:
+                        path: /livez
+                        port: 8443
+                        scheme: HTTPS
+                      initialDelaySeconds: 3
+                      periodSeconds: 3
+                    name: main
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1024Mi
+                      requests:
+                        cpu: 100m
+                        memory: 200Mi
+                    volumeMounts:
+                      - mountPath: /ui/build/runtime-env.js
+                        name: env-volume
+                        subPath: runtime-env.js
+                      - mountPath: /ui/build/index.html
+                        name: env-volume
+                        subPath: index.html
+                      - mountPath: /etc/numaflow
+                        name: rbac-config
+                      - mountPath: /etc/numaflow/metrics-proxy
+                        name: metrics-proxy-config
+                initContainers:
+                  - args:
+                      - server-init
+                    env:
+                      - name: NUMAFLOW_SERVER_BASE_HREF
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.base.href
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                    image: quay.io/numaproj/numaflow:v1.4.0
+                    imagePullPolicy: Always
+                    name: server-init
+                    volumeMounts:
+                      - mountPath: /opt/numaflow
+                        name: env-volume
+                  - args:
+                      - server-secrets-init
+                    env:
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: NUMAFLOW_SERVER_DISABLE_AUTH
+                        valueFrom:
+                          configMapKeyRef:
+                            key: server.disable.auth
+                            name: numaflow-cmd-params-config{{ .InstanceSuffix }}
+                            optional: true
+                    image: quay.io/numaproj/numaflow:v1.4.0
+                    imagePullPolicy: Always
+                    name: server-secrets-init
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 9737
+                serviceAccountName: numaflow-server-sa{{ .InstanceSuffix }}
+                volumes:
+                  - emptyDir: {}
+                    name: env-volume
+                  - configMap:
+                      name: numaflow-server-rbac-config{{ .InstanceSuffix }}
+                    name: rbac-config
+                  - configMap:
+                      name: numaflow-server-metrics-proxy-config{{ .InstanceSuffix }}
+                    name: metrics-proxy-config

--- a/tests/manifests/default/kustomization.yaml
+++ b/tests/manifests/default/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../../config/default
   - ./controller_def_1.3.3.yaml
   - ./controller_def_1.4.0.yaml
+  - ./controller_def_1.4.0-copy.yaml
 
 patches:
   - patch: |-


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Related to https://github.com/numaproj/numaplane/issues/371#issuecomment-2475085380

### Modifications

Updates e2e testing to use Numaflow v1.4.0 the entire time to be sure the MonoVertex does not fall into a crash loop consistently. This is due to the stable images it uses not working well with older versions of Numaflow.

### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->