### PR TITLE
feat: refactoring watch logic for e2e tests

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -294,16 +294,19 @@ func writeToFile(fileName string, resource Output) error {
 	mutex.Lock()
 	defer mutex.Unlock()
 
-	file, err := os.Create(fileName)
-	if err != nil {
-		fmt.Printf("Failed to open log file: %v\n", err)
-		return err
+	if _, ok := openFiles[fileName]; !ok {
+		file, err := os.Create(fileName)
+		if err != nil {
+			fmt.Printf("Failed to open log file: %v\n", err)
+			return err
+		}
+		openFiles[fileName] = file
 	}
-	openFiles[fileName] = file
 
+	file := openFiles[fileName]
 	bytes, _ := yaml.Marshal(resource)
 	updateLog := fmt.Sprintf("%s\n%v\n\n%s\n", LogSpacer, time.Now().Format(time.RFC3339Nano), string(bytes))
-	_, err = file.WriteString(updateLog)
+	_, err := file.WriteString(updateLog)
 	if err != nil {
 		fmt.Printf("Failed to write to log file: %v\n", err)
 		return err

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -273,18 +273,8 @@ func watchPods() {
 						continue
 					}
 
-					file, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+					err := writeToFile(fileName, pd)
 					if err != nil {
-						fmt.Printf("Failed to open log file: %v\n", err)
-						return
-					}
-					defer file.Close()
-
-					bytes, _ := yaml.Marshal(pd)
-					updateLog := fmt.Sprintf("%s\n%v\n\n%s\n", LogSpacer, time.Now().Format(time.RFC3339Nano), string(bytes))
-					_, err = file.WriteString(updateLog)
-					if err != nil {
-						fmt.Printf("Failed to write to log file: %v\n", err)
 						return
 					}
 				}
@@ -293,4 +283,24 @@ func watchPods() {
 			return
 		}
 	}
+}
+
+// helper func to write `kubectl get -o yaml` output to file
+func writeToFile(fileName string, resource Output) error {
+	file, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Printf("Failed to open log file: %v\n", err)
+		return err
+	}
+	defer file.Close()
+
+	bytes, _ := yaml.Marshal(resource)
+	updateLog := fmt.Sprintf("%s\n%v\n\n%s\n", LogSpacer, time.Now().Format(time.RFC3339Nano), string(bytes))
+	_, err = file.WriteString(updateLog)
+	if err != nil {
+		fmt.Printf("Failed to write to log file: %v\n", err)
+		return err
+	}
+
+	return nil
 }

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -210,11 +210,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return err
 		}, testTimeout, testPollingInterval).Should(Succeed())
 
-		if disableTestArtifacts != "true" {
-			wg.Add(1)
-			go watchNumaflowControllerRollout()
-		}
-
 		verifyNumaflowControllerRolloutReady()
 
 		verifyNumaflowControllerReady(Namespace)
@@ -233,14 +228,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return err
 		}, testTimeout, testPollingInterval).Should(Succeed())
 
-		if disableTestArtifacts != "true" {
-			wg.Add(1)
-			go watchISBServiceRollout()
-
-			wg.Add(1)
-			go watchISBService()
-		}
-
 		verifyISBSvcRolloutReady(isbServiceRolloutName)
 
 		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
@@ -258,14 +245,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 			_, err := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 			return err
 		}, testTimeout, testPollingInterval).Should(Succeed())
-
-		if disableTestArtifacts != "true" {
-			wg.Add(1)
-			go watchPipelineRollout()
-
-			wg.Add(1)
-			go watchPipeline()
-		}
 
 		document("Verifying that the Pipeline was created")
 		verifyPipelineSpec(Namespace, pipelineName, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
@@ -299,14 +278,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 		verifyMonoVertexSpec(Namespace, monoVertexName, func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec) bool {
 			return monoVertexSpec.Source != nil
 		})
-
-		if disableTestArtifacts != "true" {
-			wg.Add(1)
-			go watchMonoVertexRollout()
-
-			wg.Add(1)
-			go watchMonoVertex()
-		}
 
 		verifyMonoVertexRolloutReady(monoVertexRolloutName)
 

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -3,12 +3,9 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
-	"time"
 
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/yaml"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,13 +95,6 @@ func watchNumaflowControllerRollout() {
 	}
 	defer watcher.Stop()
 
-	file, err := os.OpenFile(filepath.Join(ResourceChangesNumaflowControllerOutputPath, "numaflowcontroller_rollout.yaml"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		fmt.Printf("Failed to open log file: %v\n", err)
-		return
-	}
-	defer file.Close()
-
 	for {
 		select {
 		case event := <-watcher.ResultChan():
@@ -118,11 +108,9 @@ func watchNumaflowControllerRollout() {
 						Spec:       rollout.Spec,
 						Status:     rollout.Status,
 					}
-					bytes, _ := yaml.Marshal(rl)
-					updateLog := fmt.Sprintf("%s\n%v\n\n%s\n", LogSpacer, time.Now().Format(time.RFC3339Nano), string(bytes))
-					_, err = file.WriteString(updateLog)
+
+					err := writeToFile(filepath.Join(ResourceChangesNumaflowControllerOutputPath, "numaflowcontroller_rollout.yaml"), rl)
 					if err != nil {
-						fmt.Printf("Failed to write to log file: %v\n", err)
 						return
 					}
 				}

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -55,6 +55,8 @@ var _ = BeforeSuite(func() {
 		setupOutputDir()
 	}
 
+	openFiles = make(map[string]*os.File)
+
 	stopCh = make(chan struct{})
 
 	ppnd = os.Getenv("PPND")
@@ -139,7 +141,11 @@ var _ = AfterSuite(func() {
 	cancel()
 	By("tearing down test environment")
 	close(stopCh)
-	err := testEnv.Stop()
+
+	err := closeAllFiles()
+	Expect(err).NotTo(HaveOccurred())
+
+	err = testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 
 })

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -114,10 +114,13 @@ var _ = BeforeSuite(func() {
 		go watchPods()
 
 		wg.Add(1)
-		go watchStatefulSet()
+		go watchNumaflowControllerRollout()
 
-		wg.Add(1)
-		go watchVertices()
+		startPipelineRolloutWatches()
+
+		startISBServiceRolloutWatches()
+
+		startMonoVertexRolloutWatches()
 
 		if enablePodLogs == "true" {
 			wg.Add(1)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #430 

### Modifications

Refactors watch logic for e2e tests to minimize code redundancy between every call. This is achieved by making the `writeToFile` function that they all share to write the `kubectl get -o yaml` output to the resulting files. We also can start up every watch before the suite starts as opposed to starting them when the resource is created.

### Verification

Running `make test-e2e` and checking result artifacts.