### PR TITLE
feat: changed USDE config to include more than just data-loss fields

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1737,72 +1737,89 @@ metadata:
 ---
 apiVersion: v1
 data:
-  isbServiceSpecDataLossFields: |
-    # Principal: Update to StatefulSet may not be backward compatible to understand the data on the PVC
-    - path: spec.jetstream.version
-    - path: spec.redis.native.version
-    - path: spec.redis.external.url
-    - path: spec.redis.external.sentinelUrl
-    - path: spec.redis.external.masterName
-  pipelineSpecDataLossFields: |
-    # Principal: Pipeline topology change could cause data loss since unconsumed data may be left on the InterstepBufferService which won't get processed
-    - path: spec.edges.from
-    - path: spec.edges.to
-    - path: spec.edges.conditions
-      includeSubfields: true
+  isbService: |
+    dataLoss:
+      # Principal: Update to StatefulSet may not be backward compatible to understand the data on the PVC
+      - path: spec.jetstream.version
+      - path: spec.redis.native.version
+      - path: spec.redis.external.url
+      - path: spec.redis.external.sentinelUrl
+      - path: spec.redis.external.masterName
+    recreate:
+      # TODO: add the recreate fields
+    progressive:
+      # TODO: add the progressive fields
+  monovertex: |
+    dataLoss:
+      # TODO: add the data-loss fields
+    recreate:
+      # TODO: add the recreate fields
+    progressive:
+      # TODO: add the progressive fields
+  pipeline: |
+    dataLoss:
+      # Principal: Pipeline topology change could cause data loss since unconsumed data may be left on the InterstepBufferService which won't get processed
+      - path: spec.edges.from
+      - path: spec.edges.to
+      - path: spec.edges.conditions
+        includeSubfields: true
 
-    # Principal: Changing the InterstepBufferService could cause data loss since unconsumed data may be left on the InterstepBufferService which won't get processed
-    - path: spec.interStepBufferServiceName
+      # Principal: Changing the InterstepBufferService could cause data loss since unconsumed data may be left on the InterstepBufferService which won't get processed
+      - path: spec.interStepBufferServiceName
 
-    # Principal: Changing an Image definition could cause data loss if the new Image is not able to process the old data from the InterstepBufferService
-    - path: spec.vertices.source.generator
-    - path: spec.vertices.source.kafka
-    - path: spec.vertices.source.http
-    - path: spec.vertices.source.nats
-    - path: spec.vertices.source.jetstream
-    - path: spec.vertices.source.serving
-    - path: spec.vertices.source.udsource.container.image
-    - path: spec.vertices.source.transformer.container.image
-    - path: spec.vertices.source.transformer.container.command
-    - path: spec.vertices.source.transformer.container.args
-    - path: spec.vertices.source.transformer.container.env
-      includeSubfields: true
-    - path: spec.vertices.source.transformer.container.envfrom
-      includeSubfields: true
-    - path: spec.vertices.source.transformer.builtin
-      includeSubfields: true
-    - path: spec.vertices.sink.log
-    - path: spec.vertices.sink.kafka
-    - path: spec.vertices.sink.blackhole
-    - path: spec.vertices.sink.udsink.container.image
-    - path: spec.vertices.sink.udsink.container.command
-    - path: spec.vertices.sink.udsink.container.args
-    - path: spec.vertices.sink.udsink.container.env
-      includeSubfields: true
-    - path: spec.vertices.sink.udsink.container.envfrom
-      includeSubfields: true
-    - path: spec.vertices.udf.container.image
-    - path: spec.vertices.udf.container.command
-    - path: spec.vertices.udf.container.args
-    - path: spec.vertices.udf.container.env
-      includeSubfields: true
-    - path: spec.vertices.udf.container.envfrom
-      includeSubfields: true
-    - path: spec.vertices.udf.builtin
-      includeSubfields: true
-    - path: spec.sideInputs.container.image
-    - path: spec.sideInputs.container.command
-    - path: spec.sideInputs.container.args
-    - path: spec.sideInputs.container.env
-      includeSubfields: true
-    - path: spec.sideInputs.container.envfrom
-      includeSubfields: true
-    - path: spec.templates     # note: this one could be broken down further into just the fields that are at risk
-      includeSubfields: true
+      # Principal: Changing an Image definition could cause data loss if the new Image is not able to process the old data from the InterstepBufferService
+      - path: spec.vertices.source.generator
+      - path: spec.vertices.source.kafka
+      - path: spec.vertices.source.http
+      - path: spec.vertices.source.nats
+      - path: spec.vertices.source.jetstream
+      - path: spec.vertices.source.serving
+      - path: spec.vertices.source.udsource.container.image
+      - path: spec.vertices.source.transformer.container.image
+      - path: spec.vertices.source.transformer.container.command
+      - path: spec.vertices.source.transformer.container.args
+      - path: spec.vertices.source.transformer.container.env
+        includeSubfields: true
+      - path: spec.vertices.source.transformer.container.envfrom
+        includeSubfields: true
+      - path: spec.vertices.source.transformer.builtin
+        includeSubfields: true
+      - path: spec.vertices.sink.log
+      - path: spec.vertices.sink.kafka
+      - path: spec.vertices.sink.blackhole
+      - path: spec.vertices.sink.udsink.container.image
+      - path: spec.vertices.sink.udsink.container.command
+      - path: spec.vertices.sink.udsink.container.args
+      - path: spec.vertices.sink.udsink.container.env
+        includeSubfields: true
+      - path: spec.vertices.sink.udsink.container.envfrom
+        includeSubfields: true
+      - path: spec.vertices.udf.container.image
+      - path: spec.vertices.udf.container.command
+      - path: spec.vertices.udf.container.args
+      - path: spec.vertices.udf.container.env
+        includeSubfields: true
+      - path: spec.vertices.udf.container.envfrom
+        includeSubfields: true
+      - path: spec.vertices.udf.builtin
+        includeSubfields: true
+      - path: spec.sideInputs.container.image
+      - path: spec.sideInputs.container.command
+      - path: spec.sideInputs.container.args
+      - path: spec.sideInputs.container.env
+        includeSubfields: true
+      - path: spec.sideInputs.container.envfrom
+        includeSubfields: true
+      - path: spec.templates     # note: this one could be broken down further into just the fields that are at risk
+        includeSubfields: true
 
