### PR TITLE
chore: move ChildNeedsUpdating() function since it's not just related to Progressive logic

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -771,3 +771,18 @@ func (r *ISBServiceRolloutReconciler) merge(existingISBService, newISBService *u
 	resultISBService.SetLabels(util.MergeMaps(existingISBService.GetLabels(), newISBService.GetLabels()))
 	return resultISBService
 }
+
+// ChildNeedsUpdating determines if the difference between the current child definition and the desired child definition requires an update
+func (r *ISBServiceRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
+	numaLogger := logger.FromContext(ctx)
+
+	specsEqual := util.CompareStructNumTypeAgnostic(from.Object["spec"], to.Object["spec"])
+	numaLogger.Debugf("specsEqual: %t, from=%v, to=%v\n",
+		specsEqual, from, to)
+	labelsEqual := util.CompareMaps(from.GetLabels(), to.GetLabels())
+	numaLogger.Debugf("labelsEqual: %t, from Labels=%v, to Labels=%v", labelsEqual, from.GetLabels(), to.GetLabels())
+	annotationsEqual := util.CompareMaps(from.GetAnnotations(), to.GetAnnotations())
+	numaLogger.Debugf("annotationsEqual: %t, from Annotations=%v, to Annotations=%v", annotationsEqual, from.GetAnnotations(), to.GetAnnotations())
+
+	return !specsEqual || !labelsEqual || !annotationsEqual, nil
+}

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -12,7 +12,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 )
 
@@ -92,21 +91,6 @@ func (r *ISBServiceRolloutReconciler) Recycle(ctx context.Context, isbsvc *unstr
 		return false, err
 	}
 	return true, nil
-}
-
-// ChildNeedsUpdating determines if the difference between the current child definition and the desired child definition requires an update
-func (r *ISBServiceRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
-	numaLogger := logger.FromContext(ctx)
-
-	specsEqual := util.CompareStructNumTypeAgnostic(from.Object["spec"], to.Object["spec"])
-	numaLogger.Debugf("specsEqual: %t, from=%v, to=%v\n",
-		specsEqual, from, to)
-	labelsEqual := util.CompareMaps(from.GetLabels(), to.GetLabels())
-	numaLogger.Debugf("labelsEqual: %t, from Labels=%v, to Labels=%v", labelsEqual, from.GetLabels(), to.GetLabels())
-	annotationsEqual := util.CompareMaps(from.GetAnnotations(), to.GetAnnotations())
-	numaLogger.Debugf("annotationsEqual: %t, from Annotations=%v, to Annotations=%v", annotationsEqual, from.GetAnnotations(), to.GetAnnotations())
-
-	return !specsEqual || !labelsEqual || !annotationsEqual, nil
 }
 
 func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error) {

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -43,6 +43,7 @@ import (
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaplane/internal/common"
 	ctlrcommon "github.com/numaproj/numaplane/internal/controller/common"
+	"github.com/numaproj/numaplane/internal/controller/common/numaflowtypes"
 	"github.com/numaproj/numaplane/internal/controller/progressive"
 	"github.com/numaproj/numaplane/internal/usde"
 	"github.com/numaproj/numaplane/internal/util"
@@ -550,5 +551,30 @@ func getBaseMonoVertexMetadata(monoVertexRollout *apiv1.MonoVertexRollout) (apiv
 	labelMapping[common.LabelKeyParentRollout] = monoVertexRollout.Name
 
 	return apiv1.Metadata{Labels: labelMapping, Annotations: monoVertexRollout.Spec.MonoVertex.Annotations}, nil
+
+}
+
+// ChildNeedsUpdating() tests for essential equality, with any irrelevant fields eliminated from the comparison
+func (r *MonoVertexRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
+	numaLogger := logger.FromContext(ctx)
+	// remove "replicas" field from comparison to test for equality
+	fromNew, err := numaflowtypes.MonoVertexWithoutReplicas(from)
+	if err != nil {
+		return false, err
+	}
+	toNew, err := numaflowtypes.MonoVertexWithoutReplicas(to)
+	if err != nil {
+		return false, err
+	}
+
+	specsEqual := util.CompareStructNumTypeAgnostic(fromNew, toNew)
+	numaLogger.Debugf("specsEqual: %t, fromNew=%v, toNew=%v\n",
+		specsEqual, fromNew, toNew)
+	labelsEqual := util.CompareMaps(from.GetLabels(), to.GetLabels())
+	numaLogger.Debugf("labelsEqual: %t, from Labels=%v, to Labels=%v", labelsEqual, from.GetLabels(), to.GetLabels())
+	annotationsEqual := util.CompareMaps(from.GetAnnotations(), to.GetAnnotations())
+	numaLogger.Debugf("annotationsEqual: %t, from Annotations=%v, to Annotations=%v", annotationsEqual, from.GetAnnotations(), to.GetAnnotations())
+
+	return !specsEqual || !labelsEqual || !annotationsEqual, nil
 
 }

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/numaproj/numaplane/internal/common"
 	ctlrcommon "github.com/numaproj/numaplane/internal/controller/common"
-	"github.com/numaproj/numaplane/internal/controller/common/numaflowtypes"
-	"github.com/numaproj/numaplane/internal/util"
 )
 
 // Implemented functions for the progressiveController interface:
@@ -80,31 +78,6 @@ func (r *MonoVertexRolloutReconciler) Recycle(ctx context.Context,
 		return false, err
 	}
 	return true, nil
-}
-
-// ChildNeedsUpdating() tests for essential equality, with any irrelevant fields eliminated from the comparison
-func (r *MonoVertexRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
-	numaLogger := logger.FromContext(ctx)
-	// remove "replicas" field from comparison to test for equality
-	fromNew, err := numaflowtypes.MonoVertexWithoutReplicas(from)
-	if err != nil {
-		return false, err
-	}
-	toNew, err := numaflowtypes.MonoVertexWithoutReplicas(to)
-	if err != nil {
-		return false, err
-	}
-
-	specsEqual := util.CompareStructNumTypeAgnostic(fromNew, toNew)
-	numaLogger.Debugf("specsEqual: %t, fromNew=%v, toNew=%v\n",
-		specsEqual, fromNew, toNew)
-	labelsEqual := util.CompareMaps(from.GetLabels(), to.GetLabels())
-	numaLogger.Debugf("labelsEqual: %t, from Labels=%v, to Labels=%v", labelsEqual, from.GetLabels(), to.GetLabels())
-	annotationsEqual := util.CompareMaps(from.GetAnnotations(), to.GetAnnotations())
-	numaLogger.Debugf("annotationsEqual: %t, from Annotations=%v, to Annotations=%v", annotationsEqual, from.GetAnnotations(), to.GetAnnotations())
-
-	return !specsEqual || !labelsEqual || !annotationsEqual, nil
-
 }
 
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -15,7 +15,6 @@ import (
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	ctlrcommon "github.com/numaproj/numaplane/internal/controller/common"
 	"github.com/numaproj/numaplane/internal/controller/common/numaflowtypes"
-	"github.com/numaproj/numaplane/internal/util"
 )
 
 // Implemented functions for the progressiveController interface:
