### PR TITLE
fix: Add phase to numaflowControllersHealth and numaflowControllerRolloutsHealth metrics

### DIFF
--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -224,9 +224,9 @@ func (r *NumaflowControllerReconciler) reconcile(
 
 	defer func() {
 		if controller.Status.IsHealthy() {
-			r.customMetrics.NumaflowControllersHealth.WithLabelValues(controller.Namespace, controller.Name).Set(1)
+			r.customMetrics.NumaflowControllersHealth.WithLabelValues(controller.Namespace, controller.Name, string(controller.Status.Phase)).Set(1)
 		} else {
-			r.customMetrics.NumaflowControllersHealth.WithLabelValues(controller.Namespace, controller.Name).Set(0)
+			r.customMetrics.NumaflowControllersHealth.WithLabelValues(controller.Namespace, controller.Name, string(controller.Status.Phase)).Set(0)
 		}
 	}()
 
@@ -244,7 +244,7 @@ func (r *NumaflowControllerReconciler) reconcile(
 
 		// generate the metrics for the numaflow controller deletion
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerNumaflowController, "delete").Observe(time.Since(syncStartTime).Seconds())
-		r.customMetrics.NumaflowControllersHealth.DeleteLabelValues(controller.Namespace, controller.Name)
+		r.customMetrics.NumaflowControllersHealth.DeleteLabelValues(controller.Namespace, controller.Name, string(controller.Status.Phase))
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -190,9 +190,9 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 
 	defer func() {
 		if nfcRollout.Status.IsHealthy() {
-			r.customMetrics.NumaflowControllerRolloutsHealth.WithLabelValues(nfcRollout.Namespace, nfcRollout.Name).Set(1)
+			r.customMetrics.NumaflowControllerRolloutsHealth.WithLabelValues(nfcRollout.Namespace, nfcRollout.Name, string(nfcRollout.Status.Phase)).Set(1)
 		} else {
-			r.customMetrics.NumaflowControllerRolloutsHealth.WithLabelValues(nfcRollout.Namespace, nfcRollout.Name).Set(0)
+			r.customMetrics.NumaflowControllerRolloutsHealth.WithLabelValues(nfcRollout.Namespace, nfcRollout.Name, string(nfcRollout.Status.Phase)).Set(0)
 		}
 	}()
 
@@ -209,7 +209,7 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 		// generate the metrics for the numaflow controller rollout deletion.
 		r.customMetrics.DecNumaflowControllerRollouts(nfcRollout.Name, nfcRollout.Namespace)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerNumaflowControllerRollout, "delete").Observe(time.Since(startTime).Seconds())
-		r.customMetrics.NumaflowControllerRolloutsHealth.DeleteLabelValues(nfcRollout.Namespace, nfcRollout.Name)
+		r.customMetrics.NumaflowControllerRolloutsHealth.DeleteLabelValues(nfcRollout.Namespace, nfcRollout.Name, string(nfcRollout.Status.Phase))
 
 		return ctrl.Result{}, nil
 	}

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -128,6 +128,20 @@ var (
 		ConstLabels: defaultLabels,
 	}, []string{LabelNamespace, LabelMonoVertex, LabelPhase})
 
+	// numaflowControllersHealth indicates whether the NumaflowControllers are healthy (from k8s resource perspective)
+	numaflowControllersHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        "numaflow_controller_health",
+		Help:        "A metric to indicate whether the NumaflowController is healthy. '1' means healthy, '0' means unhealthy",
+		ConstLabels: defaultLabels,
+	}, []string{LabelNamespace, LabelNumaflowController, LabelPhase})
+
+	// numaflowControllerRolloutsHealth indicates whether the numaflow controller rollouts are healthy (from k8s resource perspective)
+	numaflowControllerRolloutsHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        "numaflow_controller_rollout_health",
+		Help:        "A metric to indicate whether the numaflow controller rollout is healthy. '1' means healthy, '0' means unhealthy",
+		ConstLabels: defaultLabels,
+	}, []string{LabelNamespace, LabelNumaflowController, LabelPhase})
+
 	// pipelineRolloutsRunning indicates the number of PipelineRollouts
 	pipelineRolloutsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "pipeline_rollouts_running",
@@ -219,13 +233,6 @@ var (
 		ConstLabels: defaultLabels,
 	}, []string{})
 
-	// numaflowControllerRolloutsHealth indicates whether the numaflow controller rollouts are healthy (from k8s resource perspective)
-	numaflowControllerRolloutsHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "numaflow_controller_rollout_health",
-		Help:        "A metric to indicate whether the numaflow controller rollout is healthy. '1' means healthy, '0' means unhealthy",
-		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelNumaflowController})
-
 	// numaflowControllerRolloutsRunning is the gauge for the number of running numaflow controller rollouts
 	numaflowControllerRolloutsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "numaflow_controller_rollouts_running",
@@ -253,13 +260,6 @@ var (
 		Help:        "Duration a NumaflowControllerRollout paused pipelines for",
 		ConstLabels: defaultLabels,
 	}, []string{LabelName})
-
-	// numaflowControllersHealth indicates whether the NumaflowControllers are healthy (from k8s resource perspective)
-	numaflowControllersHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name:        "numaflow_controller_health",
-		Help:        "A metric to indicate whether the NumaflowController is healthy. '1' means healthy, '0' means unhealthy",
-		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelNumaflowController})
 
 	// numaflowControllerSyncErrors is the total number of NumaflowController reconciliation errors
 	numaflowControllerSyncErrors = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->
Add phase to numaflowControllersHealth and numaflowControllerRolloutsHealth metrics

### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

Verified in local kubernetes cluster.

```bash
# HELP numaflow_controller_health A metric to indicate whether the NumaflowController is healthy. '1' means healthy, '0' means unhealthy
# TYPE numaflow_controller_health gauge
numaflow_controller_health{intuit_alert="true",namespace="example-namespace",numaflowcontroller="numaflow-controller",phase="Deployed"} 1
# HELP numaflow_controller_rollout_health A metric to indicate whether the numaflow controller rollout is healthy. '1' means healthy, '0' means unhealthy
# TYPE numaflow_controller_rollout_health gauge
numaflow_controller_rollout_health{intuit_alert="true",namespace="example-namespace",numaflowcontroller="numaflow-controller",phase="Deployed"} 1
```

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
