### PR TITLE
feat: update isbservice and nfc paused metrics to include namespace label

### DIFF
--- a/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
@@ -208,6 +208,9 @@ spec:
                 type: string
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: The metadata name must start with 'numaflow-controller'
+          rule: matches(self.metadata.name, '^numaflow-controller.*')
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
@@ -208,9 +208,6 @@ spec:
                 type: string
             type: object
         type: object
-        x-kubernetes-validations:
-        - message: The metadata name must start with 'numaflow-controller'
-          rule: matches(self.metadata.name, '^numaflow-controller.*')
     served: true
     storage: true
     subresources:

--- a/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_numaflowcontrollerrollout.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   controller:
     #instanceID: "0" # uncomment for Progressive rollout to set Numaflow Controller instance
-    version: "1.3.3"  
+    version: "1.4.0"  

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -445,7 +445,7 @@ func (r *ISBServiceRolloutReconciler) MarkRolloutPaused(ctx context.Context, rol
 
 func (r *ISBServiceRolloutReconciler) updatePauseMetric(isbServiceRollout *apiv1.ISBServiceRollout) {
 	timeElapsed := time.Since(isbServiceRollout.Status.PauseRequestStatus.LastPauseBeginTime.Time)
-	r.customMetrics.ISBServicePausedSeconds.WithLabelValues(isbServiceRollout.Name).Set(timeElapsed.Seconds())
+	r.customMetrics.ISBServicePausedSeconds.WithLabelValues(isbServiceRollout.Name, isbServiceRollout.Namespace).Set(timeElapsed.Seconds())
 }
 
 func (r *ISBServiceRolloutReconciler) GetRolloutKey(rolloutNamespace string, rolloutName string) string {

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -424,7 +424,7 @@ func (r *NumaflowControllerRolloutReconciler) MarkRolloutPaused(ctx context.Cont
 
 func (r *NumaflowControllerRolloutReconciler) updatePauseMetric(nfcRollout *apiv1.NumaflowControllerRollout) {
 	timeElapsed := time.Since(nfcRollout.Status.PauseRequestStatus.LastPauseBeginTime.Time)
-	r.customMetrics.NumaflowControllerRolloutPausedSeconds.WithLabelValues(nfcRollout.Name).Set(timeElapsed.Seconds())
+	r.customMetrics.NumaflowControllerRolloutPausedSeconds.WithLabelValues(nfcRollout.Name, nfcRollout.Namespace).Set(timeElapsed.Seconds())
 }
 
 // return:

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -207,7 +207,7 @@ var (
 		Name:        "numaflow_isbservice_paused_seconds",
 		Help:        "Duration an ISBService paused resources for",
 		ConstLabels: defaultLabels,
-	}, []string{LabelName})
+	}, []string{LabelName, LabelNamespace})
 
 	// monoVertexRolloutsRunning is the gauge for the number of MonoVertexRollouts.
 	monoVertexRolloutsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -256,7 +256,7 @@ var (
 		Name:        "numaflow_controller_rollout_paused_seconds",
 		Help:        "Duration a NumaflowControllerRollout paused pipelines for",
 		ConstLabels: defaultLabels,
-	}, []string{LabelName})
+	}, []string{LabelName, LabelNamespace})
 
 	// numaflowControllerSyncErrors is the total number of NumaflowController reconciliation errors
 	numaflowControllerSyncErrors = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

Updates ISBService paused and NumaflowController paused metrics to include the `namespace` label. 

Recently we have updated our Wavefront charts for Pipeline paused and pausing charts to include this label and we are adding it here to include the same level of information for all resources.

### Verification

Tested metrics locally by updating a numaflow controller.

### Backward incompatibilities

None.