-    # Principal: TBD
-    - path: spec.sideInputs.container.envfrom
-      includeSubfields: true
+      # Principal: TBD
+      - path: spec.sideInputs.container.envfrom
+        includeSubfields: true
+    recreate:
+      # TODO: add the recreate fields
+    progressive:
+      # TODO: add the progressive fields
 kind: ConfigMap
 metadata:
   labels:

--- a/config/manager/usde-config.yaml
+++ b/config/manager/usde-config.yaml
@@ -5,69 +5,86 @@ metadata:
   labels:
     numaplane.numaproj.io/config: usde-config
 data:
-  pipelineSpecDataLossFields: |
-    # Principal: Pipeline topology change could cause data loss since unconsumed data may be left on the InterstepBufferService which won't get processed
-    - path: spec.edges.from
-    - path: spec.edges.to
-    - path: spec.edges.conditions
-      includeSubfields: true
+  pipeline: |
+    dataLoss:
+      # Principal: Pipeline topology change could cause data loss since unconsumed data may be left on the InterstepBufferService which won't get processed
+      - path: spec.edges.from
+      - path: spec.edges.to
+      - path: spec.edges.conditions
+        includeSubfields: true
 
-    # Principal: Changing the InterstepBufferService could cause data loss since unconsumed data may be left on the InterstepBufferService which won't get processed
-    - path: spec.interStepBufferServiceName
+      # Principal: Changing the InterstepBufferService could cause data loss since unconsumed data may be left on the InterstepBufferService which won't get processed
+      - path: spec.interStepBufferServiceName
 
