### PR TITLE
chore: add numaplane clientset

### DIFF
--- a/internal/util/kubernetes/clientset.go
+++ b/internal/util/kubernetes/clientset.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"fmt"
 
+	"github.com/numaproj/numaplane/pkg/client/clientset/versioned"
 	"k8s.io/client-go/dynamic"
 	clientkube "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -10,6 +11,7 @@ import (
 
 var DynamicClient *dynamic.DynamicClient
 var KubernetesClient *clientkube.Clientset
+var NumaplaneClient *versioned.Clientset
 
 func SetClientSets(restConfig *rest.Config) error {
 	var err error
@@ -20,7 +22,12 @@ func SetClientSets(restConfig *rest.Config) error {
 
 	KubernetesClient, err = clientkube.NewForConfig(restConfig)
 	if err != nil {
-		return fmt.Errorf("failed to create kubernetes client: %v", err)
+		return fmt.Errorf("failed to create kubernetes clientset: %v", err)
+	}
+
+	NumaplaneClient, err = versioned.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create numaplane clientset: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

Add the Numaplane Clientset as one we can use. This can be used to get a live Numaplane resource from Kubernetes API rather than needing to only go through our controller-runtime client, which always goes to the cache first. 


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