@@ -121,26 +120,6 @@ func (r *PipelineRolloutReconciler) Recycle(ctx context.Context,
 	}
 	return false, nil
 
-}
-
-// ChildNeedsUpdating() tests for essential equality, with any irrelevant fields eliminated from the comparison
-func (r *PipelineRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
-	numaLogger := logger.FromContext(ctx)
-	fromCopy := from.DeepCopy()
-	toCopy := to.DeepCopy()
-	// remove lifecycle.desiredPhase field from comparison to test for equality
-	numaflowtypes.PipelineWithoutDesiredPhase(fromCopy)
-	numaflowtypes.PipelineWithoutDesiredPhase(toCopy)
-
-	specsEqual := util.CompareStructNumTypeAgnostic(fromCopy.Object["spec"], toCopy.Object["spec"])
-	numaLogger.Debugf("specsEqual: %t, from=%v, to=%v\n",
-		specsEqual, fromCopy.Object["spec"], toCopy.Object["spec"])
-	labelsEqual := util.CompareMaps(from.GetLabels(), to.GetLabels())
-	numaLogger.Debugf("labelsEqual: %t, from Labels=%v, to Labels=%v", labelsEqual, from.GetLabels(), to.GetLabels())
-	annotationsEqual := util.CompareMaps(from.GetAnnotations(), to.GetAnnotations())
-	numaLogger.Debugf("annotationsEqual: %t, from Annotations=%v, to Annotations=%v", annotationsEqual, from.GetAnnotations(), to.GetAnnotations())
-
-	return !specsEqual || !labelsEqual || !annotationsEqual, nil
 }
 
 // get the isbsvc child of ISBServiceRollout with the given upgrading state label


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

Just moving the `ChildNeedsUpdating()` function out of the .go files for progressive (for each Reconciler), because the function is not only used by the progressive code.


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
