### PR TITLE
feat: add progressive to e2e test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ppnd: ["true", "false"]
+        strategy: ["pause-and-drain", "progressive", "no-strategy"]
 
     steps:
       - name: Checkout code
@@ -154,18 +154,18 @@ jobs:
         env:
           GOPATH: /home/runner/go
         run:
-          KUBECONFIG=~/.kube/config VERSION=${{ github.sha }} DOCKER_PUSH=true PPND=${{matrix.ppnd}} make start
+          KUBECONFIG=~/.kube/config VERSION=${{ github.sha }} DOCKER_PUSH=true STRATEGY=${{matrix.strategy}} make start
 
       - name: Run e2e tests
         env:
           GOPATH: /home/runner/go
-        run: KUBECONFIG=~/.kube/config VERSION=${{ github.sha }} DOCKER_PUSH=true PPND=${{matrix.ppnd}} ENABLE_POD_LOGS=true make test-e2e
+        run: KUBECONFIG=~/.kube/config VERSION=${{ github.sha }} DOCKER_PUSH=true STRATEGY=${{matrix.strategy}} ENABLE_POD_LOGS=true make test-e2e
 
       - name: Archive resource changes
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: resource-changes-${{matrix.ppnd}}
+          name: resource-changes-${{matrix.strategy}}
           path: |
             tests/e2e/output/resources/
           retention-days: 7
@@ -174,7 +174,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: pod-logs-${{matrix.ppnd}}
+          name: pod-logs-${{matrix.strategy}}
           path: |
             tests/e2e/output/logs/
           retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,11 @@ TEST_PROGRESSIVE_MANIFEST_DIR ?= tests/manifests/special-cases/progressive
 
 TEST_MANIFEST_DIR := $(TEST_NOSTRATEGY_MANIFEST_DIR)
 
-ifeq ($(PPND), true)
+ifeq ($(STRATEGY), pause-and-drain)
 TEST_MANIFEST_DIR := $(TEST_MANIFEST_DIR_DEFAULT)
 endif
 
