### PR TITLE
chore: introduce new RolloutController interface

### DIFF
--- a/internal/controller/common/rollout_controller.go
+++ b/internal/controller/common/rollout_controller.go
@@ -1,0 +1,201 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/numaproj/numaplane/internal/common"
+	"github.com/numaproj/numaplane/internal/util/kubernetes"
+	"github.com/numaproj/numaplane/internal/util/logger"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type RolloutController interface {
+
+	// IncrementChildCount updates the count of children for the Resource in Kubernetes and returns the index that should be used for the next child
+	IncrementChildCount(ctx context.Context, rolloutObject RolloutObject) (int32, error)
+
+	// Recycle deletes child; returns true if it was in fact deleted
+	Recycle(ctx context.Context, childObject *unstructured.Unstructured, c client.Client) (bool, error)
+}
+
+// Garbage Collect all recyclable children; return true if we've deleted all that are recyclable
+func GarbageCollectChildren(
+	ctx context.Context,
+	rolloutObject RolloutObject,
+	controller RolloutController,
+	c client.Client,
+) (bool, error) {
+	numaLogger := logger.FromContext(ctx)
+	recyclableObjects, err := getRecyclableObjects(ctx, rolloutObject, c)
+	if err != nil {
+		return false, err
+	}
+
+	numaLogger.WithValues("recylableObjects", recyclableObjects).Debug("recycling")
+
+	allDeleted := true
+	for _, recyclableChild := range recyclableObjects.Items {
+		deleted, err := controller.Recycle(ctx, &recyclableChild, c)
+		if err != nil {
+			return false, err
+		}
+		if !deleted {
+			allDeleted = false
+		}
+	}
+	return allDeleted, nil
+}
+func getRecyclableObjects(
+	ctx context.Context,
+	rolloutObject RolloutObject,
+	c client.Client,
+) (*unstructured.UnstructuredList, error) {
+	return kubernetes.ListResources(ctx, c, rolloutObject.GetChildGVK(),
+		rolloutObject.GetRolloutObjectMeta().Namespace,
+		client.MatchingLabels{
+			common.LabelKeyParentRollout: rolloutObject.GetRolloutObjectMeta().Name,
+			common.LabelKeyUpgradeState:  string(common.LabelValueUpgradeRecyclable),
+		},
+	)
+}
+
+func findChildrenOfUpgradeState(ctx context.Context, rolloutObject RolloutObject, upgradeState common.UpgradeState, checkLive bool, c client.Client) (*unstructured.UnstructuredList, error) {
+	childGVR := rolloutObject.GetChildGVR()
+
+	labelSelector := fmt.Sprintf(
+		"%s=%s,%s=%s", common.LabelKeyParentRollout, rolloutObject.GetRolloutObjectMeta().Name,
+		common.LabelKeyUpgradeState, string(upgradeState))
+
+	var children *unstructured.UnstructuredList
+	var err error
+	if checkLive {
+		children, err = kubernetes.ListLiveResource(
+			ctx, childGVR.Group, childGVR.Version, childGVR.Resource,
+			rolloutObject.GetRolloutObjectMeta().Namespace, labelSelector, "")
+	} else {
+		children, err = kubernetes.ListResources(ctx, c, rolloutObject.GetChildGVK(), rolloutObject.GetRolloutObjectMeta().GetNamespace(),
+			client.MatchingLabels{
+				common.LabelKeyParentRollout: rolloutObject.GetRolloutObjectMeta().Name,
+				common.LabelKeyUpgradeState:  string(upgradeState),
+			},
+		)
+	}
+
+	return children, err
+}
+
+// find the most current child of a Rollout
+// typically we should only find one, but perhaps a previous reconciliation failure could cause us to find multiple
+// if we do see older ones, recycle them
+func FindMostCurrentChildOfUpgradeState(ctx context.Context, rolloutObject RolloutObject, upgradeState common.UpgradeState, checkLive bool, c client.Client) (*unstructured.Unstructured, error) {
+	numaLogger := logger.FromContext(ctx)
+
+	children, err := findChildrenOfUpgradeState(ctx, rolloutObject, upgradeState, checkLive, c)
+	if err != nil {
+		return nil, err
+	}
+
+	numaLogger.Debugf("looking for children of Rollout %s/%s of upgrade state=%v, found: %s",
+		rolloutObject.GetRolloutObjectMeta().Namespace, rolloutObject.GetRolloutObjectMeta().Name, upgradeState, kubernetes.ExtractResourceNames(children))
+
+	if len(children.Items) > 1 {
+		var mostCurrentChild *unstructured.Unstructured
+		recycleList := []*unstructured.Unstructured{}
+		mostCurrentIndex := math.MinInt
+		for _, child := range children.Items {
+			childIndex, err := getChildIndex(rolloutObject.GetRolloutObjectMeta().Name, child.GetName())
+			if err != nil {
+				// something is improperly named for some reason - don't touch it just in case?
+				numaLogger.Warn(err.Error())
+				continue
+			}
+			if mostCurrentChild == nil { // first one in the list
+				mostCurrentChild = &child
+				mostCurrentIndex = childIndex
+			} else if childIndex > mostCurrentIndex { // most current for now
+				recycleList = append(recycleList, mostCurrentChild) // recycle the previous one
+				mostCurrentChild = &child
+				mostCurrentIndex = childIndex
+			} else {
+				recycleList = append(recycleList, &child)
+			}
+		}
+		// recycle the previous children
+		for _, recyclableChild := range recycleList {
+			numaLogger.Debugf("found multiple children of Rollout %s/%s of upgrade state=%q, marking recyclable: %s",
+				rolloutObject.GetRolloutObjectMeta().Namespace, rolloutObject.GetRolloutObjectMeta().Name, upgradeState, recyclableChild.GetName())
+			_ = UpdateUpgradeState(ctx, c, common.LabelValueUpgradeRecyclable, recyclableChild)
+		}
+		return mostCurrentChild, nil
+	} else if len(children.Items) == 1 {
+		return &children.Items[0], nil
+	} else {
+		return nil, nil
+	}
+}
+
+// update the in-memory object with the new Label and patch the object in K8S
+func UpdateUpgradeState(ctx context.Context, c client.Client, upgradeState common.UpgradeState, childObject *unstructured.Unstructured) error {
+	labels := childObject.GetLabels()
+	labels[common.LabelKeyUpgradeState] = string(upgradeState)
+	childObject.SetLabels(labels)
+	patchJson := `{"metadata":{"labels":{"` + common.LabelKeyUpgradeState + `":"` + string(upgradeState) + `"}}}`
+	return kubernetes.PatchResource(ctx, c, childObject, patchJson, k8stypes.MergePatchType)
+}
+
+// Get the index of the child following the dash in the name
+// childName should be the rolloutName + '-<integer>'
+// For backward compatibility, support child resources whose names were equivalent to rollout names, returning -1 index
+func getChildIndex(rolloutName string, childName string) (int, error) {
+	// verify that the initial part of the child name is the rolloutName
+	if !strings.HasPrefix(childName, rolloutName) {
+		return 0, fmt.Errorf("child name %q should begin with rollout name %q", childName, rolloutName)
+	}
+	// backward compatibility for older naming convention (before the '-<integer>' suffix was introduced - if it's the same name, consider it to essentially be the smallest index
+	if childName == rolloutName {
+		return -1, nil
+	}
+
+	// next character should be a dash
+	dash := childName[len(rolloutName)]
+	if dash != '-' {
+		return 0, fmt.Errorf("child name %q should begin with rollout name %q, followed by '-<integer>'", childName, rolloutName)
+	}
+
+	// remaining characters should be the integer index
+	suffix := childName[len(rolloutName)+1:]
+
+	childIndex, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0, fmt.Errorf("child name %q has a suffix which is not an integer", childName)
+	}
+	return childIndex, nil
+}
+
+// get the name of the child whose parent is "rolloutObject" and whose upgrade state is "upgradeState"
+// if none is found, create a new one
+// if one is found, create a new one if "useExistingChild=false", else use existing one
+func GetChildName(ctx context.Context, rolloutObject RolloutObject, controller RolloutController, upgradeState common.UpgradeState, c client.Client, useExistingChild bool) (string, error) {
+
+	existingChild, err := FindMostCurrentChildOfUpgradeState(ctx, rolloutObject, upgradeState, true, c) // if for some reason there's more than 1
+	if err != nil {
+		return "", err
+	}
+	// if existing child doesn't exist or if it does but we don't want to use it, then create a new one
+	if existingChild == nil || (existingChild != nil && !useExistingChild) {
+		index, err := controller.IncrementChildCount(ctx, rolloutObject)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s-%d", rolloutObject.GetRolloutObjectMeta().Name, index), nil
+	} else {
+		return existingChild.GetName(), nil
+	}
+}

