### PR TITLE
fix: Debug event logger and use zerolog instead of fmt

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,9 +81,7 @@ func main() {
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
@@ -114,7 +115,7 @@ func (cm *NumaflowControllerDefinitionsManager) UpdateNumaflowControllerDefiniti
 	for _, controller := range config.ControllerDefinitions {
 		cm.rolloutConfig[controller.Version] = controller.FullSpec
 
-		fmt.Printf("Added/Updated Controller definition Config, version: %s\n", controller.Version)
+		log.Debug().Msg(fmt.Sprintf("Added/Updated Controller definition Config, version: %s", config)) // due to cyclical dependency, we can't call logger
 	}
 }
 
@@ -125,7 +126,7 @@ func (cm *NumaflowControllerDefinitionsManager) RemoveNumaflowControllerDefiniti
 	for _, controller := range config.ControllerDefinitions {
 		delete(cm.rolloutConfig, controller.Version)
 
-		fmt.Printf("Removed Controller definition Config, version: %s\n", controller.Version)
+		log.Debug().Msg(fmt.Sprintf("Removed Controller definition Config, version: %s", controller.Version)) // due to cyclical dependency, we can't call logger
 	}
 }
 
@@ -185,7 +186,7 @@ func (cm *ConfigManager) loadGlobalConfig(
 			onErrorReloading(err)
 		}
 		cm.config = &newConfig
-		fmt.Printf("Global Config update: %+v\n", newConfig) // due to cyclical dependency, we can't call logger
+		log.Debug().Msg(fmt.Sprintf("Global Config update: %+v", newConfig)) // due to cyclical dependency, we can't call logger
 
 		// call any registered callbacks
 		for _, f := range cm.callbacks {
@@ -222,7 +223,7 @@ func (cm *ConfigManager) UpdateNamespaceConfig(namespace string, config Namespac
 	defer cm.namespaceConfigMapLock.Unlock()
 
 	cm.namespaceConfigMap[namespace] = config
-	fmt.Printf("Added Namespace ConfigMap for namespace %s\n", namespace)
+	log.Debug().Msg(fmt.Sprintf("Added Namespace ConfigMap for namespace %s", namespace)) // due to cyclical dependency, we can't call logger
 }
 
 func (cm *ConfigManager) UnsetNamespaceConfig(namespace string) {
@@ -230,7 +231,7 @@ func (cm *ConfigManager) UnsetNamespaceConfig(namespace string) {
 	defer cm.namespaceConfigMapLock.Unlock()
 
 	delete(cm.namespaceConfigMap, namespace)
-	fmt.Printf("Deleted Namespace ConfigMap for namespace %s\n", namespace)
+	log.Debug().Msg(fmt.Sprintf("Deleted Namespace ConfigMap for namespace %s", namespace)) // due to cyclical dependency, we can't call logger
 }
 
 func (cm *ConfigManager) GetNamespaceConfig(namespace string) *NamespaceConfig {

--- a/internal/controller/config/usde_config.go
+++ b/internal/controller/config/usde_config.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/rs/zerolog/log"
+)
 
 type SpecDataLossField struct {
 	Path             string `json:"path" yaml:"path"`
@@ -34,7 +37,7 @@ func (cm *ConfigManager) UpdateUSDEConfig(config USDEConfig) {
 
 	cm.usdeConfig = config
 
-	fmt.Printf("USDE Config update: %+v\n", config) // due to cyclical dependency, we can't call logger
+	log.Debug().Msg(fmt.Sprintf("USDE Config update: %+v", config)) // due to cyclical dependency, we can't call logger
 }
 
 func (cm *ConfigManager) UnsetUSDEConfig() {
@@ -43,7 +46,7 @@ func (cm *ConfigManager) UnsetUSDEConfig() {
 
 	cm.usdeConfig = USDEConfig{}
 
-	fmt.Println("USDE Config unset") // due to cyclical dependency, we can't call logger
+	log.Debug().Msg("USDE Config unset") // due to cyclical dependency, we can't call logger
 }
 
 func (cm *ConfigManager) GetUSDEConfig() USDEConfig {

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"github.com/numaproj/numaplane/internal/controller/config"
 )
@@ -93,7 +94,7 @@ func New() *NumaLogger {
 	// get the log level
 	globalConfig, err := config.GetConfigManagerInstance().GetConfig()
 	if err != nil {
-		fmt.Println("error using global config to get log level: " + err.Error())
+		log.Debug().Msg("error using global config to get log level: " + err.Error())
 		return newNumaLogger(&w, nil)
 	}
 	lvl := globalConfig.LogLevel


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #129 

### Modifications

- Fix debug event logger
- Replace printf statement to zerolog 

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

Verified in local kubernetes cluster, attached the log file for reference
[numaplane.log](https://github.com/user-attachments/files/18093527/numaplane.log)


<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->