-ifeq ($(PROGRESSIVE), true)
+ifeq ($(STRATEGY), progressive)
 TEST_MANIFEST_DIR := $(TEST_PROGRESSIVE_MANIFEST_DIR)
 endif
 

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -390,7 +390,7 @@ func getChildResource(gvr schema.GroupVersionResource, namespace, rolloutName st
 
 func getUpgradeStrategy() string {
 
-	var validStrategies = []string{"ppnd", "progressive", "no-strategy", ""}
+	var validStrategies = []string{"pause-and-drain", "progressive", "no-strategy", ""}
 
 	strategy := strings.ToLower(os.Getenv("STRATEGY"))
 	for _, validStrategy := range validStrategies {

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -53,7 +53,7 @@ var (
 	mutex  sync.RWMutex
 	stopCh chan struct{}
 
-	ppnd                 string
+	upgradeStrategy      string
 	disableTestArtifacts string
 	enablePodLogs        string
 
@@ -386,4 +386,18 @@ func getChildResource(gvr schema.GroupVersionResource, namespace, rolloutName st
 
 	return &unstructList.Items[0], nil
 
+}
+
+func getUpgradeStrategy() string {
+
+	var validStrategies = []string{"ppnd", "progressive", "no-strategy", ""}
+
+	strategy := strings.ToLower(os.Getenv("STRATEGY"))
+	for _, validStrategy := range validStrategies {
+		if strategy == validStrategy {
+			return strategy
+		}
+	}
+
+	return "invalid"
 }

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	clientgo "k8s.io/client-go/kubernetes"
 
+	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
@@ -53,9 +54,9 @@ var (
 	mutex  sync.RWMutex
 	stopCh chan struct{}
 
-	upgradeStrategy      string
 	disableTestArtifacts string
 	enablePodLogs        string
+	upgradeStrategy      config.USDEUserStrategy
 
 	openFiles map[string]*os.File
 )
@@ -388,16 +389,6 @@ func getChildResource(gvr schema.GroupVersionResource, namespace, rolloutName st
 
 }
 
-func getUpgradeStrategy() string {
-
-	var validStrategies = []string{"pause-and-drain", "progressive", "no-strategy", ""}
-
-	strategy := strings.ToLower(os.Getenv("STRATEGY"))
-	for _, validStrategy := range validStrategies {
-		if strategy == validStrategy {
-			return strategy
-		}
-	}
-
-	return "invalid"
+func getUpgradeStrategy() config.USDEUserStrategy {
+	return config.USDEUserStrategy(strings.ToLower(os.Getenv("STRATEGY")))
 }

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -298,7 +298,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return pipelineSpec, nil
 		})
 
-		if ppnd == "true" {
+		if upgradeStrategy == "ppnd" {
 			document("Verify that child Pipeline is not paused when an update not requiring pause is made")
 			verifyPipelineStatusConsistently(Namespace, pipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus numaflowv1.PipelineStatus) bool {
 				return retrievedPipelineStatus.Phase != numaflowv1.PipelinePhasePaused
@@ -337,7 +337,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
-		if ppnd == "true" {
+		if upgradeStrategy == "ppnd" {
 
 			document("Verify that in-progress-strategy gets set to PPND")
 			verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyPPND)
@@ -523,7 +523,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
-		if ppnd == "true" {
+		if upgradeStrategy == "ppnd" {
 
 			document("Verify that in-progress-strategy gets set to PPND")
 			verifyInProgressStrategyISBService(Namespace, isbServiceRolloutName, apiv1.UpgradeStrategyPPND)
@@ -779,7 +779,7 @@ func updateNumaflowControllerRolloutVersion(originalVersion, newVersion string, 
 		return rollout, nil
 	})
 
-	if ppnd == "true" {
+	if upgradeStrategy == "ppnd" {
 
 		document("Verify that in-progress-strategy gets set to PPND")
 		verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyPPND)

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaplane/internal/controller/config"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
@@ -298,7 +299,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return pipelineSpec, nil
 		})
 
-		if upgradeStrategy == "pause-and-drain" {
+		if upgradeStrategy == config.PPNDStrategyID {
 			document("Verify that child Pipeline is not paused when an update not requiring pause is made")
 			verifyPipelineStatusConsistently(Namespace, pipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus numaflowv1.PipelineStatus) bool {
 				return retrievedPipelineStatus.Phase != numaflowv1.PipelinePhasePaused
@@ -337,7 +338,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
-		if upgradeStrategy == "pause-and-drain" {
+		if upgradeStrategy == config.PPNDStrategyID {
 
 			document("Verify that in-progress-strategy gets set to PPND")
 			verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyPPND)
@@ -523,7 +524,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
-		if upgradeStrategy == "pause-and-drain" {
+		if upgradeStrategy == config.PPNDStrategyID {
 
 			document("Verify that in-progress-strategy gets set to PPND")
 			verifyInProgressStrategyISBService(Namespace, isbServiceRolloutName, apiv1.UpgradeStrategyPPND)
@@ -567,31 +568,27 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
-		document("Verify that dependent Pipeline is not paused when an update to ISBService not requiring pause is made")
-		verifyNotPausing := func() bool {
-			_, _, retrievedPipelineStatus, err := getPipelineSpecAndStatus(Namespace, pipelineRolloutName)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(retrievedPipelineStatus.Phase != numaflowv1.PipelinePhasePaused).To(BeTrue())
-			isbRollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			isbCondStatus := getRolloutConditionStatus(isbRollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-			plRollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			plCondStatus := getRolloutConditionStatus(plRollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-			if isbCondStatus == metav1.ConditionTrue || plCondStatus == metav1.ConditionTrue {
-				return false
-			}
-			if upgradeStrategy == "progressive" {
-				if isbRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyProgressive || plRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyNoOp {
+		if upgradeStrategy == config.PPNDStrategyID {
+			document("Verify that dependent Pipeline is not paused when an update to ISBService not requiring pause is made")
+			verifyNotPausing := func() bool {
+				_, _, retrievedPipelineStatus, err := getPipelineSpecAndStatus(Namespace, pipelineRolloutName)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(retrievedPipelineStatus.Phase != numaflowv1.PipelinePhasePaused).To(BeTrue())
+				isbRollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
+				isbCondStatus := getRolloutConditionStatus(isbRollout.Status.Conditions, apiv1.ConditionPausingPipelines)
+				plRollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
+				plCondStatus := getRolloutConditionStatus(plRollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
+				if isbCondStatus == metav1.ConditionTrue || plCondStatus == metav1.ConditionTrue {
 					return false
 				}
-			} else {
 				if isbRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyNoOp || plRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyNoOp {
 					return false
 				}
+				return true
 			}
-			return true
-		}
 
-		Consistently(verifyNotPausing, 30*time.Second).Should(BeTrue())
+			Consistently(verifyNotPausing, 30*time.Second).Should(BeTrue())
+		}
 
 		verifyISBServiceSpec(Namespace, isbServiceRolloutName, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return *retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() == updatedMemLimit
@@ -777,7 +774,7 @@ func updateNumaflowControllerRolloutVersion(originalVersion, newVersion string, 
 		return rollout, nil
 	})
 
-	if upgradeStrategy == "pause-and-drain" {
+	if upgradeStrategy == config.PPNDStrategyID {
 
 		document("Verify that in-progress-strategy gets set to PPND")
 		verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyPPND)

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -579,8 +579,14 @@ var _ = Describe("Functional e2e", Serial, func() {
 			if isbCondStatus == metav1.ConditionTrue || plCondStatus == metav1.ConditionTrue {
 				return false
 			}
-			if isbRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyNoOp || plRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyNoOp {
-				return false
+			if upgradeStrategy == "progressive" {
+				if isbRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyProgressive || plRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyNoOp {
+					return false
+				}
+			} else {
+				if isbRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyNoOp || plRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyNoOp {
+					return false
+				}
 			}
 			return true
 		}

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -298,7 +298,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return pipelineSpec, nil
 		})
 
-		if upgradeStrategy == "ppnd" {
+		if upgradeStrategy == "pause-and-drain" {
 			document("Verify that child Pipeline is not paused when an update not requiring pause is made")
 			verifyPipelineStatusConsistently(Namespace, pipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus numaflowv1.PipelineStatus) bool {
 				return retrievedPipelineStatus.Phase != numaflowv1.PipelinePhasePaused
@@ -337,7 +337,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
-		if upgradeStrategy == "ppnd" {
+		if upgradeStrategy == "pause-and-drain" {
 
 			document("Verify that in-progress-strategy gets set to PPND")
 			verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyPPND)
@@ -523,7 +523,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return rollout, nil
 		})
 
-		if upgradeStrategy == "ppnd" {
+		if upgradeStrategy == "pause-and-drain" {
 
 			document("Verify that in-progress-strategy gets set to PPND")
 			verifyInProgressStrategyISBService(Namespace, isbServiceRolloutName, apiv1.UpgradeStrategyPPND)
@@ -771,7 +771,7 @@ func updateNumaflowControllerRolloutVersion(originalVersion, newVersion string, 
 		return rollout, nil
 	})
 
-	if upgradeStrategy == "ppnd" {
+	if upgradeStrategy == "pause-and-drain" {
 
 		document("Verify that in-progress-strategy gets set to PPND")
 		verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyPPND)

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -18,6 +18,7 @@ import (
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 
+	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/util"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
@@ -77,7 +78,7 @@ func verifyISBSvcRolloutReady(isbServiceRolloutName string) {
 		return getRolloutConditionStatus(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 	}, 4*time.Minute, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-	if upgradeStrategy == "pause-and-drain" {
+	if upgradeStrategy == config.PPNDStrategyID {
 		document("Verifying that the ISBServiceRollout PausingPipelines condition is as expected")
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -77,7 +77,7 @@ func verifyISBSvcRolloutReady(isbServiceRolloutName string) {
 		return getRolloutConditionStatus(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 	}, 4*time.Minute, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-	if upgradeStrategy == "ppnd" {
+	if upgradeStrategy == "pause-and-drain" {
 		document("Verifying that the ISBServiceRollout PausingPipelines condition is as expected")
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -77,7 +77,7 @@ func verifyISBSvcRolloutReady(isbServiceRolloutName string) {
 		return getRolloutConditionStatus(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 	}, 4*time.Minute, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-	if ppnd == "true" {
+	if upgradeStrategy == "ppnd" {
 		document("Verifying that the ISBServiceRollout PausingPipelines condition is as expected")
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -48,7 +48,7 @@ func verifyNumaflowControllerRolloutReady() {
 		return getRolloutConditionStatus(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-	if ppnd == "true" {
+	if upgradeStrategy == "ppnd" {
 		document("Verifying that the NumaflowControllerRollout PausingPipelines condition is as expected")
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -48,7 +48,7 @@ func verifyNumaflowControllerRolloutReady() {
 		return getRolloutConditionStatus(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-	if upgradeStrategy == "ppnd" {
+	if upgradeStrategy == "pause-and-drain" {
 		document("Verifying that the NumaflowControllerRollout PausingPipelines condition is as expected")
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/numaproj/numaplane/internal/controller/config"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
@@ -48,7 +49,7 @@ func verifyNumaflowControllerRolloutReady() {
 		return getRolloutConditionStatus(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 
-	if upgradeStrategy == "pause-and-drain" {
+	if upgradeStrategy == config.PPNDStrategyID {
 		document("Verifying that the NumaflowControllerRollout PausingPipelines condition is as expected")
 		Eventually(func() metav1.ConditionStatus {
 			rollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -59,7 +59,7 @@ var _ = BeforeSuite(func() {
 
 	stopCh = make(chan struct{})
 
-	upgradeStrategy := getUpgradeStrategy()
+	upgradeStrategy = getUpgradeStrategy()
 	Expect(upgradeStrategy).ToNot(Equal("invalid"))
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -60,7 +60,7 @@ var _ = BeforeSuite(func() {
 	stopCh = make(chan struct{})
 
 	upgradeStrategy = getUpgradeStrategy()
-	Expect(upgradeStrategy).ToNot(Equal("invalid"))
+	Expect(upgradeStrategy.IsValid()).To(BeTrue())
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -59,7 +59,8 @@ var _ = BeforeSuite(func() {
 
 	stopCh = make(chan struct{})
 
-	ppnd = os.Getenv("PPND")
+	upgradeStrategy := getUpgradeStrategy()
+	Expect(upgradeStrategy).ToNot(Equal("invalid"))
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #474 

### Modifications

Incorporates `progressive` strategy to e2e test matrix and redefines matrix to be 3 different runs: `no-strategy`, `pause-and-drain` and `progressive`


### Verification

Running `make test-e2e` with `STRATEGY` variable set locally to verify change is working.
Checking that the CI's matrix is updated correctly to reflect new matrix.

### Backward incompatibilities

None.
