### PR TITLE
feat: consolidate watch functions into shared function

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -241,7 +241,7 @@ func streamPodLogs(ctx context.Context, client clientgo.Interface, namespace, po
 func watchPods() {
 
 	watchResourceType(func() (watch.Interface, error) {
-		watcher, err := dynamicClient.Resource(getGVRForVertex()).Namespace(Namespace).Watch(context.Background(), metav1.ListOptions{})
+		watcher, err := kubeClient.CoreV1().Pods(Namespace).Watch(context.Background(), metav1.ListOptions{LabelSelector: NumaflowLabel})
 		return watcher, err
 	}, func(o runtime.Object) Output {
 		if pod, ok := o.(*corev1.Pod); ok {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #441 

### Modifications

Consolidated watch functions for collecting `kubectl get <resource> -o yaml` output by creating shared function.
Also updated `writeToFile` function to create filepath based on `Output` structure passed into it.

```
func watchResourceType(getWatchFunc func() (watch.Interface, error), processEventObject func(runtime.Object) Output) {

	defer wg.Done()
	watcher, err := getWatchFunc()
	if err != nil {
		fmt.Printf("Failed to start watcher: %v\n", err)
		return
	}
	defer watcher.Stop()

	for {
		select {
		case event := <-watcher.ResultChan():
			if event.Type == watch.Modified {
				output := processEventObject(event.Object)
				err = writeToFile(output)
				if err != nil {
					return
				}
			}
		case <-stopCh:
			return
		}
	}

}
```


### Verification

Running `make test-e2e` locally multiple times to check that resource logs are still being updated properly.