### PR TITLE
fix: Add phase to health metrics for pipeline, monovertex and ISBService

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -189,9 +189,9 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 
 	defer func() {
 		if isbServiceRollout.Status.IsHealthy() {
-			r.customMetrics.ISBServicesRolloutHealth.WithLabelValues(isbServiceRollout.Namespace, isbServiceRollout.Name).Set(1)
+			r.customMetrics.ISBServicesRolloutHealth.WithLabelValues(isbServiceRollout.Namespace, isbServiceRollout.Name, string(isbServiceRollout.Status.Phase)).Set(1)
 		} else {
-			r.customMetrics.ISBServicesRolloutHealth.WithLabelValues(isbServiceRollout.Namespace, isbServiceRollout.Name).Set(0)
+			r.customMetrics.ISBServicesRolloutHealth.WithLabelValues(isbServiceRollout.Namespace, isbServiceRollout.Name, string(isbServiceRollout.Status.Phase)).Set(0)
 		}
 	}()
 
@@ -208,7 +208,7 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 		// generate metrics for ISB Service deletion.
 		r.customMetrics.DecISBServiceRollouts(isbServiceRollout.Name, isbServiceRollout.Namespace)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerISBSVCRollout, "delete").Observe(time.Since(startTime).Seconds())
-		r.customMetrics.ISBServicesRolloutHealth.DeleteLabelValues(isbServiceRollout.Namespace, isbServiceRollout.Name)
+		r.customMetrics.ISBServicesRolloutHealth.DeleteLabelValues(isbServiceRollout.Namespace, isbServiceRollout.Name, string(isbServiceRollout.Status.Phase))
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -188,9 +188,9 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 
 	defer func() {
 		if monoVertexRollout.Status.IsHealthy() {
-			r.customMetrics.MonoVerticesRolloutHealth.WithLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name).Set(1)
+			r.customMetrics.MonoVerticesRolloutHealth.WithLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name, string(monoVertexRollout.Status.Phase)).Set(1)
 		} else {
-			r.customMetrics.MonoVerticesRolloutHealth.WithLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name).Set(0)
+			r.customMetrics.MonoVerticesRolloutHealth.WithLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name, string(monoVertexRollout.Status.Phase)).Set(0)
 		}
 	}()
 
@@ -203,7 +203,7 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 		// generate metrics for MonoVertex deletion
 		r.customMetrics.DecMonoVertexRollouts(monoVertexRollout.Name, monoVertexRollout.Namespace)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerMonoVertexRollout, "delete").Observe(time.Since(startTime).Seconds())
-		r.customMetrics.MonoVerticesRolloutHealth.DeleteLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name)
+		r.customMetrics.MonoVerticesRolloutHealth.DeleteLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name, string(monoVertexRollout.Status.Phase))
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -335,9 +335,9 @@ func (r *PipelineRolloutReconciler) reconcile(
 	numaLogger := logger.FromContext(ctx)
 	defer func() {
 		if pipelineRollout.Status.IsHealthy() {
-			r.customMetrics.PipelinesRolloutHealth.WithLabelValues(pipelineRollout.Namespace, pipelineRollout.Name).Set(1)
+			r.customMetrics.PipelinesRolloutHealth.WithLabelValues(pipelineRollout.Namespace, pipelineRollout.Name, string(pipelineRollout.Status.Phase)).Set(1)
 		} else {
-			r.customMetrics.PipelinesRolloutHealth.WithLabelValues(pipelineRollout.Namespace, pipelineRollout.Name).Set(0)
+			r.customMetrics.PipelinesRolloutHealth.WithLabelValues(pipelineRollout.Namespace, pipelineRollout.Name, string(pipelineRollout.Status.Phase)).Set(0)
 		}
 	}()
 
@@ -351,7 +351,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 		// generate the metrics for the Pipeline deletion.
 		r.customMetrics.DecPipelineROsRunning(pipelineRollout.Name, pipelineRollout.Namespace)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerPipelineRollout, "delete").Observe(time.Since(syncStartTime).Seconds())
-		r.customMetrics.PipelinesRolloutHealth.DeleteLabelValues(pipelineRollout.Namespace, pipelineRollout.Name)
+		r.customMetrics.PipelinesRolloutHealth.DeleteLabelValues(pipelineRollout.Namespace, pipelineRollout.Name, string(pipelineRollout.Status.Phase))
 		return false, nil, nil
 	}
 

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -112,21 +112,21 @@ var (
 		Name:        "numaplane_pipeline_rollout_health",
 		Help:        "A metric to indicate whether the pipeline rollout is healthy. '1' means healthy, '0' means unhealthy",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelPipeline})
+	}, []string{LabelNamespace, LabelPipeline, LabelPhase})
 
 	// isbServicesRolloutHealth indicates whether the ISB service rollouts are healthy (from k8s resource perspective).
 	isbServicesRolloutHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "numaplane_isb_services_rollout_health",
 		Help:        "A metric to indicate whether the isb services rollout is healthy. '1' means healthy, '0' means unhealthy",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelISBService})
+	}, []string{LabelNamespace, LabelISBService, LabelPhase})
 
 	// monoVerticesRolloutHealth indicates whether the mono vertices are healthy (from k8s resource perspective).
 	monoVerticesRolloutHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "numaplane_monovertex_rollout_health",
 		Help:        "A metric to indicate whether the MonoVertex is healthy. '1' means healthy, '0' means unhealthy",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelMonoVertex})
+	}, []string{LabelNamespace, LabelMonoVertex, LabelPhase})
 
 	// pipelineRolloutsRunning indicates the number of PipelineRollouts
 	pipelineRolloutsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.intuit.com/oss-analytics/numa-manifest-generator/issues/148

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

Added `Phase` attribute to Rollout health metrics data


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

```bash
# HELP numaplane_isb_services_rollout_health A metric to indicate whether the isb services rollout is healthy. '1' means healthy, '0' means unhealthy
# TYPE numaplane_isb_services_rollout_health gauge
numaplane_isb_services_rollout_health{intuit_alert="true",isbservice="my-isbsvc",namespace="example-namespace",phase="Deployed"} 1
# HELP numaplane_pipeline_rollout_health A metric to indicate whether the pipeline rollout is healthy. '1' means healthy, '0' means unhealthy
# TYPE numaplane_pipeline_rollout_health gauge
numaplane_pipeline_rollout_health{intuit_alert="true",namespace="example-namespace",phase="Deployed",pipeline="my-pipeline"} 1
# HELP numaplane_monovertex_rollout_health A metric to indicate whether the MonoVertex is healthy. '1' means healthy, '0' means unhealthy
# TYPE numaplane_monovertex_rollout_health gauge
numaplane_monovertex_rollout_health{intuit_alert="true",monovertex="my-monovertex",namespace="example-namespace",phase="Deployed"} 1
```

### Backward incompatibilities
- It only affect on metrics dashboard for rollout health

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
