### PR TITLE
feat: Use controller definition configmap from user namespace

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -101,6 +101,9 @@ const (
 
 	// AnnotationKeyNumaflowInstanceID is the annotation passed to Numaflow Controller so it knows whether it should reconcile the resource
 	AnnotationKeyNumaflowInstanceID = "numaflow.numaproj.io/instance"
+
+	// NumaplaneSystemNamespace is the namespace where the Numaplane Controller is deployed
+	NumaplaneSystemNamespace = "numaplane-system"
 )
 
 var (

--- a/internal/controller/ginkgo_suite_test.go
+++ b/internal/controller/ginkgo_suite_test.go
@@ -158,7 +158,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	definitions, err := ctlrcommon.GetNumaflowControllerDefinitions("../../tests/config/controller-definitions-config.yaml")
 	Expect(err).ToNot(HaveOccurred())
-	config.GetConfigManagerInstance().GetControllerDefinitionsMgr().UpdateNumaflowControllerDefinitionConfig(*definitions)
+	config.GetConfigManagerInstance().GetControllerDefinitionsMgr().UpdateNumaflowControllerDefinitionConfig(*definitions, "")
 
 	go func() {
 		defer GinkgoRecover()

--- a/internal/controller/ginkgo_suite_test.go
+++ b/internal/controller/ginkgo_suite_test.go
@@ -18,15 +18,15 @@ package controller
 
 import (
 	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaplane/internal/common"
 	ctlrcommon "github.com/numaproj/numaplane/internal/controller/common"
 	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/controller/isbservicerollout"
@@ -158,7 +159,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	definitions, err := ctlrcommon.GetNumaflowControllerDefinitions("../../tests/config/controller-definitions-config.yaml")
 	Expect(err).ToNot(HaveOccurred())
-	config.GetConfigManagerInstance().GetControllerDefinitionsMgr().UpdateNumaflowControllerDefinitionConfig(*definitions, "")
+	config.GetConfigManagerInstance().GetControllerDefinitionsMgr().UpdateNumaflowControllerDefinitionConfig(*definitions, common.NumaplaneSystemNamespace)
 
 	go func() {
 		defer GinkgoRecover()

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -414,12 +414,9 @@ func determineTargetObjects(
 	version string,
 	namespace string,
 ) ([]*unstructured.Unstructured, error) {
-
-	// Get the target manifests based on the given version and throw an error if the definition does not have that version
-	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetNumaflowControllerDefinitionsConfig()
-	manifest, manifestExists := definition[version]
-	if !manifestExists {
-		return nil, fmt.Errorf("no controller definition found for version %s", version)
+	manifest, err := getNumaflowControllerDefinition(namespace, version)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get controller definition: %w", err)
 	}
 
 	// Update templated manifest with information from the NumaflowController definition
@@ -448,6 +445,22 @@ func determineTargetObjects(
 	}
 
 	return targetObjs, nil
+}
+
+// getNumaflowControllerDefinition looks up the controller definition from user namespace, if not found then use from global namespace.
+func getNumaflowControllerDefinition(namespace, version string) (string, error) {
+	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetNumaflowControllerDefinitionsConfig()
+	key := fmt.Sprintf("%s/%s", namespace, version)
+	manifest, manifestExists := definition[key]
+	if !manifestExists {
+		key = fmt.Sprintf("%s/%s", common.NumaplaneSystemNamespace, version)
+		manifest, manifestExists = definition[key]
+		if !manifestExists {
+			return "", fmt.Errorf("no controller definition found for version %s", version)
+		}
+	}
+
+	return manifest, nil
 }
 
 func (r *NumaflowControllerReconciler) sync(

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -414,7 +414,7 @@ func determineTargetObjects(
 	version string,
 	namespace string,
 ) ([]*unstructured.Unstructured, error) {
-	manifest, err := getNumaflowControllerDefinition(namespace, version)
+	manifest, err := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetNumaflowControllerDefinitionsConfig(namespace, version)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get controller definition: %w", err)
 	}
@@ -445,22 +445,6 @@ func determineTargetObjects(
 	}
 
 	return targetObjs, nil
-}
-
-// getNumaflowControllerDefinition looks up the controller definition from user namespace, if not found then use from global namespace.
-func getNumaflowControllerDefinition(namespace, version string) (string, error) {
-	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetNumaflowControllerDefinitionsConfig()
-	key := fmt.Sprintf("%s/%s", namespace, version)
-	manifest, manifestExists := definition[key]
-	if !manifestExists {
-		key = fmt.Sprintf("%s/%s", common.NumaplaneSystemNamespace, version)
-		manifest, manifestExists = definition[key]
-		if !manifestExists {
-			return "", fmt.Errorf("no controller definition found for version %s", version)
-		}
-	}
-
-	return manifest, nil
 }
 
 func (r *NumaflowControllerReconciler) sync(

--- a/internal/util/kubernetes/config_watcher.go
+++ b/internal/util/kubernetes/config_watcher.go
@@ -67,12 +67,7 @@ func watchConfigMaps(ctx context.Context, client kubernetes.Interface, numaplane
 		switch labelVal {
 
 		case common.LabelValueNumaflowControllerDefinitions:
-
-			// Only handle this kind of ConfigMap if it is in the Numaplane namespace
-			if configMap.Namespace != numaplaneNamespace {
-				break
-			}
-
+			// Handle all namespace configmaps
 			handleNumaflowControllerDefinitionsConfigMapEvent(ctx, configMap, event)
 
 		case common.LabelValueUSDEConfig:
@@ -115,9 +110,9 @@ func handleNumaflowControllerDefinitionsConfigMapEvent(ctx context.Context, conf
 
 		// controller config definition is immutable, so no need to update the existing config
 		if event.Type == watch.Added {
-			config.GetConfigManagerInstance().GetControllerDefinitionsMgr().UpdateNumaflowControllerDefinitionConfig(controllerConfig)
+			config.GetConfigManagerInstance().GetControllerDefinitionsMgr().UpdateNumaflowControllerDefinitionConfig(controllerConfig, configMap.Namespace)
 		} else if event.Type == watch.Deleted {
-			config.GetConfigManagerInstance().GetControllerDefinitionsMgr().RemoveNumaflowControllerDefinitionConfig(controllerConfig)
+			config.GetConfigManagerInstance().GetControllerDefinitionsMgr().RemoveNumaflowControllerDefinitionConfig(controllerConfig, configMap.Namespace)
 		}
 	}
 }

--- a/internal/util/kubernetes/config_watcher_test.go
+++ b/internal/util/kubernetes/config_watcher_test.go
@@ -51,8 +51,12 @@ func Test_watchConfigMaps(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// Validate the controller definition config is set correctly
-	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetNumaflowControllerDefinitionsConfig()
+	definition := config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetRolloutConfig()
 	assert.Len(t, definition, 2)
+
+	// validate namespace based controller definition config
+	_, exists := definition["default/1.2.0"]
+	assert.True(t, exists)
 
 	// Delete the ConfigMap object from the fake clientset
 	err = clientSet.CoreV1().ConfigMaps("default").Delete(ctx, configMap.Name, metav1.DeleteOptions{})
@@ -62,7 +66,7 @@ func Test_watchConfigMaps(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// Validate the controller definition config has been removed
-	definition = config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetNumaflowControllerDefinitionsConfig()
+	definition = config.GetConfigManagerInstance().GetControllerDefinitionsMgr().GetRolloutConfig()
 	assert.Len(t, definition, 0)
 
 	// === USDE Config Test =====================================


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/429

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

- Update `rolloutConfig` map for storing [namespace/version] as key with fullSpec as value
- While reading the data from `rolloutConfig` firstly check user specific namespace configmap if not found then use from "numaplane-system" namespace

### Verification

- Verified on local kubernetes cluster by creating configmap in user namesapce

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
