### PR TITLE
fix: Add version and name of numalfow controller in metrics

### DIFF
--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -169,8 +169,8 @@ func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
-	// generate metrics for NumaflowControllerRollout
-	r.customMetrics.IncNumaflowControllerRollouts(numaflowControllerRollout.Name, numaflowControllerRollout.Namespace)
+	// generate metrics for NumaflowControllerRollout.
+	r.customMetrics.NumaflowControllerRolloutsRunning.WithLabelValues(numaflowControllerRollout.Name, numaflowControllerRollout.Namespace, numaflowControllerRollout.Spec.Controller.Version).Set(1)
 
 	r.recorder.Eventf(numaflowControllerRollout, corev1.EventTypeNormal, "ReconcilationSuccessful", "Reconciliation successful")
 	numaLogger.Debug("reconciliation successful")
@@ -207,7 +207,7 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 		}
 
 		// generate the metrics for the numaflow controller rollout deletion.
-		r.customMetrics.DecNumaflowControllerRollouts(nfcRollout.Name, nfcRollout.Namespace)
+		r.customMetrics.NumaflowControllerRolloutsRunning.DeleteLabelValues(nfcRollout.Name, nfcRollout.Namespace, nfcRollout.Spec.Controller.Version)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerNumaflowControllerRollout, "delete").Observe(time.Since(startTime).Seconds())
 		r.customMetrics.NumaflowControllerRolloutsHealth.DeleteLabelValues(nfcRollout.Namespace, nfcRollout.Name, string(nfcRollout.Status.Phase))
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/483

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

Add Numaflow controller version and name in metrics data.

### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

```bash
# HELP numaflow_controller_rollouts_running Number of NumaflowControllerRollouts
# TYPE numaflow_controller_rollouts_running gauge
numaflow_controller_rollouts_running{intuit_alert="true",name="numaflow-controller",namespace="example-namespace",version="1.3.3"} 1
# HELP numaflow_controller_sync_errors_total The total number of NumaflowController sync errors
```

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