-    # Principal: Changing an Image definition could cause data loss if the new Image is not able to process the old data from the InterstepBufferService
-    - path: spec.vertices.source.generator
-    - path: spec.vertices.source.kafka
-    - path: spec.vertices.source.http
-    - path: spec.vertices.source.nats
-    - path: spec.vertices.source.jetstream
-    - path: spec.vertices.source.serving
-    - path: spec.vertices.source.udsource.container.image
-    - path: spec.vertices.source.transformer.container.image
-    - path: spec.vertices.source.transformer.container.command
-    - path: spec.vertices.source.transformer.container.args
-    - path: spec.vertices.source.transformer.container.env
-      includeSubfields: true
-    - path: spec.vertices.source.transformer.container.envfrom
-      includeSubfields: true
-    - path: spec.vertices.source.transformer.builtin
-      includeSubfields: true
-    - path: spec.vertices.sink.log
-    - path: spec.vertices.sink.kafka
-    - path: spec.vertices.sink.blackhole
-    - path: spec.vertices.sink.udsink.container.image
-    - path: spec.vertices.sink.udsink.container.command
-    - path: spec.vertices.sink.udsink.container.args
-    - path: spec.vertices.sink.udsink.container.env
-      includeSubfields: true
-    - path: spec.vertices.sink.udsink.container.envfrom
-      includeSubfields: true
-    - path: spec.vertices.udf.container.image
-    - path: spec.vertices.udf.container.command
-    - path: spec.vertices.udf.container.args
-    - path: spec.vertices.udf.container.env
-      includeSubfields: true
-    - path: spec.vertices.udf.container.envfrom
-      includeSubfields: true
-    - path: spec.vertices.udf.builtin
-      includeSubfields: true
-    - path: spec.sideInputs.container.image
-    - path: spec.sideInputs.container.command
-    - path: spec.sideInputs.container.args
-    - path: spec.sideInputs.container.env
-      includeSubfields: true
-    - path: spec.sideInputs.container.envfrom
-      includeSubfields: true
-    - path: spec.templates     # note: this one could be broken down further into just the fields that are at risk
-      includeSubfields: true
+      # Principal: Changing an Image definition could cause data loss if the new Image is not able to process the old data from the InterstepBufferService
+      - path: spec.vertices.source.generator
+      - path: spec.vertices.source.kafka
+      - path: spec.vertices.source.http
+      - path: spec.vertices.source.nats
+      - path: spec.vertices.source.jetstream
+      - path: spec.vertices.source.serving
+      - path: spec.vertices.source.udsource.container.image
+      - path: spec.vertices.source.transformer.container.image
+      - path: spec.vertices.source.transformer.container.command
+      - path: spec.vertices.source.transformer.container.args
+      - path: spec.vertices.source.transformer.container.env
+        includeSubfields: true
+      - path: spec.vertices.source.transformer.container.envfrom
+        includeSubfields: true
+      - path: spec.vertices.source.transformer.builtin
+        includeSubfields: true
+      - path: spec.vertices.sink.log
+      - path: spec.vertices.sink.kafka
+      - path: spec.vertices.sink.blackhole
+      - path: spec.vertices.sink.udsink.container.image
+      - path: spec.vertices.sink.udsink.container.command
+      - path: spec.vertices.sink.udsink.container.args
+      - path: spec.vertices.sink.udsink.container.env
+        includeSubfields: true
+      - path: spec.vertices.sink.udsink.container.envfrom
+        includeSubfields: true
+      - path: spec.vertices.udf.container.image
+      - path: spec.vertices.udf.container.command
+      - path: spec.vertices.udf.container.args
+      - path: spec.vertices.udf.container.env
+        includeSubfields: true
+      - path: spec.vertices.udf.container.envfrom
+        includeSubfields: true
+      - path: spec.vertices.udf.builtin
+        includeSubfields: true
+      - path: spec.sideInputs.container.image
+      - path: spec.sideInputs.container.command
+      - path: spec.sideInputs.container.args
+      - path: spec.sideInputs.container.env
+        includeSubfields: true
+      - path: spec.sideInputs.container.envfrom
+        includeSubfields: true
+      - path: spec.templates     # note: this one could be broken down further into just the fields that are at risk
+        includeSubfields: true
 
-    # Principal: TBD
-    - path: spec.sideInputs.container.envfrom
-      includeSubfields: true
-  isbServiceSpecDataLossFields: |
-    # Principal: Update to StatefulSet may not be backward compatible to understand the data on the PVC
-    - path: spec.jetstream.version
-    - path: spec.redis.native.version
-    - path: spec.redis.external.url
-    - path: spec.redis.external.sentinelUrl
-    - path: spec.redis.external.masterName
+      # Principal: TBD
+      - path: spec.sideInputs.container.envfrom
+        includeSubfields: true
+    recreate:
+      # TODO: add the recreate fields
+    progressive:
+      # TODO: add the progressive fields
+  isbService: |
+    dataLoss:
+      # Principal: Update to StatefulSet may not be backward compatible to understand the data on the PVC
+      - path: spec.jetstream.version
+      - path: spec.redis.native.version
+      - path: spec.redis.external.url
+      - path: spec.redis.external.sentinelUrl
+      - path: spec.redis.external.masterName
+    recreate:
+      # TODO: add the recreate fields
+    progressive:
+      # TODO: add the progressive fields
+  monovertex: |
+    dataLoss:
+      # TODO: add the data-loss fields
+    recreate:
+      # TODO: add the recreate fields
+    progressive:
+      # TODO: add the progressive fields

