### PR TITLE
fix: Ensure NumaflowControllerRollout is not removed until dependent are deleted

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -617,11 +617,18 @@ func generateNewISBServiceDef(isbServiceRollout *apiv1.ISBServiceRollout) (*unst
 	newISBServiceDef := &unstructured.Unstructured{Object: make(map[string]interface{})}
 	newISBServiceDef.SetName(isbServiceRollout.Name)
 	newISBServiceDef.SetNamespace(isbServiceRollout.Namespace)
-	newISBServiceDef.SetLabels(isbServiceRollout.Spec.InterStepBufferService.Labels)
 	newISBServiceDef.SetAnnotations(isbServiceRollout.Spec.InterStepBufferService.Annotations)
 	newISBServiceDef.SetOwnerReferences([]metav1.OwnerReference{*metav1.NewControllerRef(isbServiceRollout.GetObjectMeta(), apiv1.ISBServiceRolloutGroupVersionKind)})
 	newISBServiceDef.SetAPIVersion(common.NumaflowAPIGroup + "/" + common.NumaflowAPIVersion)
 	newISBServiceDef.SetKind(common.NumaflowISBServiceKind)
+	// Update label of ISBService to include the parent rollout name
+	existingLabel := isbServiceRollout.Spec.InterStepBufferService.Labels
+	if existingLabel == nil {
+		existingLabel = make(map[string]string)
+	}
+	existingLabel[common.LabelKeyParentRollout] = isbServiceRollout.Name
+	newISBServiceDef.SetLabels(existingLabel)
+	// Update spec of ISBService to match the ISBServiceRollout spec
 	var isbServiceSpec map[string]interface{}
 	if err := util.StructToStruct(isbServiceRollout.Spec.InterStepBufferService.Spec, &isbServiceSpec); err != nil {
 		return nil, err

--- a/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
@@ -351,6 +351,9 @@ func createDefaultISBService(jetstreamVersion string, phase numaflowv1.ISBSvcPha
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ctlrcommon.DefaultTestISBSvcRolloutName,
 			Namespace: ctlrcommon.DefaultTestNamespace,
+			Labels: map[string]string{
+				common.LabelKeyParentRollout: ctlrcommon.DefaultTestISBSvcRolloutName,
+			},
 		},
 		Spec:   createDefaultISBServiceSpec(jetstreamVersion),
 		Status: status,

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -245,9 +245,9 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 		if controllerutil.ContainsFinalizer(controllerRollout, finalizerName) {
 			ppnd.GetPauseModule().DeletePauseRequest(controllerKey)
 			// Check if dependent resources are deleted, if not then requeue after 5 seconds
-			if !r.isDependentResourceDeleted(ctx, controllerRollout) {
+			if !r.areDependentResourcesDeleted(ctx, controllerRollout) {
 				numaLogger.Warn("Dependent resources are not deleted yet, requeue after 5 seconds")
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+				return ctrl.Result{Requeue: true}, nil
 			}
 			controllerutil.RemoveFinalizer(controllerRollout, finalizerName)
 		}
@@ -909,8 +909,8 @@ func (r *NumaflowControllerRolloutReconciler) ErrorHandler(numaflowControllerRol
 	r.recorder.Eventf(numaflowControllerRollout, corev1.EventTypeWarning, reason, msg+" %v", err.Error())
 }
 
-// isDependentResourceDeleted checks if dependent resources are deleted.
-func (r *NumaflowControllerRolloutReconciler) isDependentResourceDeleted(ctx context.Context, controllerRollout *apiv1.NumaflowControllerRollout) bool {
+// areDependentResourcesDeleted checks if dependent resources are deleted.
+func (r *NumaflowControllerRolloutReconciler) areDependentResourcesDeleted(ctx context.Context, controllerRollout *apiv1.NumaflowControllerRollout) bool {
 	pipelineRolloutList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines",
 		controllerRollout.Namespace, common.LabelKeyParentRollout, "")
 	if err != nil {

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -200,7 +200,7 @@ func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req
 	}
 
 	// generate the metrics for the numaflow controller based on a numaflow version.
-	r.customMetrics.NumaflowControlleRORunning.WithLabelValues(numaflowControllerRollout.Name, numaflowControllerRollout.Namespace, numaflowControllerRollout.Spec.Controller.Version).Set(1)
+	r.customMetrics.NumaflowControllerRORunning.WithLabelValues(numaflowControllerRollout.Name, numaflowControllerRollout.Namespace, numaflowControllerRollout.Spec.Controller.Version).Set(1)
 
 	numaLogger.Debug("reconciliation successful")
 	r.recorder.Eventf(numaflowControllerRollout, corev1.EventTypeNormal, "ReconcileSuccess", "Reconciliation successful")
@@ -244,10 +244,15 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 		r.recorder.Eventf(controllerRollout, corev1.EventTypeNormal, "Deleting", "Deleting NumaflowControllerRollout")
 		if controllerutil.ContainsFinalizer(controllerRollout, finalizerName) {
 			ppnd.GetPauseModule().DeletePauseRequest(controllerKey)
+			// Check if dependent resources are deleted, if not then requeue after 5 seconds
+			if !r.isDependentResourceDeleted(ctx, controllerRollout) {
+				numaLogger.Warn("Dependent resources are not deleted yet, requeue after 5 seconds")
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+			}
 			controllerutil.RemoveFinalizer(controllerRollout, finalizerName)
 		}
 		// generate the metrics for the numaflow controller deletion based on a numaflow version.
-		r.customMetrics.NumaflowControlleRORunning.DeleteLabelValues(controllerRollout.Name, controllerRollout.Namespace, controllerRollout.Spec.Controller.Version)
+		r.customMetrics.NumaflowControllerRORunning.DeleteLabelValues(controllerRollout.Name, controllerRollout.Namespace, controllerRollout.Spec.Controller.Version)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerNumaflowControllerRollout, "delete").Observe(time.Since(syncStartTime).Seconds())
 		r.customMetrics.NumaflowControllersRolloutHealth.DeleteLabelValues(controllerRollout.Namespace, controllerRollout.Name)
 		return ctrl.Result{}, nil
@@ -902,4 +907,28 @@ func (r *NumaflowControllerRolloutReconciler) updateNumaflowControllerRolloutSta
 func (r *NumaflowControllerRolloutReconciler) ErrorHandler(numaflowControllerRollout *apiv1.NumaflowControllerRollout, err error, reason, msg string) {
 	r.customMetrics.NumaflowControllerROSyncErrors.WithLabelValues().Inc()
 	r.recorder.Eventf(numaflowControllerRollout, corev1.EventTypeWarning, reason, msg+" %v", err.Error())
+}
+
+// isDependentResourceDeleted checks if dependent resources are deleted.
+func (r *NumaflowControllerRolloutReconciler) isDependentResourceDeleted(ctx context.Context, controllerRollout *apiv1.NumaflowControllerRollout) bool {
+	pipelineRolloutList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines",
+		controllerRollout.Namespace, common.LabelKeyParentRollout, "")
+	if err != nil {
+		return false
+	}
+	monoVertexRolloutList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "monovertices",
+		controllerRollout.Namespace, common.LabelKeyParentRollout, "")
+	if err != nil {
+		return false
+	}
+	isbServiceRolloutList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "interstepbufferservices",
+		controllerRollout.Namespace, common.LabelKeyParentRollout, "")
+	if err != nil {
+		return false
+	}
+	if len(pipelineRolloutList.Items)+len(monoVertexRolloutList.Items)+len(isbServiceRolloutList.Items) == 0 {
+		return true
+	}
+
+	return false
 }

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -43,8 +43,8 @@ type CustomMetrics struct {
 	MonoVertexROSyncs *prometheus.CounterVec
 	// NumaflowControllersRolloutHealth is the gauge for the health of NumaflowControllerRollouts.
 	NumaflowControllersRolloutHealth *prometheus.GaugeVec
-	// NumaflowControlleRORunning is the gauge for the number of running NumaflowControllerRollouts with a specific version.
-	NumaflowControlleRORunning *prometheus.GaugeVec
+	// NumaflowControllerRORunning is the gauge for the number of running NumaflowControllerRollouts with a specific version.
+	NumaflowControllerRORunning *prometheus.GaugeVec
 	// NumaflowControllerROSyncErrors is the counter for the total number of NumaflowControllerRollout reconciliation errors
 	NumaflowControllerROSyncErrors *prometheus.CounterVec
 	// NumaflowControllersROSyncs in the counter for the total number of NumaflowControllerRollout reconciliations
@@ -309,7 +309,7 @@ func RegisterCustomMetrics() *CustomMetrics {
 		MonoVertexROSyncs:                         monoVertexROSyncs,
 		MonoVertexROSyncErrors:                    monoVertexROSyncErrors,
 		NumaflowControllersRolloutHealth:          numaflowControllersRolloutHealth,
-		NumaflowControlleRORunning:                numaflowControllerRORunning,
+		NumaflowControllerRORunning:               numaflowControllerRORunning,
 		NumaflowControllersROSyncs:                numaflowControllerROSyncs,
 		NumaflowControllerROSyncErrors:            numaflowControllerROSyncErrors,
 		KubeRequestCounter:                        kubeRequestCounter,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #425 

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

Hold the deletion of NumaflowControllerRollout util the dependent resource are deleted


### Verification

Verified in local kind cluster.
Tested Scenario:
- Created NumaflowControllerRollout, ISBServiceRollout, PipelineRollout and MonovertexRollout
- Tried Deleting NumaflowControllerRollout - It got stuck in deleting as the dependent resources are still running and Numaplane controller started showing logs as below:
`{"level":"warn","numaflowcontrollerrollout":{"Namespace":"example-namespace","Name":"numaflow-controller"},"logger":"numaplane.controller-manager.numaflowcontrollerrollout-reconciler","caller":"numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go:248","ts":"2024-11-30T16:15:59.713068342Z","msg":"Dependent resources are not deleted yet, requeue after 5 seconds"}`
- Deleted all the dependent resource, then NumaflowControllerRollout get auto deleted.

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->