--- a/internal/controller/common/rollout_controller_test.go
+++ b/internal/controller/common/rollout_controller_test.go
@@ -1,0 +1,164 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+	"github.com/numaproj/numaplane/internal/common"
+	"github.com/numaproj/numaplane/internal/util/kubernetes"
+	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
+	commontest "github.com/numaproj/numaplane/tests/common"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// This tests the FindMostCurrentChildOfUpgradeState() function
+// This function both finds the most current child of the upgrade-state, but also recycles any others that are found
+// So, it should only be called if there in fact should be only one child of that upgrade-state in existence
+func TestFindMostCurrentChildOfUpgradeState(t *testing.T) {
+
+	restConfig, numaflowClientSet, client, _, err := commontest.PrepareK8SEnvironment()
+	assert.Nil(t, err)
+	assert.Nil(t, kubernetes.SetClientSets(restConfig))
+
+	ctx := context.TODO()
+	pipelineRollout := &apiv1.PipelineRollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pipeline",
+			Namespace: DefaultTestNamespace,
+		},
+	}
+	checkLive := false
+
+	tests := []struct {
+		name          string
+		pipelines     []*numaflowv1.Pipeline
+		expectedName  string
+		expectedError error
+	}{
+		{
+			name: "Multiple children with valid indices",
+			pipelines: []*numaflowv1.Pipeline{
+				createPipeline("my-pipeline-1", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
+				createPipeline("my-pipeline-2", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
+				createPipeline("my-pipeline-3", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
+			},
+
+			expectedName:  "my-pipeline-3",
+			expectedError: nil,
+		},
+		{
+			name:          "No children",
+			pipelines:     []*numaflowv1.Pipeline{},
+			expectedName:  "",
+			expectedError: nil,
+		},
+		{
+			name: "Backward compatibility with older code",
+			pipelines: []*numaflowv1.Pipeline{
+				createPipeline("my-pipeline-1", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
+				createPipeline("my-pipeline-2", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
+				createPipeline("my-pipeline-3", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
+				createPipeline("my-pipeline", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
+			},
+
+			expectedName:  "my-pipeline-3",
+			expectedError: nil,
+		},
+		{
+			name: "Backward compatibility with older code, and just one pipeline exists",
+			pipelines: []*numaflowv1.Pipeline{
+				createPipeline("my-pipeline", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
+			},
+
+			expectedName:  "my-pipeline",
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Clean up any pipelines on the namespace beforehand
+			_ = numaflowClientSet.NumaflowV1alpha1().Pipelines(DefaultTestNamespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
+			pipelineList, err := numaflowClientSet.NumaflowV1alpha1().Pipelines(DefaultTestNamespace).List(ctx, metav1.ListOptions{})
+			assert.NoError(t, err)
+			assert.Len(t, pipelineList.Items, 0)
+
+			// Create the Pipelines in Kubernetes
+			for _, pipeline := range tt.pipelines {
+				_, err := numaflowClientSet.NumaflowV1alpha1().Pipelines(DefaultTestNamespace).Create(ctx, pipeline, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			mostCurrentChild, err := FindMostCurrentChildOfUpgradeState(ctx, pipelineRollout, common.LabelValueUpgradePromoted, checkLive, client)
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Nil(t, mostCurrentChild)
+			} else {
+				assert.NoError(t, err)
+				if tt.expectedName == "" {
+					assert.Nil(t, mostCurrentChild)
+				} else {
+					// verify the most current child is correct
+					assert.NotNil(t, mostCurrentChild)
+					assert.Equal(t, tt.expectedName, mostCurrentChild.GetName())
+
+					// verify all other children have been marked "recyclable"
+					for _, p := range tt.pipelines {
+						retrievedPipeline, err := numaflowClientSet.NumaflowV1alpha1().Pipelines(DefaultTestNamespace).Get(ctx, p.Name, metav1.GetOptions{})
+						assert.NoError(t, err)
+
+						retrievedUpgradeState, found := retrievedPipeline.GetLabels()[common.LabelKeyUpgradeState]
+						assert.True(t, found)
+						if p.Name == tt.expectedName {
+							assert.Equal(t, string(common.LabelValueUpgradePromoted), retrievedUpgradeState)
+						} else {
+							assert.Equal(t, string(common.LabelValueUpgradeRecyclable), retrievedUpgradeState)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+var (
+	defaultISBSVCRolloutName = "my-isbsvc"
+	pipelineSpec             = numaflowv1.PipelineSpec{
+		InterStepBufferServiceName: defaultISBSVCRolloutName + "-0",
+		Vertices: []numaflowv1.AbstractVertex{
+			{
+				Name: "in",
+				Source: &numaflowv1.Source{
+					Generator: &numaflowv1.GeneratorSource{},
+				},
+			},
+			{
+				Name: "out",
+				Sink: &numaflowv1.Sink{
+					AbstractSink: numaflowv1.AbstractSink{
+						Log: &numaflowv1.Log{},
+					},
+				},
+			},
+		},
+		Edges: []numaflowv1.Edge{
+			{
+				From: "in",
+				To:   "out",
+			},
+		},
+	}
+)
+
+func createPipeline(pipelineName string, pipelineRolloutName string, isbsvcRolloutName string, upgradeState common.UpgradeState) *numaflowv1.Pipeline {
+	return CreateTestPipelineOfSpec(pipelineSpec, pipelineName, numaflowv1.PipelinePhaseRunning, numaflowv1.Status{}, false,
+		map[string]string{
+			common.LabelKeyParentRollout:               pipelineRolloutName,
+			common.LabelKeyISBServiceRONameForPipeline: isbsvcRolloutName,
+			common.LabelKeyUpgradeState:                string(upgradeState),
+		},
+		map[string]string{})
+}

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -407,7 +407,7 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 		return 0, fmt.Errorf("%v strategy not recognized", inProgressStrategy)
 	}
 	// clean up recyclable interstepbufferservices
-	allDeleted, err := progressive.GarbageCollectChildren(ctx, isbServiceRollout, r, r.client)
+	allDeleted, err := ctlrcommon.GarbageCollectChildren(ctx, isbServiceRollout, r, r.client)
 	if err != nil {
 		return 0, fmt.Errorf("error deleting recyclable interstepbufferservices: %s", err.Error())
 	}
@@ -717,7 +717,7 @@ func (r *ISBServiceRolloutReconciler) makePromotedISBServiceDef(
 	isbServiceRollout *apiv1.ISBServiceRollout,
 ) (*unstructured.Unstructured, error) {
 	// if a "promoted" InterstepBufferService exists, gets its name; otherwise create a new name
-	isbsvcName, err := progressive.GetChildName(ctx, isbServiceRollout, r, common.LabelValueUpgradePromoted, r.client, true)
+	isbsvcName, err := ctlrcommon.GetChildName(ctx, isbServiceRollout, r, common.LabelValueUpgradePromoted, r.client, true)
 	if err != nil {
 		return nil, err
 	}
@@ -777,6 +777,7 @@ func (r *ISBServiceRolloutReconciler) merge(existingISBService, newISBService *u
 }
 
 // ChildNeedsUpdating determines if the difference between the current child definition and the desired child definition requires an update
+// This implements a function of the progressiveController interface
 func (r *ISBServiceRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
 
@@ -789,4 +790,63 @@ func (r *ISBServiceRolloutReconciler) ChildNeedsUpdating(ctx context.Context, fr
 	numaLogger.Debugf("annotationsEqual: %t, from Annotations=%v, to Annotations=%v", annotationsEqual, from.GetAnnotations(), to.GetAnnotations())
 
 	return !specsEqual || !labelsEqual || !annotationsEqual, nil
+}
+
+func (r *ISBServiceRolloutReconciler) getCurrentChildCount(rolloutObject ctlrcommon.RolloutObject) (int32, bool) {
+	isbsvcRollout := rolloutObject.(*apiv1.ISBServiceRollout)
+	if isbsvcRollout.Status.NameCount == nil {
+		return int32(0), false
+	} else {
+		return *isbsvcRollout.Status.NameCount, true
+	}
+}
+
+func (r *ISBServiceRolloutReconciler) updateCurrentChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, nameCount int32) error {
+	isbsvcRollout := rolloutObject.(*apiv1.ISBServiceRollout)
+	isbsvcRollout.Status.NameCount = &nameCount
+	return r.updateISBServiceRolloutStatus(ctx, isbsvcRollout)
+}
+
+// IncrementChildCount updates the count of children for the Resource in Kubernetes and returns the index that should be used for the next child
+// This implements a function of the progressiveController interface
+func (r *ISBServiceRolloutReconciler) IncrementChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject) (int32, error) {
+	currentNameCount, found := r.getCurrentChildCount(rolloutObject)
+	if !found {
+		currentNameCount = int32(0)
+		err := r.updateCurrentChildCount(ctx, rolloutObject, int32(0))
+		if err != nil {
+			return int32(0), err
+		}
+	}
+
+	err := r.updateCurrentChildCount(ctx, rolloutObject, currentNameCount+1)
+	if err != nil {
+		return int32(0), err
+	}
+	return currentNameCount, nil
+}
+
+// Recycle deletes child; returns true if it was in fact deleted
+// This implements a function of the progressiveController interface
+func (r *ISBServiceRolloutReconciler) Recycle(ctx context.Context, isbsvc *unstructured.Unstructured, c client.Client) (bool, error) {
+	numaLogger := logger.FromContext(ctx).WithValues("isbsvc", fmt.Sprintf("%s/%s", isbsvc.GetNamespace(), isbsvc.GetName()))
+
+	// For InterstepBufferService, the main thing is that we don't want to delete it until we can be sure there are no
+	// Pipelines using it
+
+	pipelines, err := r.getPipelineListForChildISBSvc(ctx, isbsvc.GetNamespace(), isbsvc.GetName())
+	if err != nil {
+		return false, fmt.Errorf("can't recycle isbsvc %s/%s; got error retrieving pipelines using it: %s", isbsvc.GetNamespace(), isbsvc.GetName(), err)
+	}
+	if pipelines != nil && len(pipelines.Items) > 0 {
+		numaLogger.Debugf("can't recycle isbsvc; there are still %d pipelines using it", len(pipelines.Items))
+		return false, nil
+	}
+	// okay to delete now
+	numaLogger.Debug("deleting isbsvc")
+	err = kubernetes.DeleteResource(ctx, c, isbsvc)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -808,7 +808,7 @@ func (r *ISBServiceRolloutReconciler) updateCurrentChildCount(ctx context.Contex
 }
 
 // IncrementChildCount updates the count of children for the Resource in Kubernetes and returns the index that should be used for the next child
-// This implements a function of the progressiveController interface
+// This implements a function of the RolloutController interface
 func (r *ISBServiceRolloutReconciler) IncrementChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject) (int32, error) {
 	currentNameCount, found := r.getCurrentChildCount(rolloutObject)
 	if !found {
@@ -827,7 +827,7 @@ func (r *ISBServiceRolloutReconciler) IncrementChildCount(ctx context.Context, r
 }
 
 // Recycle deletes child; returns true if it was in fact deleted
-// This implements a function of the progressiveController interface
+// This implements a function of the RolloutController interface
 func (r *ISBServiceRolloutReconciler) Recycle(ctx context.Context, isbsvc *unstructured.Unstructured, c client.Client) (bool, error) {
 	numaLogger := logger.FromContext(ctx).WithValues("isbsvc", fmt.Sprintf("%s/%s", isbsvc.GetNamespace(), isbsvc.GetName()))
 

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -9,15 +9,10 @@ import (
 	"github.com/numaproj/numaplane/internal/util/logger"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/numaproj/numaplane/internal/util/kubernetes"
 )
 
-// Implemented functions for the progressiveController interface:
-
 // CreateUpgradingChildDefinition creates an InterstepBufferService in an "upgrading" state with the given name
+// This implements a function of the progressiveController interface
 func (r *ISBServiceRolloutReconciler) CreateUpgradingChildDefinition(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, name string) (*unstructured.Unstructured, error) {
 	isbsvcRollout := rolloutObject.(*apiv1.ISBServiceRollout)
 	metadata, err := getBaseISBSVCMetadata(isbsvcRollout)
@@ -36,63 +31,8 @@ func (r *ISBServiceRolloutReconciler) CreateUpgradingChildDefinition(ctx context
 	return isbsvc, nil
 }
 
-func (r *ISBServiceRolloutReconciler) getCurrentChildCount(rolloutObject ctlrcommon.RolloutObject) (int32, bool) {
-	isbsvcRollout := rolloutObject.(*apiv1.ISBServiceRollout)
-	if isbsvcRollout.Status.NameCount == nil {
-		return int32(0), false
-	} else {
-		return *isbsvcRollout.Status.NameCount, true
-	}
-}
-
-func (r *ISBServiceRolloutReconciler) updateCurrentChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, nameCount int32) error {
-	isbsvcRollout := rolloutObject.(*apiv1.ISBServiceRollout)
-	isbsvcRollout.Status.NameCount = &nameCount
-	return r.updateISBServiceRolloutStatus(ctx, isbsvcRollout)
-}
-
-// IncrementChildCount updates the count of children for the Resource in Kubernetes and returns the index that should be used for the next child
-func (r *ISBServiceRolloutReconciler) IncrementChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject) (int32, error) {
-	currentNameCount, found := r.getCurrentChildCount(rolloutObject)
-	if !found {
-		currentNameCount = int32(0)
-		err := r.updateCurrentChildCount(ctx, rolloutObject, int32(0))
-		if err != nil {
-			return int32(0), err
-		}
-	}
-
-	err := r.updateCurrentChildCount(ctx, rolloutObject, currentNameCount+1)
-	if err != nil {
-		return int32(0), err
-	}
-	return currentNameCount, nil
-}
-
-// Recycle deletes child; returns true if it was in fact deleted
-func (r *ISBServiceRolloutReconciler) Recycle(ctx context.Context, isbsvc *unstructured.Unstructured, c client.Client) (bool, error) {
-	numaLogger := logger.FromContext(ctx).WithValues("isbsvc", fmt.Sprintf("%s/%s", isbsvc.GetNamespace(), isbsvc.GetName()))
-
-	// For InterstepBufferService, the main thing is that we don't want to delete it until we can be sure there are no
-	// Pipelines using it
-
-	pipelines, err := r.getPipelineListForChildISBSvc(ctx, isbsvc.GetNamespace(), isbsvc.GetName())
-	if err != nil {
-		return false, fmt.Errorf("can't recycle isbsvc %s/%s; got error retrieving pipelines using it: %s", isbsvc.GetNamespace(), isbsvc.GetName(), err)
-	}
-	if pipelines != nil && len(pipelines.Items) > 0 {
-		numaLogger.Debugf("can't recycle isbsvc; there are still %d pipelines using it", len(pipelines.Items))
-		return false, nil
-	}
-	// okay to delete now
-	numaLogger.Debug("deleting isbsvc")
-	err = kubernetes.DeleteResource(ctx, c, isbsvc)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
+// AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
+// This implements a function of the progressiveController interface
 func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error) {
 	numaLogger := logger.FromContext(ctx).WithValues("upgrading child", fmt.Sprintf("%s/%s", existingUpgradingChildDef.GetNamespace(), existingUpgradingChildDef.GetName()))
 

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -343,7 +343,7 @@ func (r *MonoVertexRolloutReconciler) processExistingMonoVertex(ctx context.Cont
 		}
 	}
 	// clean up recyclable monovertices
-	allDeleted, err := progressive.GarbageCollectChildren(ctx, monoVertexRollout, r, r.client)
+	allDeleted, err := ctlrcommon.GarbageCollectChildren(ctx, monoVertexRollout, r, r.client)
 	if err != nil {
 		return 0, err
 	}
@@ -510,7 +510,7 @@ func (r *MonoVertexRolloutReconciler) makePromotedMonoVertexDefinition(
 	ctx context.Context,
 	monoVertexRollout *apiv1.MonoVertexRollout,
 ) (*unstructured.Unstructured, error) {
-	monoVertexName, err := progressive.GetChildName(ctx, monoVertexRollout, r, common.LabelValueUpgradePromoted, r.client, true)
+	monoVertexName, err := ctlrcommon.GetChildName(ctx, monoVertexRollout, r, common.LabelValueUpgradePromoted, r.client, true)
 	if err != nil {
 		return nil, err
 	}
@@ -558,6 +558,7 @@ func getBaseMonoVertexMetadata(monoVertexRollout *apiv1.MonoVertexRollout) (apiv
 }
 
 // ChildNeedsUpdating() tests for essential equality, with any irrelevant fields eliminated from the comparison
+// This implements a function of the progressiveController interface
 func (r *MonoVertexRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
 	// remove "replicas" field from comparison to test for equality
@@ -580,4 +581,51 @@ func (r *MonoVertexRolloutReconciler) ChildNeedsUpdating(ctx context.Context, fr
 
 	return !specsEqual || !labelsEqual || !annotationsEqual, nil
 
+}
+
+func (r *MonoVertexRolloutReconciler) getCurrentChildCount(rolloutObject ctlrcommon.RolloutObject) (int32, bool) {
+	monoVertexRollout := rolloutObject.(*apiv1.MonoVertexRollout)
+	if monoVertexRollout.Status.NameCount == nil {
+		return int32(0), false
+	} else {
+		return *monoVertexRollout.Status.NameCount, true
+	}
+}
+
+func (r *MonoVertexRolloutReconciler) updateCurrentChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, nameCount int32) error {
+	monoVertexRollout := rolloutObject.(*apiv1.MonoVertexRollout)
+	monoVertexRollout.Status.NameCount = &nameCount
+	return r.updateMonoVertexRolloutStatus(ctx, monoVertexRollout)
+}
+
+// IncrementChildCount increments the child count for the Rollout and returns the count to use
+// This implements a function of the progressiveController interface
+func (r *MonoVertexRolloutReconciler) IncrementChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject) (int32, error) {
+	currentNameCount, found := r.getCurrentChildCount(rolloutObject)
+	if !found {
+		currentNameCount = int32(0)
+		err := r.updateCurrentChildCount(ctx, rolloutObject, int32(0))
+		if err != nil {
+			return int32(0), err
+		}
+	}
+
+	err := r.updateCurrentChildCount(ctx, rolloutObject, currentNameCount+1)
+	if err != nil {
+		return int32(0), err
+	}
+	return currentNameCount, nil
+}
+
+// Recycle deletes child; returns true if it was in fact deleted
+// This implements a function of the progressiveController interface
+func (r *MonoVertexRolloutReconciler) Recycle(ctx context.Context,
+	monoVertexDef *unstructured.Unstructured,
+	c client.Client,
+) (bool, error) {
+	err := kubernetes.DeleteResource(ctx, c, monoVertexDef)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -599,7 +599,7 @@ func (r *MonoVertexRolloutReconciler) updateCurrentChildCount(ctx context.Contex
 }
 
 // IncrementChildCount increments the child count for the Rollout and returns the count to use
-// This implements a function of the progressiveController interface
+// This implements a function of the RolloutController interface
 func (r *MonoVertexRolloutReconciler) IncrementChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject) (int32, error) {
 	currentNameCount, found := r.getCurrentChildCount(rolloutObject)
 	if !found {
@@ -618,7 +618,7 @@ func (r *MonoVertexRolloutReconciler) IncrementChildCount(ctx context.Context, r
 }
 
 // Recycle deletes child; returns true if it was in fact deleted
-// This implements a function of the progressiveController interface
+// This implements a function of the RolloutController interface
 func (r *MonoVertexRolloutReconciler) Recycle(ctx context.Context,
 	monoVertexDef *unstructured.Unstructured,
 	c client.Client,

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -9,14 +9,12 @@ import (
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/numaproj/numaplane/internal/common"
 	ctlrcommon "github.com/numaproj/numaplane/internal/controller/common"
 )
 
-// Implemented functions for the progressiveController interface:
-
+// CreateUpgradingChildDefinition creates a definition for an "upgrading" monovertex
+// This implements a function of the progressiveController interface
 func (r *MonoVertexRolloutReconciler) CreateUpgradingChildDefinition(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, name string) (*unstructured.Unstructured, error) {
 	monoVertexRollout := rolloutObject.(*apiv1.MonoVertexRollout)
 	metadata, err := getBaseMonoVertexMetadata(monoVertexRollout)
@@ -35,56 +33,12 @@ func (r *MonoVertexRolloutReconciler) CreateUpgradingChildDefinition(ctx context
 	return monoVertex, nil
 }
 
-func (r *MonoVertexRolloutReconciler) getCurrentChildCount(rolloutObject ctlrcommon.RolloutObject) (int32, bool) {
-	monoVertexRollout := rolloutObject.(*apiv1.MonoVertexRollout)
-	if monoVertexRollout.Status.NameCount == nil {
-		return int32(0), false
-	} else {
-		return *monoVertexRollout.Status.NameCount, true
-	}
-}
-
-func (r *MonoVertexRolloutReconciler) updateCurrentChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, nameCount int32) error {
-	monoVertexRollout := rolloutObject.(*apiv1.MonoVertexRollout)
-	monoVertexRollout.Status.NameCount = &nameCount
-	return r.updateMonoVertexRolloutStatus(ctx, monoVertexRollout)
-}
-
-// increment the child count for the Rollout and return the count to use
-func (r *MonoVertexRolloutReconciler) IncrementChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject) (int32, error) {
-	currentNameCount, found := r.getCurrentChildCount(rolloutObject)
-	if !found {
-		currentNameCount = int32(0)
-		err := r.updateCurrentChildCount(ctx, rolloutObject, int32(0))
-		if err != nil {
-			return int32(0), err
-		}
-	}
-
-	err := r.updateCurrentChildCount(ctx, rolloutObject, currentNameCount+1)
-	if err != nil {
-		return int32(0), err
-	}
-	return currentNameCount, nil
-}
-
-// Recycle deletes child; returns true if it was in fact deleted
-func (r *MonoVertexRolloutReconciler) Recycle(ctx context.Context,
-	monoVertexDef *unstructured.Unstructured,
-	c client.Client,
-) (bool, error) {
-	err := kubernetes.DeleteResource(ctx, c, monoVertexDef)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
 // Assessment:
 // Success: phase must be "Running" and all conditions must be True
 // Failure: phase is "Failed" or any condition is False
-// Unknowk: neither of the above if met
+// Unknown: neither of the above if met
+// This implements a function of the progressiveController interface
 // TODO: fix this assessment not to return an immediate result as soon as things are healthy or unhealthy
 func (r *MonoVertexRolloutReconciler) AssessUpgradingChild(ctx context.Context, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error) {
 	numaLogger := logger.FromContext(ctx)

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -560,7 +560,7 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 	}
 
 	// clean up recyclable pipelines
-	allDeleted, err := progressive.GarbageCollectChildren(ctx, pipelineRollout, r, r.client)
+	allDeleted, err := ctlrcommon.GarbageCollectChildren(ctx, pipelineRollout, r, r.client)
 	if err != nil {
 		return 0, err
 	}
@@ -587,7 +587,7 @@ func (r *PipelineRolloutReconciler) processPipelineStatus(ctx context.Context, p
 	// Only fetch the latest pipeline object while deleting the pipeline object, i.e. when pipelineRollout.DeletionTimestamp.IsZero() is false
 	if existingPipelineDef == nil {
 		// determine name of the promoted Pipeline
-		pipelineName, err := progressive.GetChildName(ctx, pipelineRollout, r, common.LabelValueUpgradePromoted, r.client, true)
+		pipelineName, err := ctlrcommon.GetChildName(ctx, pipelineRollout, r, common.LabelValueUpgradePromoted, r.client, true)
 		if err != nil {
 			return fmt.Errorf("Unable to process pipeline status: err=%s", err)
 		}
@@ -785,7 +785,7 @@ func (r *PipelineRolloutReconciler) makePromotedPipelineDefinition(
 	numaLogger := logger.FromContext(ctx)
 
 	// determine name of the Pipeline
-	pipelineName, err := progressive.GetChildName(ctx, pipelineRollout, r, common.LabelValueUpgradePromoted, r.client, true)
+	pipelineName, err := ctlrcommon.GetChildName(ctx, pipelineRollout, r, common.LabelValueUpgradePromoted, r.client, true)
 	if err != nil {
 		return nil, err
 	}
@@ -867,6 +867,7 @@ func (r *PipelineRolloutReconciler) drain(ctx context.Context, pipeline *unstruc
 }
 
 // ChildNeedsUpdating() tests for essential equality, with any irrelevant fields eliminated from the comparison
+// This implements a function of the progressiveController interface
 func (r *PipelineRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
 	fromCopy := from.DeepCopy()
@@ -897,6 +898,87 @@ func getPipelineChildResourceHealth(conditions []metav1.Condition) (metav1.Condi
 		}
 	}
 	return metav1.ConditionTrue, ""
+}
+
+func (r *PipelineRolloutReconciler) getCurrentChildCount(rolloutObject ctlrcommon.RolloutObject) (int32, bool) {
+	pipelineRollout := rolloutObject.(*apiv1.PipelineRollout)
+	if pipelineRollout.Status.NameCount == nil {
+		return int32(0), false
+	} else {
+		return *pipelineRollout.Status.NameCount, true
+	}
+}
+
+func (r *PipelineRolloutReconciler) updateCurrentChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, nameCount int32) error {
+	pipelineRollout := rolloutObject.(*apiv1.PipelineRollout)
+	pipelineRollout.Status.NameCount = &nameCount
+	return r.updatePipelineRolloutStatus(ctx, pipelineRollout)
+}
+
+// IncrementChildCount increments the child count for the Rollout and returns the count to use
+// This implements a function of the progressiveController interface
+func (r *PipelineRolloutReconciler) IncrementChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject) (int32, error) {
+	currentNameCount, found := r.getCurrentChildCount(rolloutObject)
+	if !found {
+		currentNameCount = int32(0)
+		err := r.updateCurrentChildCount(ctx, rolloutObject, int32(0))
+		if err != nil {
+			return int32(0), err
+		}
+	}
+
+	err := r.updateCurrentChildCount(ctx, rolloutObject, currentNameCount+1)
+	if err != nil {
+		return int32(0), err
+	}
+	return currentNameCount, nil
+}
+
+// Recycle deletes child; returns true if it was in fact deleted
+// This implements a function of the progressiveController interface
+func (r *PipelineRolloutReconciler) Recycle(ctx context.Context,
+	pipeline *unstructured.Unstructured,
+	c client.Client,
+) (bool, error) {
+
+	pipelineRollout, err := numaflowtypes.GetRolloutForPipeline(ctx, c, pipeline)
+	if err != nil {
+		return false, err
+	}
+	// if the Pipeline has been paused or if it can't be paused, then delete the pipeline
+	pausedOrWontPause, err := numaflowtypes.IsPipelinePausedOrWontPause(ctx, pipeline, pipelineRollout, true)
+	if err != nil {
+		return false, err
+	}
+	if pausedOrWontPause {
+		err = kubernetes.DeleteResource(ctx, c, pipeline)
+		return true, err
+	}
+	// make sure we request Paused if we haven't yet
+	desiredPhaseSetting, err := numaflowtypes.GetPipelineDesiredPhase(pipeline)
+	if err != nil {
+		return false, err
+	}
+	if desiredPhaseSetting != string(numaflowv1.PipelinePhasePaused) {
+		_ = r.drain(ctx, pipeline)
+		return false, nil
+	}
+	return false, nil
+
+}
+
+// get the isbsvc child of ISBServiceRollout with the given upgrading state label
+func (r *PipelineRolloutReconciler) getISBSvc(ctx context.Context, pipelineRollout *apiv1.PipelineRollout, upgradeState common.UpgradeState) (*unstructured.Unstructured, error) {
+	isbsvcRollout, err := r.getISBSvcRollout(ctx, pipelineRollout)
+	if err != nil || isbsvcRollout == nil {
+		return nil, fmt.Errorf("unable to find ISBServiceRollout, err=%v", err)
+	}
+
+	isbsvc, err := ctlrcommon.FindMostCurrentChildOfUpgradeState(ctx, isbsvcRollout, upgradeState, false, r.client)
+	if err != nil {
+		return nil, err
+	}
+	return isbsvc, nil
 }
 
 func (r *PipelineRolloutReconciler) ErrorHandler(pipelineRollout *apiv1.PipelineRollout, err error, reason, msg string) {

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -916,7 +916,7 @@ func (r *PipelineRolloutReconciler) updateCurrentChildCount(ctx context.Context,
 }
 
 // IncrementChildCount increments the child count for the Rollout and returns the count to use
-// This implements a function of the progressiveController interface
+// This implements a function of the RolloutController interface
 func (r *PipelineRolloutReconciler) IncrementChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject) (int32, error) {
 	currentNameCount, found := r.getCurrentChildCount(rolloutObject)
 	if !found {
@@ -935,7 +935,7 @@ func (r *PipelineRolloutReconciler) IncrementChildCount(ctx context.Context, rol
 }
 
 // Recycle deletes child; returns true if it was in fact deleted
-// This implements a function of the progressiveController interface
+// This implements a function of the RolloutController interface
 func (r *PipelineRolloutReconciler) Recycle(ctx context.Context,
 	pipeline *unstructured.Unstructured,
 	c client.Client,

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -19,14 +19,10 @@ package progressive
 import (
 	"context"
 	"fmt"
-	"math"
-	"strconv"
-	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/numaproj/numaplane/internal/common"
@@ -40,15 +36,10 @@ import (
 // progressiveController describes a Controller that can progressively roll out a second child alongside the original child,
 // taking down the original child once the new one is healthy
 type progressiveController interface {
+	ctlrcommon.RolloutController
 
 	// CreateUpgradingChildDefinition creates a Kubernetes definition for a child resource of the Rollout with the given name in an "upgrading" state
 	CreateUpgradingChildDefinition(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, name string) (*unstructured.Unstructured, error)
-
-	// IncrementChildCount updates the count of children for the Resource in Kubernetes and returns the index that should be used for the next child
-	IncrementChildCount(ctx context.Context, rolloutObject ctlrcommon.RolloutObject) (int32, error)
-
-	// Recycle deletes child; returns true if it was in fact deleted
-	Recycle(ctx context.Context, childObject *unstructured.Unstructured, c client.Client) (bool, error)
 
 	// ChildNeedsUpdating determines if the difference between the current child definition and the desired child definition requires an update
 	ChildNeedsUpdating(ctx context.Context, existingChild, newChildDefinition *unstructured.Unstructured) (bool, error)
@@ -75,7 +66,7 @@ func ProcessResource(
 	numaLogger := logger.FromContext(ctx)
 
 	// is there currently an "upgrading" child?
-	currentUpgradingChildDef, err := FindMostCurrentChildOfUpgradeState(ctx, rolloutObject, common.LabelValueUpgradeInProgress, false, c)
+	currentUpgradingChildDef, err := ctlrcommon.FindMostCurrentChildOfUpgradeState(ctx, rolloutObject, common.LabelValueUpgradeInProgress, false, c)
 	if err != nil {
 		return false, false, 0, err
 	}
@@ -83,7 +74,7 @@ func ProcessResource(
 	// if there's a difference between the desired spec and the current "promoted" child, and there isn't already an "upgrading" definition, then create one and return
 	if promotedDifference && currentUpgradingChildDef == nil {
 		// Create it, first making sure one doesn't already exist by checking the live K8S API
-		currentUpgradingChildDef, err = FindMostCurrentChildOfUpgradeState(ctx, rolloutObject, common.LabelValueUpgradeInProgress, true, c)
+		currentUpgradingChildDef, err = ctlrcommon.FindMostCurrentChildOfUpgradeState(ctx, rolloutObject, common.LabelValueUpgradeInProgress, true, c)
 		if err != nil {
 			return false, false, 0, fmt.Errorf("error getting %s: %v", currentUpgradingChildDef.GetKind(), err)
 		}
@@ -125,7 +116,7 @@ func makeUpgradingObjectDefinition(ctx context.Context, rolloutObject ctlrcommon
 
 	numaLogger := logger.FromContext(ctx)
 
-	childName, err := GetChildName(ctx, rolloutObject, controller, common.LabelValueUpgradeInProgress, c, useExistingChildName)
+	childName, err := ctlrcommon.GetChildName(ctx, rolloutObject, controller, common.LabelValueUpgradeInProgress, c, useExistingChildName)
 	if err != nil {
 		return nil, err
 	}
@@ -136,131 +127,6 @@ func makeUpgradingObjectDefinition(ctx context.Context, rolloutObject ctlrcommon
 	}
 
 	return upgradingChild, nil
-}
-
-func findChildrenOfUpgradeState(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, upgradeState common.UpgradeState, checkLive bool, c client.Client) (*unstructured.UnstructuredList, error) {
-	childGVR := rolloutObject.GetChildGVR()
-
-	labelSelector := fmt.Sprintf(
-		"%s=%s,%s=%s", common.LabelKeyParentRollout, rolloutObject.GetRolloutObjectMeta().Name,
-		common.LabelKeyUpgradeState, string(upgradeState))
-
-	var children *unstructured.UnstructuredList
-	var err error
-	if checkLive {
-		children, err = kubernetes.ListLiveResource(
-			ctx, childGVR.Group, childGVR.Version, childGVR.Resource,
-			rolloutObject.GetRolloutObjectMeta().Namespace, labelSelector, "")
-	} else {
-		children, err = kubernetes.ListResources(ctx, c, rolloutObject.GetChildGVK(), rolloutObject.GetRolloutObjectMeta().GetNamespace(),
-			client.MatchingLabels{
-				common.LabelKeyParentRollout: rolloutObject.GetRolloutObjectMeta().Name,
-				common.LabelKeyUpgradeState:  string(upgradeState),
-			},
-		)
-	}
-
-	return children, err
-}
-
-// find the most current child of a Rollout
-// typically we should only find one, but perhaps a previous reconciliation failure could cause us to find multiple
-// if we do see older ones, recycle them
-func FindMostCurrentChildOfUpgradeState(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, upgradeState common.UpgradeState, checkLive bool, c client.Client) (*unstructured.Unstructured, error) {
-	numaLogger := logger.FromContext(ctx)
-
-	children, err := findChildrenOfUpgradeState(ctx, rolloutObject, upgradeState, checkLive, c)
-	if err != nil {
-		return nil, err
-	}
-
-	numaLogger.Debugf("looking for children of Rollout %s/%s of upgrade state=%v, found: %s",
-		rolloutObject.GetRolloutObjectMeta().Namespace, rolloutObject.GetRolloutObjectMeta().Name, upgradeState, kubernetes.ExtractResourceNames(children))
-
-	if len(children.Items) > 1 {
-		var mostCurrentChild *unstructured.Unstructured
-		recycleList := []*unstructured.Unstructured{}
-		mostCurrentIndex := math.MinInt
-		for _, child := range children.Items {
-			childIndex, err := getChildIndex(rolloutObject.GetRolloutObjectMeta().Name, child.GetName())
-			if err != nil {
-				// something is improperly named for some reason - don't touch it just in case?
-				numaLogger.Warn(err.Error())
-				continue
-			}
-			if mostCurrentChild == nil { // first one in the list
-				mostCurrentChild = &child
-				mostCurrentIndex = childIndex
-			} else if childIndex > mostCurrentIndex { // most current for now
-				recycleList = append(recycleList, mostCurrentChild) // recycle the previous one
-				mostCurrentChild = &child
-				mostCurrentIndex = childIndex
-			} else {
-				recycleList = append(recycleList, &child)
-			}
-		}
-		// recycle the previous children
-		for _, recyclableChild := range recycleList {
-			numaLogger.Debugf("found multiple children of Rollout %s/%s of upgrade state=%q, marking recyclable: %s",
-				rolloutObject.GetRolloutObjectMeta().Namespace, rolloutObject.GetRolloutObjectMeta().Name, upgradeState, recyclableChild.GetName())
-			_ = updateUpgradeState(ctx, c, common.LabelValueUpgradeRecyclable, recyclableChild)
-		}
-		return mostCurrentChild, nil
-	} else if len(children.Items) == 1 {
-		return &children.Items[0], nil
-	} else {
-		return nil, nil
-	}
-}
-
-// Get the index of the child following the dash in the name
-// childName should be the rolloutName + '-<integer>'
-// For backward compatibility, support child resources whose names were equivalent to rollout names, returning -1 index
-func getChildIndex(rolloutName string, childName string) (int, error) {
-	// verify that the initial part of the child name is the rolloutName
-	if !strings.HasPrefix(childName, rolloutName) {
-		return 0, fmt.Errorf("child name %q should begin with rollout name %q", childName, rolloutName)
-	}
-	// backward compatibility for older naming convention (before the '-<integer>' suffix was introduced - if it's the same name, consider it to essentially be the smallest index
-	if childName == rolloutName {
-		return -1, nil
-	}
-
-	// next character should be a dash
-	dash := childName[len(rolloutName)]
-	if dash != '-' {
-		return 0, fmt.Errorf("child name %q should begin with rollout name %q, followed by '-<integer>'", childName, rolloutName)
-	}
-
-	// remaining characters should be the integer index
-	suffix := childName[len(rolloutName)+1:]
-
-	childIndex, err := strconv.Atoi(suffix)
-	if err != nil {
-		return 0, fmt.Errorf("child name %q has a suffix which is not an integer", childName)
-	}
-	return childIndex, nil
-}
-
-// get the name of the child whose parent is "rolloutObject" and whose upgrade state is "upgradeState"
-// if none is found, create a new one
-// if one is found, create a new one if "useExistingChild=false", else use existing one
-func GetChildName(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, controller progressiveController, upgradeState common.UpgradeState, c client.Client, useExistingChild bool) (string, error) {
-
-	existingChild, err := FindMostCurrentChildOfUpgradeState(ctx, rolloutObject, upgradeState, true, c) // if for some reason there's more than 1
-	if err != nil {
-		return "", err
-	}
-	// if existing child doesn't exist or if it does but we don't want to use it, then create a new one
-	if existingChild == nil || (existingChild != nil && !useExistingChild) {
-		index, err := controller.IncrementChildCount(ctx, rolloutObject)
-		if err != nil {
-			return "", err
-		}
-		return fmt.Sprintf("%s-%d", rolloutObject.GetRolloutObjectMeta().Name, index), nil
-	} else {
-		return existingChild.GetName(), nil
-	}
 }
 
 /*
@@ -379,7 +245,7 @@ func processUpgradingChild(
 			}
 
 			numaLogger.WithValues("old child", existingUpgradingChildDef.GetName(), "new child", newUpgradingChildDef.GetName()).Debug("replacing 'upgrading' child")
-			err = updateUpgradeState(ctx, c, common.LabelValueUpgradeRecyclable, existingUpgradingChildDef)
+			err = ctlrcommon.UpdateUpgradeState(ctx, c, common.LabelValueUpgradeRecyclable, existingUpgradingChildDef)
 			if err != nil {
 				return false, false, 0, err
 			}
@@ -393,12 +259,12 @@ func processUpgradingChild(
 	case apiv1.AssessmentResultSuccess:
 		// Label the new child as promoted and then remove the label from the old one
 		numaLogger.WithValues("old child", existingPromotedChildDef.GetName(), "new child", existingUpgradingChildDef.GetName(), "replacing 'promoted' child")
-		err := updateUpgradeState(ctx, c, common.LabelValueUpgradePromoted, existingUpgradingChildDef)
+		err := ctlrcommon.UpdateUpgradeState(ctx, c, common.LabelValueUpgradePromoted, existingUpgradingChildDef)
 		if err != nil {
 			return false, false, 0, err
 		}
 
-		err = updateUpgradeState(ctx, c, common.LabelValueUpgradeRecyclable, existingPromotedChildDef)
+		err = ctlrcommon.UpdateUpgradeState(ctx, c, common.LabelValueUpgradeRecyclable, existingPromotedChildDef)
 		if err != nil {
 			return false, false, 0, err
 		}
@@ -419,15 +285,6 @@ func processUpgradingChild(
 	}
 }
 
-// update the in-memory object with the new Label and patch the object in K8S
-func updateUpgradeState(ctx context.Context, c client.Client, upgradeState common.UpgradeState, childObject *unstructured.Unstructured) error {
-	labels := childObject.GetLabels()
-	labels[common.LabelKeyUpgradeState] = string(upgradeState)
-	childObject.SetLabels(labels)
-	patchJson := `{"metadata":{"labels":{"` + common.LabelKeyUpgradeState + `":"` + string(upgradeState) + `"}}}`
-	return kubernetes.PatchResource(ctx, c, childObject, patchJson, k8stypes.MergePatchType)
-}
-
 func IsNumaflowChildReady(upgradingObjectStatus *kubernetes.GenericStatus) bool {
 	if len(upgradingObjectStatus.Conditions) == 0 {
 		return false
@@ -438,45 +295,4 @@ func IsNumaflowChildReady(upgradingObjectStatus *kubernetes.GenericStatus) bool 
 		}
 	}
 	return true
-}
-
-// Garbage Collect all recyclable children; return true if we've deleted all that are recyclable
-func GarbageCollectChildren(
-	ctx context.Context,
-	rolloutObject ctlrcommon.RolloutObject,
-	controller progressiveController,
-	c client.Client,
-) (bool, error) {
-	numaLogger := logger.FromContext(ctx)
-	recyclableObjects, err := getRecyclableObjects(ctx, rolloutObject, c)
-	if err != nil {
-		return false, err
-	}
-
-	numaLogger.WithValues("recylableObjects", recyclableObjects).Debug("recycling")
-
-	allDeleted := true
-	for _, recyclableChild := range recyclableObjects.Items {
-		deleted, err := controller.Recycle(ctx, &recyclableChild, c)
-		if err != nil {
-			return false, err
-		}
-		if !deleted {
-			allDeleted = false
-		}
-	}
-	return allDeleted, nil
-}
-func getRecyclableObjects(
-	ctx context.Context,
-	rolloutObject ctlrcommon.RolloutObject,
-	c client.Client,
-) (*unstructured.UnstructuredList, error) {
-	return kubernetes.ListResources(ctx, c, rolloutObject.GetChildGVK(),
-		rolloutObject.GetRolloutObjectMeta().Namespace,
-		client.MatchingLabels{
-			common.LabelKeyParentRollout: rolloutObject.GetRolloutObjectMeta().Name,
-			common.LabelKeyUpgradeState:  string(common.LabelValueUpgradeRecyclable),
-		},
-	)
 }

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
-	"github.com/numaproj/numaplane/internal/common"
 	ctlrcommon "github.com/numaproj/numaplane/internal/controller/common"
 	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
@@ -19,169 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// This tests the FindMostCurrentChildOfUpgradeState() function
-// This function both finds the most current child of the upgrade-state, but also recycles any others that are found
-// So, it should only be called if there in fact should be only one child of that upgrade-state in existence
-func TestFindMostCurrentChildOfUpgradeState(t *testing.T) {
-
-	restConfig, numaflowClientSet, client, _, err := commontest.PrepareK8SEnvironment()
-	assert.Nil(t, err)
-	assert.Nil(t, kubernetes.SetClientSets(restConfig))
-
-	ctx := context.TODO()
-	pipelineRollout := &apiv1.PipelineRollout{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-pipeline",
-			Namespace: ctlrcommon.DefaultTestNamespace,
-		},
-	}
-	checkLive := false
-
-	tests := []struct {
-		name          string
-		pipelines     []*numaflowv1.Pipeline
-		expectedName  string
-		expectedError error
-	}{
-		{
-			name: "Multiple children with valid indices",
-			pipelines: []*numaflowv1.Pipeline{
-				createPipeline("my-pipeline-1", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
-				createPipeline("my-pipeline-2", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
-				createPipeline("my-pipeline-3", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
-			},
-
-			expectedName:  "my-pipeline-3",
-			expectedError: nil,
-		},
-		{
-			name:          "No children",
-			pipelines:     []*numaflowv1.Pipeline{},
-			expectedName:  "",
-			expectedError: nil,
-		},
-		{
-			name: "Backward compatibility with older code",
-			pipelines: []*numaflowv1.Pipeline{
-				createPipeline("my-pipeline-1", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
-				createPipeline("my-pipeline-2", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
-				createPipeline("my-pipeline-3", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
-				createPipeline("my-pipeline", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
-			},
-
-			expectedName:  "my-pipeline-3",
-			expectedError: nil,
-		},
-		{
-			name: "Backward compatibility with older code, and just one pipeline exists",
-			pipelines: []*numaflowv1.Pipeline{
-				createPipeline("my-pipeline", "my-pipeline", defaultISBSVCRolloutName, common.LabelValueUpgradePromoted),
-			},
-
-			expectedName:  "my-pipeline",
-			expectedError: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			// Clean up any pipelines on the namespace beforehand
-			_ = numaflowClientSet.NumaflowV1alpha1().Pipelines(ctlrcommon.DefaultTestNamespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
-			pipelineList, err := numaflowClientSet.NumaflowV1alpha1().Pipelines(ctlrcommon.DefaultTestNamespace).List(ctx, metav1.ListOptions{})
-			assert.NoError(t, err)
-			assert.Len(t, pipelineList.Items, 0)
-
-			// Create the Pipelines in Kubernetes
-			for _, pipeline := range tt.pipelines {
-				_, err := numaflowClientSet.NumaflowV1alpha1().Pipelines(ctlrcommon.DefaultTestNamespace).Create(ctx, pipeline, metav1.CreateOptions{})
-				assert.NoError(t, err)
-			}
-
-			mostCurrentChild, err := ctlrcommon.FindMostCurrentChildOfUpgradeState(ctx, pipelineRollout, common.LabelValueUpgradePromoted, checkLive, client)
-			if tt.expectedError != nil {
-				assert.Error(t, err)
-				assert.Nil(t, mostCurrentChild)
-			} else {
-				assert.NoError(t, err)
-				if tt.expectedName == "" {
-					assert.Nil(t, mostCurrentChild)
-				} else {
-					// verify the most current child is correct
-					assert.NotNil(t, mostCurrentChild)
-					assert.Equal(t, tt.expectedName, mostCurrentChild.GetName())
-
-					// verify all other children have been marked "recyclable"
-					for _, p := range tt.pipelines {
-						retrievedPipeline, err := numaflowClientSet.NumaflowV1alpha1().Pipelines(ctlrcommon.DefaultTestNamespace).Get(ctx, p.Name, metav1.GetOptions{})
-						assert.NoError(t, err)
-
-						retrievedUpgradeState, found := retrievedPipeline.GetLabels()[common.LabelKeyUpgradeState]
-						assert.True(t, found)
-						if p.Name == tt.expectedName {
-							assert.Equal(t, string(common.LabelValueUpgradePromoted), retrievedUpgradeState)
-						} else {
-							assert.Equal(t, string(common.LabelValueUpgradeRecyclable), retrievedUpgradeState)
-						}
-					}
-				}
-			}
-		})
-	}
-}
-
-var (
-	defaultISBSVCRolloutName = "my-isbsvc"
-	pipelineSpec             = numaflowv1.PipelineSpec{
-		InterStepBufferServiceName: defaultISBSVCRolloutName + "-0",
-		Vertices: []numaflowv1.AbstractVertex{
-			{
-				Name: "in",
-				Source: &numaflowv1.Source{
-					Generator: &numaflowv1.GeneratorSource{},
-				},
-			},
-			{
-				Name: "out",
-				Sink: &numaflowv1.Sink{
-					AbstractSink: numaflowv1.AbstractSink{
-						Log: &numaflowv1.Log{},
-					},
-				},
-			},
-		},
-		Edges: []numaflowv1.Edge{
-			{
-				From: "in",
-				To:   "out",
-			},
-		},
-	}
-)
-
-func createPipeline(pipelineName string, pipelineRolloutName string, isbsvcRolloutName string, upgradeState common.UpgradeState) *numaflowv1.Pipeline {
-	return ctlrcommon.CreateTestPipelineOfSpec(pipelineSpec, pipelineName, numaflowv1.PipelinePhaseRunning, numaflowv1.Status{}, false,
-		map[string]string{
-			common.LabelKeyParentRollout:               pipelineRolloutName,
-			common.LabelKeyISBServiceRONameForPipeline: isbsvcRolloutName,
-			common.LabelKeyUpgradeState:                string(upgradeState),
-		},
-		map[string]string{})
-}
-
-var defaultMonoVertexRollout = &apiv1.MonoVertexRollout{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "test",
-	},
-	Status: apiv1.MonoVertexRolloutStatus{
-		Status: apiv1.Status{
-			ProgressiveStatus: apiv1.ProgressiveStatus{
-				UpgradingChildStatus: nil,
-			},
-		},
-	},
-}
 
 type fakeProgressiveController struct{}
 
@@ -310,4 +145,17 @@ func Test_processUpgradingChild(t *testing.T) {
 func setRolloutObjectUpgradingChildStatus(rolloutObject ctlrcommon.RolloutObject, childStatus *apiv1.ChildStatus) ctlrcommon.RolloutObject {
 	rolloutObject.GetRolloutStatus().ProgressiveStatus.UpgradingChildStatus = childStatus
 	return rolloutObject
+}
+
+var defaultMonoVertexRollout = &apiv1.MonoVertexRollout{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "test",
+	},
+	Status: apiv1.MonoVertexRolloutStatus{
+		Status: apiv1.Status{
+			ProgressiveStatus: apiv1.ProgressiveStatus{
+				UpgradingChildStatus: nil,
+			},
+		},
+	},
 }

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -99,7 +99,7 @@ func TestFindMostCurrentChildOfUpgradeState(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			mostCurrentChild, err := FindMostCurrentChildOfUpgradeState(ctx, pipelineRollout, common.LabelValueUpgradePromoted, checkLive, client)
+			mostCurrentChild, err := ctlrcommon.FindMostCurrentChildOfUpgradeState(ctx, pipelineRollout, common.LabelValueUpgradePromoted, checkLive, client)
 			if tt.expectedError != nil {
 				assert.Error(t, err)
 				assert.Nil(t, mostCurrentChild)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


Note: this PR makes no logic changes.

### Modifications

Previously, the whole idea of having an "upgrade-state" and also the idea of using that to garbage collect children was considered to be a "progressive" thing. Now that we are introducing the delete/recreate capability for child objects, we can use the same "recyclable" label value for performing that deletion and the same logic for performing the delete. 

This means we need to move the code related to updating that value and for updating the label altogether out of the progressive-specific code. 

Therefore, I am introducing a new interface called `RolloutController`, where all 4 of our Rollouts either implement them now or will in the future (`NumaflowControllerRollout` would be future for performing blue/green; the others already do). 


### Verification

no logic was changed, so standard CI is sufficient

### Backward incompatibilities

N/A