--- a/internal/controller/config/usde_config.go
+++ b/internal/controller/config/usde_config.go
@@ -18,17 +18,25 @@ package config
 
 import (
 	"fmt"
+
 	"github.com/rs/zerolog/log"
 )
 
-type SpecDataLossField struct {
+type SpecField struct {
 	Path             string `json:"path" yaml:"path"`
 	IncludeSubfields bool   `json:"includeSubfields,omitempty" yaml:"includeSubfields,omitempty"`
 }
 
+type USDEResourceConfig struct {
+	DataLoss    []SpecField `json:"dataLoss" yaml:"dataLoss"`
+	Recreate    []SpecField `json:"recreate" yaml:"recreate"`
+	Progressive []SpecField `json:"progressive" yaml:"progressive"`
+}
+
 type USDEConfig struct {
-	PipelineSpecDataLossFields   []SpecDataLossField `json:"pipelineSpecDataLossFields,omitempty" yaml:"pipelineSpecDataLossFields,omitempty"`
-	ISBServiceSpecDataLossFields []SpecDataLossField `json:"isbServiceSpecDataLossFields,omitempty" yaml:"isbServiceSpecDataLossFields,omitempty"`
+	Pipeline   USDEResourceConfig `json:"pipeline" yaml:"pipeline"`
+	ISBService USDEResourceConfig `json:"isbService" yaml:"isbService"`
+	Monovertex USDEResourceConfig `json:"monovertex" yaml:"monovertex"`
 }
 
 func (cm *ConfigManager) UpdateUSDEConfig(config USDEConfig) {

--- a/internal/controller/config/user_config.go
+++ b/internal/controller/config/user_config.go
@@ -58,11 +58,7 @@ func (s *USDEUserStrategy) UnmarshalJSON(data []byte) (err error) {
 
 func (s USDEUserStrategy) IsValid() bool {
 	switch s {
-	case ProgressiveStrategyID:
-		return true
-	case PPNDStrategyID:
-		return true
-	case NoStrategyID:
+	case ProgressiveStrategyID, PPNDStrategyID, NoStrategyID:
 		return true
 	default:
 		return false

--- a/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
@@ -68,7 +68,9 @@ func Test_reconcile_isbservicerollout_PPND(t *testing.T) {
 	assert.NoError(t, err)
 
 	usdeConfig := config.USDEConfig{
-		ISBServiceSpecDataLossFields: []config.SpecDataLossField{{Path: "spec", IncludeSubfields: true}},
+		ISBService: config.USDEResourceConfig{
+			DataLoss: []config.SpecField{{Path: "spec", IncludeSubfields: true}},
+		},
 	}
 
 	config.GetConfigManagerInstance().UpdateUSDEConfig(usdeConfig)

--- a/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
@@ -532,7 +532,9 @@ func Test_processExistingPipeline_PPND(t *testing.T) {
 	assert.NoError(t, err)
 
 	config.GetConfigManagerInstance().UpdateUSDEConfig(config.USDEConfig{
-		PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.vertices", IncludeSubfields: true}},
+		Pipeline: config.USDEResourceConfig{
+			DataLoss: []config.SpecField{{Path: "spec.vertices", IncludeSubfields: true}},
+		},
 	})
 
 	ctx := context.Background()
@@ -787,7 +789,9 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 	assert.NoError(t, err)
 
 	config.GetConfigManagerInstance().UpdateUSDEConfig(config.USDEConfig{
-		PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.vertices", IncludeSubfields: true}},
+		Pipeline: config.USDEResourceConfig{
+			DataLoss: []config.SpecField{{Path: "spec.vertices", IncludeSubfields: true}},
+		},
 	})
 	ctx := context.Background()
 

--- a/internal/usde/usde_test.go
+++ b/internal/usde/usde_test.go
@@ -197,7 +197,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return pipelineDef
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{},
+				},
 			},
 			namespaceConfig:       nil,
 			expectedNeedsUpdating: false,
@@ -212,7 +214,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{},
+				},
 			},
 			namespaceConfig:       nil,
 			expectedNeedsUpdating: true,
@@ -227,7 +231,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.interStepBufferServiceName"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.interStepBufferServiceName"}},
+				},
 			},
 			namespaceConfig:       nil,
 			expectedNeedsUpdating: true,
