### PR TITLE
prevent panic in e2e test

### DIFF
--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -591,7 +591,10 @@ var _ = Describe("Functional e2e", Serial, func() {
 		}
 
 		verifyISBServiceSpec(Namespace, isbServiceRolloutName, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
-			return *retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() == updatedMemLimit
+			return retrievedISBServiceSpec.JetStream != nil &&
+				retrievedISBServiceSpec.JetStream.ContainerTemplate != nil &&
+				retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() != nil &&
+				*retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() == updatedMemLimit
 		})
 
 		verifyISBSvcRolloutReady(isbServiceRolloutName)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

I realized that if the e2e test panics, it does it silently. It doesn't print the panic. It just fails the test. The thing I noticed is that it doesn't perform the `Eventually()` statement for the full 2 minute timeout like it's supposed to, which gave me a clue that this was happening. 


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
