### PR TITLE
chore: update imports to use latest numaflow (1.4.2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-swagger/go-swagger v0.31.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.6.0
-	github.com/numaproj/numaflow v0.0.0-20241024150937-8e98c0854bc3
+	github.com/numaproj/numaflow v1.4.2
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.2
 	github.com/prometheus/client_golang v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/numaproj/numaflow v0.0.0-20241024150937-8e98c0854bc3 h1:y7CWwiHQqGPdTIm9SuaBn83W/6AJvv9EwIggLIZCunc=
-github.com/numaproj/numaflow v0.0.0-20241024150937-8e98c0854bc3/go.mod h1:wt6hXNYT4kb6h7hCx4U5oW7LHsp1lAl1eDcR2HW0bDI=
+github.com/numaproj/numaflow v1.4.2 h1:KItpGa5e5k4Li7n2J40+XUHxDouB928hUmCrXJyoCVU=
+github.com/numaproj/numaflow v1.4.2/go.mod h1:2ibgLnsCRLIShm6k8FwmsEEuKbmphJA0mQ6kg3M7Wzk=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

May fix: #497 

### Modifications

Apparently, this same test failure happened twice (which I can confirm to be an error in the test and not an error in numaplane functionality based on looking at the resource output), and both occurred after we updated the e2e test to use numaflow 1.4.0/1.4.2  [here.](https://github.com/numaproj/numaplane/pull/490/files)

Possible theory is that [this](https://github.com/numaproj/numaplane/blob/main/tests/e2e/pipeline.go#L177-L191) code could possibly fail if the PipelineSpec and PipelineStatus fields aren't compatible with the version of Numaflow that's running.

Since the test is using numaflow 1.4.x, I thought I'd try updating the numaflow package to match 1.4.2 at least, and see if we still get the intermittent e2e failure.

### Verification

CI

### Backward incompatibilities

I checked our non-test code, and the only places we're using "numaflow" module code are to refer to specific constants, so I think we should be okay.