@@ -238,7 +244,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			newDefinition:      *pipelineDefn.DeepCopy(),
 			existingDefinition: *pipelineDefn.DeepCopy(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.interStepBufferServiceName"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.interStepBufferServiceName"}},
+				},
 			},
 			namespaceConfig:       nil,
 			expectedNeedsUpdating: false,
@@ -253,7 +261,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.interStepBufferServiceName"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.interStepBufferServiceName"}},
+				},
 			},
 			namespaceConfig:       nil,
 			expectedNeedsUpdating: true,
@@ -268,7 +278,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.interStepBufferServiceName"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.interStepBufferServiceName"}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "invalid"},
 			expectedNeedsUpdating: true,
@@ -283,7 +295,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.interStepBufferServiceName"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.interStepBufferServiceName"}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: true,
@@ -299,7 +313,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.vertices.source.generator", IncludeSubfields: true}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.vertices.source.generator", IncludeSubfields: true}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: true,
@@ -315,7 +331,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.vertices.source.generator.rpu"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.vertices.source.generator.rpu"}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: true,
@@ -331,7 +349,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.vertices.sink.log"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.vertices.sink.log"}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: true,
@@ -347,7 +367,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.vertices"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.vertices"}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: true,
@@ -363,7 +385,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.vertices.sink"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.vertices.sink"}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: true,
@@ -379,7 +403,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makePipelineDefinition(*newPipelineDef)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.vertices.sink", IncludeSubfields: true}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.vertices.sink", IncludeSubfields: true}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: true,
@@ -390,7 +416,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			newDefinition:      *pipelineDefn.DeepCopy(),
 			existingDefinition: *pipelineDefn.DeepCopy(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.vertices.source.something"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.vertices.source.something"}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: false,
@@ -405,8 +433,12 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makeISBServiceDefinition(*newISBServiceSpec)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields:   []config.SpecDataLossField{{Path: "spec.vertices.source.something"}},
-				ISBServiceSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.jetstream.containerTemplate.resources.limits"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.vertices.source.something"}},
+				},
+				ISBService: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.jetstream.containerTemplate.resources.limits"}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: true,
@@ -421,8 +453,12 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return makeISBServiceDefinition(*newISBServiceSpec)
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields:   []config.SpecDataLossField{{Path: "spec.vertices.source.something"}},
-				ISBServiceSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.jetstream.containerTemplate.resources.limits", IncludeSubfields: true}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.vertices.source.something"}},
+				},
+				ISBService: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.jetstream.containerTemplate.resources.limits", IncludeSubfields: true}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: true,
@@ -441,7 +477,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return pipelineDef
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{},
+				},
 			},
 			namespaceConfig:       nil,
 			expectedNeedsUpdating: true,
@@ -464,7 +502,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 				return pipelineDef
 			}(),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.interStepBufferServiceName"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.interStepBufferServiceName"}},
+				},
 			},
 			namespaceConfig:       nil,
 			expectedNeedsUpdating: true,
@@ -480,7 +520,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			}(),
 			existingDefinition: makePipelineDefinition(existingPipelineSpec1),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.vertices.source.generator"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.vertices.source.generator"}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: true,
@@ -496,7 +538,9 @@ func Test_ResourceNeedsUpdating(t *testing.T) {
 			}(),
 			existingDefinition: makePipelineDefinition(existingPipelineSpec2),
 			usdeConfig: config.USDEConfig{
-				PipelineSpecDataLossFields: []config.SpecDataLossField{{Path: "spec.vertices.source.generator"}},
+				Pipeline: config.USDEResourceConfig{
+					DataLoss: []config.SpecField{{Path: "spec.vertices.source.generator"}},
+				},
 			},
 			namespaceConfig:       &config.NamespaceConfig{UpgradeStrategy: "pause-and-drain"},
 			expectedNeedsUpdating: true,

