### PR TITLE
fix: Configure SyncPeriod for reconcile at given interval of time

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"os"
 	"time"
 
@@ -114,7 +113,7 @@ func main() {
 
 	ctx := logger.WithLogger(context.Background(), numaLogger)
 
-	syncPeriod := time.Minute * 1
+	syncPeriod := 15 * time.Minute
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -145,8 +144,6 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
-
-	fmt.Printf("mgr.GetCache(): %+v", mgr.GetCache())
 
 	// initialize the custom metrics with the global prometheus registry
 	customMetrics := metrics.RegisterCustomMetrics()
@@ -239,7 +236,6 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-
 }
 
 func loadConfigs() {

--- a/internal/controller/common/predicate_filters.go
+++ b/internal/controller/common/predicate_filters.go
@@ -39,6 +39,7 @@ type TypedGenerationChangedPredicate[object metav1.Object] struct {
 }
 
 func (p TypedGenerationChangedPredicate[object]) Update(e event.TypedUpdateEvent[object]) bool {
+	// It will effectively check of ObjectOld and ObjectNew does not exist or if the name of the object is empty
 	if e.ObjectOld.GetName() == "" || e.ObjectNew.GetName() == "" {
 		return false
 	}

--- a/internal/controller/common/predicate_filters.go
+++ b/internal/controller/common/predicate_filters.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package common
 
 import (
@@ -6,7 +22,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+/*
+	Reference: https://github.com/kubernetes-sigs/controller-runtime/issues/2355#issuecomment-2477548322
+	There's not an explicit attribute that holds this info about sync trigger. However, the "update" events that come in
+	when these batches of resync-triggered events happen, the resource version changes for every real update,
+	but doesn't for the resync-triggered events. So, to detect these cases while also making use of the generation change check,
+	added a custom predicate that is a logical OR of checking
+		1. If the generation changed between the old and new object.
+		2. If the resource version remained the same between the old and new object.
+	Assuming there are no other edge cases where the resource version remains the same across an update event
+*/
+
 type TypedGenerationChangedPredicate[object metav1.Object] struct {
+	// Returns true by default for all events; see overrides below.
 	predicate.TypedFuncs[object]
 }
 
@@ -15,10 +43,16 @@ func (p TypedGenerationChangedPredicate[object]) Update(e event.TypedUpdateEvent
 		return false
 	}
 
+	// Process the event if the generation changed (which happens e.g. if the spec
+	// was updated, but not if the status or metadata fields were updated).
 	if e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration() {
 		return true
 	}
 
+	// If the generation is unchanged, we generally don't want to process the event,
+	// except events triggered by periodic resyncs (which are, for some
+	// reason, categorized as updates). We identify such events by checking if the old
+	// and new resource versions are equal.
 	if e.ObjectNew.GetResourceVersion() == e.ObjectOld.GetResourceVersion() {
 		return true
 	}

--- a/internal/controller/common/predicate_filters.go
+++ b/internal/controller/common/predicate_filters.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type TypedGenerationChangedPredicate[object metav1.Object] struct {
+	predicate.TypedFuncs[object]
+}
+
+func (p TypedGenerationChangedPredicate[object]) Update(e event.TypedUpdateEvent[object]) bool {
+	if e.ObjectOld.GetName() == "" || e.ObjectNew.GetName() == "" {
+		return false
+	}
+
+	if e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration() {
+		return true
+	}
+
+	if e.ObjectNew.GetResourceVersion() == e.ObjectOld.GetResourceVersion() {
+		return true
+	}
+
+	return false
+}

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -606,7 +606,7 @@ func (r *ISBServiceRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Watch ISBServiceRollouts
 	if err := controller.Watch(source.Kind(mgr.GetCache(), &apiv1.ISBServiceRollout{},
-		&handler.TypedEnqueueRequestForObject[*apiv1.ISBServiceRollout]{}, predicate.TypedGenerationChangedPredicate[*apiv1.ISBServiceRollout]{})); err != nil {
+		&handler.TypedEnqueueRequestForObject[*apiv1.ISBServiceRollout]{})); err != nil {
 		return fmt.Errorf("failed to watch ISBServiceRollout: %v", err)
 	}
 

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -606,7 +606,7 @@ func (r *ISBServiceRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Watch ISBServiceRollouts
 	if err := controller.Watch(source.Kind(mgr.GetCache(), &apiv1.ISBServiceRollout{},
-		&handler.TypedEnqueueRequestForObject[*apiv1.ISBServiceRollout]{})); err != nil {
+		&handler.TypedEnqueueRequestForObject[*apiv1.ISBServiceRollout]{}, ctlrcommon.TypedGenerationChangedPredicate[*apiv1.ISBServiceRollout]{})); err != nil {
 		return fmt.Errorf("failed to watch ISBServiceRollout: %v", err)
 	}
 

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -340,7 +340,7 @@ func (r *MonoVertexRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Watch MonoVertexRollouts
 	if err := controller.Watch(source.Kind(mgr.GetCache(), &apiv1.MonoVertexRollout{},
-		&handler.TypedEnqueueRequestForObject[*apiv1.MonoVertexRollout]{}, predicate.TypedGenerationChangedPredicate[*apiv1.MonoVertexRollout]{})); err != nil {
+		&handler.TypedEnqueueRequestForObject[*apiv1.MonoVertexRollout]{})); err != nil {
 		return fmt.Errorf("failed to watch MonoVertexRollouts: %w", err)
 	}
 

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -340,7 +340,7 @@ func (r *MonoVertexRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Watch MonoVertexRollouts
 	if err := controller.Watch(source.Kind(mgr.GetCache(), &apiv1.MonoVertexRollout{},
-		&handler.TypedEnqueueRequestForObject[*apiv1.MonoVertexRollout]{})); err != nil {
+		&handler.TypedEnqueueRequestForObject[*apiv1.MonoVertexRollout]{}, ctlrcommon.TypedGenerationChangedPredicate[*apiv1.MonoVertexRollout]{})); err != nil {
 		return fmt.Errorf("failed to watch MonoVertexRollouts: %w", err)
 	}
 

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -51,6 +51,7 @@ import (
 	sigsyaml "sigs.k8s.io/yaml"
 
 	"github.com/numaproj/numaplane/internal/common"
+	ctlrcommon "github.com/numaproj/numaplane/internal/controller/common"
 	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/sync"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
@@ -622,7 +623,7 @@ func (r *NumaflowControllerReconciler) SetupWithManager(mgr ctrl.Manager) error 
 
 	// Watch for changes to primary resource NumaflowController
 	if err := controller.Watch(source.Kind(mgr.GetCache(), &apiv1.NumaflowController{},
-		&handler.TypedEnqueueRequestForObject[*apiv1.NumaflowController]{}, predicate.TypedGenerationChangedPredicate[*apiv1.NumaflowController]{})); err != nil {
+		&handler.TypedEnqueueRequestForObject[*apiv1.NumaflowController]{}, ctlrcommon.TypedGenerationChangedPredicate[*apiv1.NumaflowController]{})); err != nil {
 		return fmt.Errorf("failed to watch NumaflowController: %w", err)
 	}
 

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -547,7 +547,7 @@ func (r *NumaflowControllerRolloutReconciler) SetupWithManager(mgr ctrl.Manager)
 
 	// Watch NumaflowControllerRollout
 	if err := controller.Watch(source.Kind(mgr.GetCache(), &apiv1.NumaflowControllerRollout{},
-		&handler.TypedEnqueueRequestForObject[*apiv1.NumaflowControllerRollout]{}, predicate.TypedGenerationChangedPredicate[*apiv1.NumaflowControllerRollout]{})); err != nil {
+		&handler.TypedEnqueueRequestForObject[*apiv1.NumaflowControllerRollout]{})); err != nil {
 		return fmt.Errorf("failed to watch NumaflowControllerRollout: %w", err)
 	}
 

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -547,7 +547,7 @@ func (r *NumaflowControllerRolloutReconciler) SetupWithManager(mgr ctrl.Manager)
 
 	// Watch NumaflowControllerRollout
 	if err := controller.Watch(source.Kind(mgr.GetCache(), &apiv1.NumaflowControllerRollout{},
-		&handler.TypedEnqueueRequestForObject[*apiv1.NumaflowControllerRollout]{})); err != nil {
+		&handler.TypedEnqueueRequestForObject[*apiv1.NumaflowControllerRollout]{}, ctlrcommon.TypedGenerationChangedPredicate[*apiv1.NumaflowControllerRollout]{})); err != nil {
 		return fmt.Errorf("failed to watch NumaflowControllerRollout: %w", err)
 	}
 

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -697,7 +697,7 @@ func (r *PipelineRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Watch PipelineRollouts
 	if err := controller.Watch(source.Kind(mgr.GetCache(), &apiv1.PipelineRollout{},
-		&handler.TypedEnqueueRequestForObject[*apiv1.PipelineRollout]{})); err != nil {
+		&handler.TypedEnqueueRequestForObject[*apiv1.PipelineRollout]{}, ctlrcommon.TypedGenerationChangedPredicate[*apiv1.PipelineRollout]{})); err != nil {
 		return fmt.Errorf("failed to watch PipelineRollouts: %v", err)
 	}
 

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -697,7 +697,7 @@ func (r *PipelineRolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Watch PipelineRollouts
 	if err := controller.Watch(source.Kind(mgr.GetCache(), &apiv1.PipelineRollout{},
-		&handler.TypedEnqueueRequestForObject[*apiv1.PipelineRollout]{}, predicate.TypedGenerationChangedPredicate[*apiv1.PipelineRollout]{})); err != nil {
+		&handler.TypedEnqueueRequestForObject[*apiv1.PipelineRollout]{})); err != nil {
 		return fmt.Errorf("failed to watch PipelineRollouts: %v", err)
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/388

### Modifications

Add custom predicate filter which filter all the events other than "ResourceVersion" change and "SyncPeriod" event.

Reference taken from already open issue in controller-runtime: https://github.com/kubernetes-sigs/controller-runtime/issues/2355#issuecomment-2477548322

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

Verified on local Kubernetes cluster by setting the SyncPeriod time as 2 min, Numaplane is reconciling every resource every 2min.

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
