### PR TITLE
chore: Make function signatures similar for WithDesiredPhase() and WithoutDesiredPhase()

### DIFF
--- a/internal/controller/common/numaflowtypes/pipeline.go
+++ b/internal/controller/common/numaflowtypes/pipeline.go
@@ -152,22 +152,15 @@ func WithDesiredPhase(pipeline *unstructured.Unstructured, phase string) error {
 	return nil
 }
 
-// TODO: make this and the WithDesiredPhase() signature (and possibly implmentation) from above similar to each other
-// (this may naturally happen after refactoring)
 // remove 'lifecycle.desiredPhase' key/value pair from spec
 // also remove 'lifecycle' if it's an empty map
-func WithoutDesiredPhase(pipeline *unstructured.Unstructured) (map[string]interface{}, error) {
-	var specAsMap map[string]any
-	if err := util.StructToStruct(pipeline.Object["spec"], &specAsMap); err != nil {
-		return nil, err
-	}
-	// remove "lifecycle.desiredPhase"
-	comparisonExcludedPaths := []string{"lifecycle.desiredPhase"}
-	util.RemovePaths(specAsMap, comparisonExcludedPaths, ".")
+func WithoutDesiredPhase(pipeline *unstructured.Unstructured) {
+	unstructured.RemoveNestedField(pipeline.Object, "spec", "lifecycle", "desiredPhase")
+
 	// if "lifecycle" is there and empty, remove it
-	lifecycleMap, found := specAsMap["lifecycle"].(map[string]interface{})
+	spec := pipeline.Object["spec"].(map[string]interface{})
+	lifecycleMap, found := spec["lifecycle"].(map[string]interface{})
 	if found && len(lifecycleMap) == 0 {
-		util.RemovePaths(specAsMap, []string{"lifecycle"}, ".")
+		unstructured.RemoveNestedField(pipeline.Object, "spec", "lifecycle")
 	}
-	return specAsMap, nil
 }

--- a/internal/controller/common/numaflowtypes/pipeline_test.go
+++ b/internal/controller/common/numaflowtypes/pipeline_test.go
@@ -1,0 +1,265 @@
+package numaflowtypes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var (
+	withDesiredPhase = `
+	{
+	  "interStepBufferServiceName": "default",
+	  "lifecycle": {
+		"desiredPhase": "Paused"
+	  },
+	  "vertices": [
+		{
+		  "name": "in",
+		  "source": {
+			"generator": {
+			  "rpu": 5,
+			  "duration": "1s"
+			}
+		  }
+		},
+		{
+		  "name": "out",
+		  "sink": {
+			"log": {}
+		  }
+		}
+	  ],
+	  "edges": [
+		{
+		  "from": "in",
+		  "to": "out"
+		}
+	  ]
+	}
+	`
+
+	withLifecycle = `
+	{
+	  "interStepBufferServiceName": "default",
+	  "lifecycle": {},
+	  "vertices": [
+		{
+		  "name": "in",
+		  "source": {
+			"generator": {
+			  "rpu": 5,
+			  "duration": "1s"
+			}
+		  }
+		},
+		{
+		  "name": "out",
+		  "sink": {
+			"log": {}
+		  }
+		}
+	  ],
+	  "edges": [
+		{
+		  "from": "in",
+		  "to": "out"
+		}
+	  ]
+	}
+	`
+
+	withoutLifecycle = `
+	{
+	  "interStepBufferServiceName": "default",
+	  "vertices": [
+		{
+		  "name": "in",
+		  "source": {
+			"generator": {
+			  "rpu": 5,
+			  "duration": "1s"
+			}
+		  }
+		},
+		{
+		  "name": "out",
+		  "sink": {
+			"log": {}
+		  }
+		}
+	  ],
+	  "edges": [
+		{
+		  "from": "in",
+		  "to": "out"
+		}
+	  ]
+	}
+	`
+
+	withDesiredPhaseAndPauseGracePeriodSeconds = `
+	{
+	  "interStepBufferServiceName": "default",
+	  "lifecycle": {
+		"desiredPhase": "Paused",
+		"pauseGracePeriodSeconds": "60"
+	  },
+	  "vertices": [
+		{
+		  "name": "in",
+		  "source": {
+			"generator": {
+			  "rpu": 5,
+			  "duration": "1s"
+			}
+		  }
+		},
+		{
+		  "name": "out",
+		  "sink": {
+			"log": {}
+		  }
+		}
+	  ],
+	  "edges": [
+		{
+		  "from": "in",
+		  "to": "out"
+		}
+	  ]
+	}
+	`
+
+	withPauseGracePeriodSeconds = `
+	{
+	  "interStepBufferServiceName": "default",
+	  "lifecycle": {
+		"pauseGracePeriodSeconds": "60"
+	  },
+	  "vertices": [
+		{
+		  "name": "in",
+		  "source": {
+			"generator": {
+			  "rpu": 5,
+			  "duration": "1s"
+			}
+		  }
+		},
+		{
+		  "name": "out",
+		  "sink": {
+			"log": {}
+		  }
+		}
+	  ],
+	  "edges": [
+		{
+		  "from": "in",
+		  "to": "out"
+		}
+	  ]
+	}
+	`
+)
+
+func Test_WithDesiredPhase(t *testing.T) {
+
+	testCases := []struct {
+		name                 string
+		originalPipelineYAML string
+		expectedPipelineYAML string
+	}{
+		{
+			name:                 "no initial lifecycle or desired phase",
+			originalPipelineYAML: withoutLifecycle,
+			expectedPipelineYAML: withDesiredPhase,
+		},
+		{
+			name:                 "initial lifecycle but not desired phase",
+			originalPipelineYAML: withLifecycle,
+			expectedPipelineYAML: withDesiredPhase,
+		},
+		{
+			name:                 "initial lifecycle and desired phase",
+			originalPipelineYAML: withDesiredPhase,
+			expectedPipelineYAML: withDesiredPhase,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// marshal original yaml into a map and put into an Unstructured type
+			pipeline := &unstructured.Unstructured{Object: make(map[string]interface{})}
+			var originalYamlSpec map[string]interface{}
+			err := json.Unmarshal([]byte(tc.originalPipelineYAML), &originalYamlSpec)
+			assert.NoError(t, err)
+			pipeline.Object["spec"] = originalYamlSpec
+
+			_ = WithDesiredPhase(pipeline, "Paused")
+
+			// marshal expected yaml into a map so we can compare them
+			var expectedYamlSpec map[string]interface{}
+			err = json.Unmarshal([]byte(tc.expectedPipelineYAML), &expectedYamlSpec)
+			assert.NoError(t, err)
+
+			assert.Equal(t, expectedYamlSpec, originalYamlSpec)
+
+		})
+	}
+}
+
+func Test_WithoutDesiredPhase(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		originalPipelineYAML string
+		expectedPipelineYAML string
+	}{
+		{
+			name:                 "no initial lifecycle or desired phase",
+			originalPipelineYAML: withoutLifecycle,
+			expectedPipelineYAML: withoutLifecycle,
+		},
+		{
+			name:                 "initial lifecycle but not desired phase",
+			originalPipelineYAML: withLifecycle,
+			expectedPipelineYAML: withoutLifecycle,
+		},
+		{
+			name:                 "initial lifecycle and desired phase",
+			originalPipelineYAML: withDesiredPhase,
+			expectedPipelineYAML: withoutLifecycle,
+		},
+		{
+			name:                 "initial lifecycle and desired phase and pauseGracePeriodSeconds",
+			originalPipelineYAML: withDesiredPhaseAndPauseGracePeriodSeconds,
+			expectedPipelineYAML: withPauseGracePeriodSeconds,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// marshal original yaml into a map and put into an Unstructured type
+			pipeline := &unstructured.Unstructured{Object: make(map[string]interface{})}
+			var originalYamlSpec map[string]interface{}
+			err := json.Unmarshal([]byte(tc.originalPipelineYAML), &originalYamlSpec)
+			assert.NoError(t, err)
+			pipeline.Object["spec"] = originalYamlSpec
+
+			WithoutDesiredPhase(pipeline)
+
+			// marshal expected yaml into a map so we can compare them
+			var expectedYamlSpec map[string]interface{}
+			err = json.Unmarshal([]byte(tc.expectedPipelineYAML), &expectedYamlSpec)
+			assert.NoError(t, err)
+
+			assert.Equal(t, expectedYamlSpec, originalYamlSpec)
+
+		})
+	}
+}

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -869,13 +869,15 @@ func (r *PipelineRolloutReconciler) drain(ctx context.Context, pipeline *unstruc
 // ChildNeedsUpdating() tests for essential equality, with any irrelevant fields eliminated from the comparison
 func (r *PipelineRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
+	fromCopy := from.DeepCopy()
+	toCopy := to.DeepCopy()
 	// remove lifecycle.desiredPhase field from comparison to test for equality
-	numaflowtypes.WithoutDesiredPhase(from)
-	numaflowtypes.WithoutDesiredPhase(to)
+	numaflowtypes.WithoutDesiredPhase(fromCopy)
+	numaflowtypes.WithoutDesiredPhase(toCopy)
 
-	specsEqual := reflect.DeepEqual(from.Object["spec"], to.Object["spec"])
+	specsEqual := reflect.DeepEqual(fromCopy.Object["spec"], toCopy.Object["spec"])
 	numaLogger.Debugf("specsEqual: %t, from=%v, to=%v\n",
-		specsEqual, from, to)
+		specsEqual, fromCopy, toCopy)
 	labelsEqual := util.CompareMaps(from.GetLabels(), to.GetLabels())
 	numaLogger.Debugf("labelsEqual: %t, from Labels=%v, to Labels=%v", labelsEqual, from.GetLabels(), to.GetLabels())
 	annotationsEqual := util.CompareMaps(from.GetAnnotations(), to.GetAnnotations())

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -870,18 +870,12 @@ func (r *PipelineRolloutReconciler) drain(ctx context.Context, pipeline *unstruc
 func (r *PipelineRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
 	// remove lifecycle.desiredPhase field from comparison to test for equality
-	pipelineWithoutDesiredPhaseA, err := numaflowtypes.WithoutDesiredPhase(from)
-	if err != nil {
-		return false, err
-	}
-	pipelineWithoutDesiredPhaseB, err := numaflowtypes.WithoutDesiredPhase(to)
-	if err != nil {
-		return false, err
-	}
+	numaflowtypes.WithoutDesiredPhase(from)
+	numaflowtypes.WithoutDesiredPhase(to)
 
-	specsEqual := reflect.DeepEqual(pipelineWithoutDesiredPhaseA, pipelineWithoutDesiredPhaseB)
-	numaLogger.Debugf("specsEqual: %t, pipelineWithoutDesiredPhaseA=%v, pipelineWithoutDesiredPhaseB=%v\n",
-		specsEqual, pipelineWithoutDesiredPhaseA, pipelineWithoutDesiredPhaseB)
+	specsEqual := reflect.DeepEqual(from.Object["spec"], to.Object["spec"])
+	numaLogger.Debugf("specsEqual: %t, from=%v, to=%v\n",
+		specsEqual, from, to)
 	labelsEqual := util.CompareMaps(from.GetLabels(), to.GetLabels())
 	numaLogger.Debugf("labelsEqual: %t, from Labels=%v, to Labels=%v", labelsEqual, from.GetLabels(), to.GetLabels())
 	annotationsEqual := util.CompareMaps(from.GetAnnotations(), to.GetAnnotations())

--- a/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
@@ -550,7 +550,7 @@ func Test_processExistingPipeline_PPND(t *testing.T) {
 		// require these Conditions to be set (note that in real life, previous reconciliations may have set other Conditions from before which are still present)
 		expectedPipelineSpecResult func(numaflowv1.PipelineSpec) bool
 	}{
-		/*{
+		{
 			name:                           "nothing to do",
 			newPipelineSpec:                pipelineSpec,
 			existingPipelineDef:            *createDefaultTestPipeline(numaflowv1.PipelinePhaseRunning),
@@ -650,7 +650,7 @@ func Test_processExistingPipeline_PPND(t *testing.T) {
 			expectedPipelineSpecResult: func(spec numaflowv1.PipelineSpec) bool {
 				return reflect.DeepEqual(ctlrcommon.PipelineWithDesiredPhase(pipelineSpec, numaflowv1.PipelinePhasePaused), spec)
 			},
-		},*/
+		},
 		{
 			name:            "PPND in progress, spec applied",
 			newPipelineSpec: pipelineSpecWithTopologyChange,

--- a/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
@@ -550,7 +550,7 @@ func Test_processExistingPipeline_PPND(t *testing.T) {
 		// require these Conditions to be set (note that in real life, previous reconciliations may have set other Conditions from before which are still present)
 		expectedPipelineSpecResult func(numaflowv1.PipelineSpec) bool
 	}{
-		{
+		/*{
 			name:                           "nothing to do",
 			newPipelineSpec:                pipelineSpec,
 			existingPipelineDef:            *createDefaultTestPipeline(numaflowv1.PipelinePhaseRunning),
@@ -650,7 +650,7 @@ func Test_processExistingPipeline_PPND(t *testing.T) {
 			expectedPipelineSpecResult: func(spec numaflowv1.PipelineSpec) bool {
 				return reflect.DeepEqual(ctlrcommon.PipelineWithDesiredPhase(pipelineSpec, numaflowv1.PipelinePhasePaused), spec)
 			},
-		},
+		},*/
 		{
 			name:            "PPND in progress, spec applied",
 			newPipelineSpec: pipelineSpecWithTopologyChange,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

Improving code quality by having these function signatures match


### Verification

- new unit tests plus existing unit test for `PipelineRolloutReconciler.ChildNeedsUpdating()` function
- existing e2e tests