--- a/internal/util/kubernetes/config_watcher.go
+++ b/internal/util/kubernetes/config_watcher.go
@@ -130,14 +130,19 @@ func handleUSDEConfigMapEvent(configMap *corev1.ConfigMap, event watch.Event) er
 
 		usdeConfig := config.USDEConfig{}
 
-		err := yaml.Unmarshal([]byte(configMap.Data["pipelineSpecDataLossFields"]), &usdeConfig.PipelineSpecDataLossFields)
+		err := yaml.Unmarshal([]byte(configMap.Data["pipeline"]), &usdeConfig.Pipeline)
 		if err != nil {
-			return fmt.Errorf("error unmarshalling USDE PipelineSpecDataLossFields: %v", err)
+			return fmt.Errorf("error unmarshalling USDE Config for Pipeline: %v", err)
 		}
 
-		err = yaml.Unmarshal([]byte(configMap.Data["isbServiceSpecDataLossFields"]), &usdeConfig.ISBServiceSpecDataLossFields)
+		err = yaml.Unmarshal([]byte(configMap.Data["isbService"]), &usdeConfig.ISBService)
 		if err != nil {
-			return fmt.Errorf("error unmarshalling USDE ISBServiceSpecDataLossFields: %v", err)
+			return fmt.Errorf("error unmarshalling USDE Config for ISBService: %v", err)
+		}
+
+		err = yaml.Unmarshal([]byte(configMap.Data["monovertex"]), &usdeConfig.Monovertex)
+		if err != nil {
+			return fmt.Errorf("error unmarshalling USDE Config for Monovertex: %v", err)
 		}
 
 		config.GetConfigManagerInstance().UpdateUSDEConfig(usdeConfig)

--- a/internal/util/kubernetes/config_watcher_test.go
+++ b/internal/util/kubernetes/config_watcher_test.go
@@ -76,13 +76,21 @@ func Test_watchConfigMaps(t *testing.T) {
 			},
 		},
 		Data: map[string]string{
-			"pipelineSpecDataLossFields": `
-        - path: "abc"
-        - path: "abcde/xyz"
-        - path: "path/array/sample"
+			"pipeline": `
+        dataLoss:
+          - path: "abc"
+          - path: "abcde/xyz"
+          - path: "path/array/sample"
+        recreate:
+        - path: "recreate/path"
       `,
-			"isbServiceSpecDataLossFields": `
-        - path: "invalid"
+			"isbService": `
+        dataLoss:
+          - path: "invalid"
+        progressive:
+          - path: "progressive/path/a"
+          - path: "progressive/path/b"
+          - path: "progressive/path/c"
       `,
 		},
 	}
@@ -93,8 +101,14 @@ func Test_watchConfigMaps(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	expectedUSDEConfig := config.USDEConfig{
-		PipelineSpecDataLossFields:   []config.SpecDataLossField{{Path: "abc"}, {Path: "abcde/xyz"}, {Path: "path/array/sample"}},
-		ISBServiceSpecDataLossFields: []config.SpecDataLossField{{Path: "invalid"}},
+		Pipeline: config.USDEResourceConfig{
+			DataLoss: []config.SpecField{{Path: "abc"}, {Path: "abcde/xyz"}, {Path: "path/array/sample"}},
+			Recreate: []config.SpecField{{Path: "recreate/path"}},
+		},
+		ISBService: config.USDEResourceConfig{
+			DataLoss:    []config.SpecField{{Path: "invalid"}},
+			Progressive: []config.SpecField{{Path: "progressive/path/a"}, {Path: "progressive/path/b"}, {Path: "progressive/path/c"}},
+		},
 	}
 
 	actualUSDEConfig := config.GetConfigManagerInstance().GetUSDEConfig()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Changed USDE config to include more than just data-loss fields (recreate and progressive fields).
This PR only includes the changes to modify the USDE config structure. Future PR will include changes to the logic to utilize those new configuration fields and to properly setup the configuration spec fields.

### Verification

Manually tested that the USDE config structure is loaded correctly. Updated unit tests to reflect the new structure.

### Backward incompatibilities

At this point, this PR should not cause backward incompatibility issues unless the USDE ConfigMap cannot be updated during upgrade.
