### PR TITLE
fix: update jetstream versions used in e2e

### DIFF
--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -44,8 +44,8 @@ const (
 	monoVertexName                   = "test-monovertex-rollout-0"
 	initialNumaflowControllerVersion = "1.3.3"
 	updatedNumaflowControllerVersion = "1.4.0"
-	initialJetstreamVersion          = "2.9.6"
-	updatedJetstreamVersion          = "2.9.8"
+	initialJetstreamVersion          = "2.10.17"
+	updatedJetstreamVersion          = "2.10.11"
 )
 
 var (


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Attempted fix to #435 

### Modifications

Apparently, newer version of Jetstream is more stable.


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->