### PR TITLE
fix: if Progressive is set, do Apply strategy for Numaflow Controller updates 

### DIFF
--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -343,8 +343,11 @@ func (r *NumaflowControllerRolloutReconciler) processExistingNumaflowController(
 			r.inProgressStrategyMgr.SetStrategy(ctx, nfcRollout, inProgressStrategy)
 		}
 		if upgradeStrategyType == apiv1.UpgradeStrategyProgressive {
-			inProgressStrategy = apiv1.UpgradeStrategyProgressive
-			r.inProgressStrategyMgr.SetStrategy(ctx, nfcRollout, inProgressStrategy)
+			// TODO: Progressive strategy
+			// for now, we just do "Apply" strategy
+			upgradeStrategyType = apiv1.UpgradeStrategyApply
+			//inProgressStrategy = apiv1.UpgradeStrategyProgressive
+			//r.inProgressStrategyMgr.SetStrategy(ctx, nfcRollout, inProgressStrategy)
 		}
 		if upgradeStrategyType == apiv1.UpgradeStrategyApply {
 			inProgressStrategy = apiv1.UpgradeStrategyApply
@@ -372,9 +375,7 @@ func (r *NumaflowControllerRolloutReconciler) processExistingNumaflowController(
 			// requeue if done with PPND is false
 			return true, nil
 		}
-	// TODO: Progressive strategy should ideally be creating a second parallel NumaflowController, and all Pipelines should be on it;
-	// for now we just create a 2nd NumaflowControllerRollout, so we need the Apply path to work
-	case apiv1.UpgradeStrategyApply, apiv1.UpgradeStrategyProgressive:
+	case apiv1.UpgradeStrategyApply:
 		// update NumaflowController
 		err = r.updateNumaflowController(ctx, nfcRollout, newNumaflowControllerDef)
 		if err != nil {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

The problem: When updating NumaflowControllerRollout, if Progressive strategy is set as preferred, we are doing Apply strategy, but we are still setting the `UpgradeInProgress` field to "Progressive" in the `NumaflowControllerRollout` and we are leaving it set there. This changes it so we don't set that at all.


### Verification

Updated NumaflowControllerRollout. This applied the Numaflow Controller and did not set the `UpgradeInProgress` field.

### Backward incompatibilities

none
