### PR TITLE
fix: updated deletion test case to not require getting the child resource name

### DIFF
--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -630,8 +630,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		document("Verifying PipelineRollout deletion")
-		pipeline, err := getPipeline(Namespace, pipelineRolloutName)
-		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(func() bool {
 			_, err := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
 			if err != nil {
@@ -646,15 +644,15 @@ var _ = Describe("Functional e2e", Serial, func() {
 		document("Verifying Pipeline deletion")
 
 		Eventually(func() bool {
-			_, err := dynamicClient.Resource(pipelinegvr).Namespace(Namespace).Get(ctx, pipeline.GetName(), metav1.GetOptions{})
+			list, err := dynamicClient.Resource(pipelinegvr).Namespace(Namespace).List(ctx, metav1.ListOptions{})
 			if err != nil {
-				if !errors.IsNotFound(err) {
-					Fail("An unexpected error occurred when fetching the Pipeline: " + err.Error())
-				}
 				return false
 			}
-			return true
-		}).WithTimeout(testTimeout).Should(BeFalse(), "The Pipeline should have been deleted but it was found.")
+			if len(list.Items) == 0 {
+				return true
+			}
+			return false
+		}).WithTimeout(testTimeout).Should(BeTrue(), "The Pipeline should have been deleted but it was found.")
 
 	})
 
@@ -666,9 +664,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		document("Verifying MonoVertexRollout deletion")
-
-		monoVertex, err := getMonoVertex(Namespace, monoVertexRolloutName)
-		Expect(err).ShouldNot(HaveOccurred())
 
 		Eventually(func() bool {
 			_, err := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
@@ -684,15 +679,15 @@ var _ = Describe("Functional e2e", Serial, func() {
 		document("Verifying MonoVertex deletion")
 
 		Eventually(func() bool {
-			_, err := dynamicClient.Resource(monovertexgvr).Namespace(Namespace).Get(ctx, monoVertex.GetName(), metav1.GetOptions{})
+			list, err := dynamicClient.Resource(monovertexgvr).Namespace(Namespace).List(ctx, metav1.ListOptions{})
 			if err != nil {
-				if !errors.IsNotFound(err) {
-					Fail("An unexpected error occurred when fetching the MonoVertex: " + err.Error())
-				}
 				return false
 			}
-			return true
-		}).WithTimeout(testTimeout).Should(BeFalse(), "The MonoVertex should have been deleted but it was found.")
+			if len(list.Items) == 0 {
+				return true
+			}
+			return false
+		}).WithTimeout(testTimeout).Should(BeTrue(), "The MonoVertex should have been deleted but it was found.")
 	})
 
 	It("Should delete the ISBServiceRollout and child ISBService", func() {
@@ -703,9 +698,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		document("Verifying ISBServiceRollout deletion")
-
-		isbService, err := getISBService(Namespace, isbServiceRolloutName)
-		Expect(err).ShouldNot(HaveOccurred())
 
 		Eventually(func() bool {
 			_, err := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
@@ -721,15 +713,15 @@ var _ = Describe("Functional e2e", Serial, func() {
 		document("Verifying ISBService deletion")
 
 		Eventually(func() bool {
-			_, err := dynamicClient.Resource(isbservicegvr).Namespace(Namespace).Get(ctx, isbService.GetName(), metav1.GetOptions{})
+			list, err := dynamicClient.Resource(isbservicegvr).Namespace(Namespace).List(ctx, metav1.ListOptions{})
 			if err != nil {
-				if !errors.IsNotFound(err) {
-					Fail("An unexpected error occurred when fetching the ISBService: " + err.Error())
-				}
 				return false
 			}
-			return true
-		}).WithTimeout(testTimeout).Should(BeFalse(), "The ISBService should have been deleted but it was found.")
+			if len(list.Items) == 0 {
+				return true
+			}
+			return false
+		}).WithTimeout(testTimeout).Should(BeTrue(), "The ISBService should have been deleted but it was found.")
 
 	})
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

Makes update to the e2e test case where we delete the rollout and check that the corresponding child resource is deleted. We previously would get the resource and check that it returned the correct error to indicate it doesn't exist. This requires having the resource's name which was previously a constant but is no longer the case with the new naming convention (ex. pipeline-0) for all resources. To remedy this, we can list the resources and verify that the returned list is empty.

### Verification

Running `make test-e2e` locally and verifying that it is passing on the CI.

### Backward incompatibilities

None.
