### PR TITLE
feat: create reusable e2e functions

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -412,6 +412,9 @@ func beforeSuiteSetup() {
 	if disableTestArtifacts != "true" {
 		setupOutputDir()
 	}
+	// this must be set for all tests to run
+	upgradeStrategy = getUpgradeStrategy()
+	Expect(upgradeStrategy.IsValid()).To(BeTrue())
 
 	openFiles = make(map[string]*os.File)
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -453,10 +453,6 @@ var _ = Describe("Functional e2e", Serial, func() {
 			return retrievedISBServiceSpec.JetStream.Version == updatedJetstreamVersion
 		}, true)
 
-		verifyISBServiceSpec(Namespace, isbServiceRolloutName, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
-			return retrievedISBServiceSpec.JetStream.Version == updatedJetstreamVersion
-		})
-
 	})
 
 	It("Should update the child ISBService updating a no-data-loss field", func() {

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -185,9 +185,6 @@ func TestFunctionalE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	BeforeSuite(func() {
-		// this must be set for all tests to run
-		upgradeStrategy = getUpgradeStrategy()
-		Expect(upgradeStrategy.IsValid()).To(BeTrue())
 		beforeSuiteSetup()
 	})
 

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -18,18 +18,14 @@ package e2e
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 
@@ -88,7 +84,6 @@ var (
 			},
 		},
 	}
-	numPipelineVertices = 2
 
 	updatedPipelineSpec = numaflowv1.PipelineSpec{
 		InterStepBufferServiceName: isbServiceRolloutName,
@@ -209,90 +204,21 @@ func init() {
 var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should create the NumaflowControllerRollout if it doesn't exist", func() {
-
-		numaflowControllerRolloutSpec := createNumaflowControllerRolloutSpec(numaflowControllerRolloutName, Namespace)
-		_, err := numaflowControllerRolloutClient.Create(ctx, numaflowControllerRolloutSpec, metav1.CreateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		document("Verifying that the NumaflowControllerRollout was created")
-		Eventually(func() error {
-			_, err := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			return err
-		}, testTimeout, testPollingInterval).Should(Succeed())
-
-		verifyNumaflowControllerRolloutReady()
-
-		verifyNumaflowControllerExists(Namespace)
-
+		createNumaflowControllerRollout(initialNumaflowControllerVersion)
 	})
 
 	It("Should create the ISBServiceRollout if it doesn't exist", func() {
-
-		isbServiceRolloutSpec := createISBServiceRolloutSpec(isbServiceRolloutName, Namespace)
-		_, err := isbServiceRolloutClient.Create(ctx, isbServiceRolloutSpec, metav1.CreateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		document("Verifying that the ISBServiceRollout was created")
-		Eventually(func() error {
-			_, err := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			return err
-		}, testTimeout, testPollingInterval).Should(Succeed())
-
-		verifyISBSvcRolloutReady(isbServiceRolloutName)
-
-		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
-
+		createISBServiceRollout(isbServiceRolloutName, isbServiceSpec)
 	})
 
 	It("Should create the PipelineRollout if it does not exist", func() {
-
-		pipelineRolloutSpec := createPipelineRolloutSpec(pipelineRolloutName, Namespace, initialPipelineSpec)
-		_, err := pipelineRolloutClient.Create(ctx, pipelineRolloutSpec, metav1.CreateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		document("Verifying that the PipelineRollout was created")
-		Eventually(func() error {
-			_, err := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			return err
-		}, testTimeout, testPollingInterval).Should(Succeed())
-
-		document("Verifying that the Pipeline was created")
-		verifyPipelineSpec(Namespace, pipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
-			return len(initialPipelineSpec.Vertices) == len(retrievedPipelineSpec.Vertices) // TODO: make less kludgey
-			//return reflect.DeepEqual(pipelineSpec, retrievedPipelineSpec) // this may have had some false negatives due to "lifecycle" field maybe, or null values in one
-		})
-
-		verifyPipelineRolloutDeployed(pipelineRolloutName)
-		verifyPipelineRolloutHealthy(pipelineRolloutName)
-		verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
-
-		verifyPipelineRunning(Namespace, pipelineRolloutName, numPipelineVertices)
-
+		createPipelineRollout(pipelineRolloutName, Namespace, initialPipelineSpec)
 	})
 
 	currentPipelineSpec = initialPipelineSpec
 
 	It("Should create the MonoVertexRollout if it does not exist", func() {
-
-		monoVertexRolloutSpec := createMonoVertexRolloutSpec(monoVertexRolloutName, Namespace)
-		_, err := monoVertexRolloutClient.Create(ctx, monoVertexRolloutSpec, metav1.CreateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		document("Verifying that the MonoVertexRollout was created")
-		Eventually(func() error {
-			_, err := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
-			return err
-		}, testTimeout, testPollingInterval).Should(Succeed())
-
-		document("Verifying that the MonoVertex was created")
-		verifyMonoVertexSpec(Namespace, monoVertexRolloutName, func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec) bool {
-			return initialMonoVertexSpec.Source != nil
-		})
-
-		verifyMonoVertexRolloutReady(monoVertexRolloutName)
-
-		verifyMonoVertexReady(Namespace, monoVertexRolloutName)
-
+		createMonoVertexRollout(monoVertexRolloutName, Namespace, initialMonoVertexSpec)
 	})
 
 	currentMonoVertexSpec = initialMonoVertexSpec
@@ -330,7 +256,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
 
-		verifyPipelineRunning(Namespace, pipelineRolloutName, numPipelineVertices)
+		verifyPipelineRunning(Namespace, pipelineRolloutName)
 
 	})
 
@@ -338,42 +264,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should update the child Pipeline if the PipelineRollout is updated", func() {
 
-		document("Updating Pipeline spec in PipelineRollout")
-		rawSpec, err := json.Marshal(updatedPipelineSpec)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// update the PipelineRollout
-		updatePipelineRolloutInK8S(Namespace, pipelineRolloutName, func(rollout apiv1.PipelineRollout) (apiv1.PipelineRollout, error) {
-			rollout.Spec.Pipeline.Spec.Raw = rawSpec
-			return rollout, nil
-		})
-
-		if upgradeStrategy == config.PPNDStrategyID {
-
-			document("Verify that in-progress-strategy gets set to PPND")
-			verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyPPND)
-
-			verifyPipelinePaused(Namespace, pipelineRolloutName)
-
-		}
-
-		// wait for update to reconcile
-		time.Sleep(5 * time.Second)
-
-		document("Verifying Pipeline got updated")
-		numPipelineVertices = 3
-
-		// get Pipeline to check that spec has been updated to correct spec
-		verifyPipelineSpec(Namespace, pipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
-			return len(retrievedPipelineSpec.Vertices) == numPipelineVertices
-		})
-
-		verifyPipelineRolloutDeployed(pipelineRolloutName)
-		verifyPipelineRolloutHealthy(pipelineRolloutName)
-
-		verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
-
-		verifyPipelineRunning(Namespace, pipelineRolloutName, numPipelineVertices)
+		updatePipelineRollout(pipelineRolloutName, updatedPipelineSpec, numaflowv1.PipelinePhaseRunning)
 
 	})
 
@@ -410,7 +301,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 				return len(slowPipelineSpec.Vertices) == len(retrievedPipelineSpec.Vertices)
 			})
 
-			verifyPipelineRunning(Namespace, slowPipelineRolloutName, len(slowPipelineSpec.Vertices))
+			verifyPipelineRunning(Namespace, slowPipelineRolloutName)
 			verifyInProgressStrategy(slowPipelineRolloutName, apiv1.UpgradeStrategyNoOp)
 
 			document("Updating Pipeline Topology to cause a PPND change")
@@ -451,7 +342,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 			})
 
 			document("Verifying that Pipeline has stopped trying to pause")
-			verifyPipelineRunning(Namespace, slowPipelineRolloutName, len(slowPipelineSpec.Vertices))
+			verifyPipelineRunning(Namespace, slowPipelineRolloutName)
 
 			document("Deleting Slow PipelineRollout")
 
@@ -465,23 +356,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should pause the Pipeline if user requests it", func() {
 
+		document("setting desiredPhase=Paused")
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhasePaused
 
-		document("setting desiredPhase=Paused")
+		updatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhasePaused)
 
-		rawSpec, err := json.Marshal(currentPipelineSpec)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// update the PipelineRollout
-		updatePipelineRolloutInK8S(Namespace, pipelineRolloutName, func(rollout apiv1.PipelineRollout) (apiv1.PipelineRollout, error) {
-			rollout.Spec.Pipeline.Spec.Raw = rawSpec
-			return rollout, nil
-		})
-		document("verifying PipelineRollout spec deployed")
-		verifyPipelineRolloutDeployed(pipelineRolloutName)
-
-		// Give it a little while to get to Paused and then verify that it stays in Paused (or otherwise Pausing)
-		verifyPipelinePaused(Namespace, pipelineRolloutName)
 		document("verifying Pipeline stays in paused or otherwise pausing")
 		Consistently(func() bool {
 			rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
@@ -502,48 +381,22 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	time.Sleep(2 * time.Second)
 
+	// how to use update pipelinerollout function in the same fashion here
 	It("Should resume the Pipeline if user requests it", func() {
 
+		document("setting desiredPhase=Running")
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhaseRunning
 
-		document("setting desiredPhase=Running")
-
-		rawSpec, err := json.Marshal(currentPipelineSpec)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// update the PipelineRollout
-		updatePipelineRolloutInK8S(Namespace, pipelineRolloutName, func(rollout apiv1.PipelineRollout) (apiv1.PipelineRollout, error) {
-			rollout.Spec.Pipeline.Spec.Raw = rawSpec
-			return rollout, nil
-		})
-		document("verifying PipelineRollout spec deployed")
-
-		verifyPipelineRolloutDeployed(pipelineRolloutName)
-		verifyPipelineRolloutHealthy(pipelineRolloutName)
-
-		verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
-		verifyPipelineRunning(Namespace, pipelineRolloutName, numPipelineVertices)
+		updatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhaseRunning)
 	})
 
 	It("Should pause the MonoVertex if user requests it", func() {
 
+		document("setting desiredPhase=Paused")
 		currentMonoVertexSpec.Lifecycle.DesiredPhase = numaflowv1.MonoVertexPhasePaused
 
-		document("setting desiredPhase=Paused")
+		updateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhasePaused)
 
-		rawSpec, err := json.Marshal(currentMonoVertexSpec)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// update the MonoVertexRollout
-		updateMonoVertexRolloutInK8S(monoVertexRolloutName, func(rollout apiv1.MonoVertexRollout) (apiv1.MonoVertexRollout, error) {
-			rollout.Spec.MonoVertex.Spec.Raw = rawSpec
-			return rollout, nil
-		})
-		document("verifying MonoVertexRollout spec deployed")
-		verifyMonoVertexRolloutDeployed(monoVertexRolloutName)
-
-		// Give it a little while to get to Paused and then verify that it stays in Paused
-		verifyMonoVertexPaused(Namespace, monoVertexRolloutName)
 		document("verifying MonoVertex stays in paused or otherwise pausing")
 		Consistently(func() bool {
 			rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
@@ -564,42 +417,29 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should resume the MonoVertex if user requests it", func() {
 
+		document("setting desiredPhase=Running")
 		currentMonoVertexSpec.Lifecycle.DesiredPhase = numaflowv1.MonoVertexPhaseRunning
 
-		document("setting desiredPhase=Running")
+		updateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning)
 
-		rawSpec, err := json.Marshal(currentMonoVertexSpec)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// update the MonoVertexRollout
-		updateMonoVertexRolloutInK8S(monoVertexRolloutName, func(rollout apiv1.MonoVertexRollout) (apiv1.MonoVertexRollout, error) {
-			rollout.Spec.MonoVertex.Spec.Raw = rawSpec
-			return rollout, nil
-		})
-
-		document("verifying MonoVertexRollout spec deployed")
-		verifyMonoVertexRolloutDeployed(monoVertexRolloutName)
-		verifyMonoVertexRolloutHealthy(monoVertexRolloutName)
-
-		verifyInProgressStrategy(monoVertexRolloutName, apiv1.UpgradeStrategyNoOp)
 	})
 
 	time.Sleep(2 * time.Second)
 
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is updated", func() {
-		updateNumaflowControllerRolloutVersion(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, true)
+		updateNumaflowControllerRollout(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, pipelineRolloutName, true)
 	})
 
 	time.Sleep(2 * time.Second)
 
 	It("Should fail if the NumaflowControllerRollout is updated with a bad version", func() {
-		updateNumaflowControllerRolloutVersion(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, false)
+		updateNumaflowControllerRollout(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, pipelineRolloutName, false)
 	})
 
 	time.Sleep(2 * time.Second)
 
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is restored back to previous version", func() {
-		updateNumaflowControllerRolloutVersion(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, true)
+		updateNumaflowControllerRollout(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, pipelineRolloutName, true)
 	})
 
 	time.Sleep(2 * time.Second)
@@ -609,93 +449,25 @@ var _ = Describe("Functional e2e", Serial, func() {
 		// new ISBService spec
 		updatedISBServiceSpec := isbServiceSpec
 		updatedISBServiceSpec.JetStream.Version = updatedJetstreamVersion
-		rawSpec, err := json.Marshal(updatedISBServiceSpec)
-		Expect(err).ShouldNot(HaveOccurred())
 
-		updateISBServiceRolloutInK8S(isbServiceRolloutName, func(rollout apiv1.ISBServiceRollout) (apiv1.ISBServiceRollout, error) {
-			rollout.Spec.InterStepBufferService.Spec.Raw = rawSpec
-			return rollout, nil
-		})
-
-		if upgradeStrategy == config.PPNDStrategyID {
-
-			document("Verify that in-progress-strategy gets set to PPND")
-			verifyInProgressStrategyISBService(Namespace, isbServiceRolloutName, apiv1.UpgradeStrategyPPND)
-			verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyPPND)
-			verifyPipelinePaused(Namespace, pipelineRolloutName)
-
-			document("Verify that the pipelines are unpaused by checking the PPND conditions on ISBService Rollout and PipelineRollout")
-			Eventually(func() bool {
-				isbRollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-				isbCondStatus := getRolloutConditionStatus(isbRollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-				plRollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-				plCondStatus := getRolloutConditionStatus(plRollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-				if isbCondStatus != metav1.ConditionTrue || plCondStatus != metav1.ConditionTrue {
-					return false
-				}
-				return true
-			}, testTimeout).Should(BeTrue())
-
-		}
+		updateISBServiceRollout(isbServiceRolloutName, pipelineRolloutName, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+			return retrievedISBServiceSpec.JetStream.Version == updatedJetstreamVersion
+		}, true)
 
 		verifyISBServiceSpec(Namespace, isbServiceRolloutName, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream.Version == updatedJetstreamVersion
 		})
 
-		verifyISBSvcRolloutReady(isbServiceRolloutName)
-
-		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
-
-		verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
-		verifyPipelineRunning(Namespace, pipelineRolloutName, numPipelineVertices)
-
 	})
 
 	It("Should update the child ISBService updating a no-data-loss field", func() {
 
-		// new ISBService spec
-		rawSpec, err := json.Marshal(ISBServiceSpecNoDataLossField)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		updateISBServiceRolloutInK8S(isbServiceRolloutName, func(rollout apiv1.ISBServiceRollout) (apiv1.ISBServiceRollout, error) {
-			rollout.Spec.InterStepBufferService.Spec.Raw = rawSpec
-			return rollout, nil
-		})
-
-		if upgradeStrategy == config.PPNDStrategyID {
-			document("Verify that dependent Pipeline is not paused when an update to ISBService not requiring pause is made")
-			verifyNotPausing := func() bool {
-				_, _, retrievedPipelineStatus, err := getPipelineSpecAndStatus(Namespace, pipelineRolloutName)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(retrievedPipelineStatus.Phase != numaflowv1.PipelinePhasePaused).To(BeTrue())
-				isbRollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-				isbCondStatus := getRolloutConditionStatus(isbRollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-				plRollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-				plCondStatus := getRolloutConditionStatus(plRollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-				if isbCondStatus == metav1.ConditionTrue || plCondStatus == metav1.ConditionTrue {
-					return false
-				}
-				if isbRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyNoOp || plRollout.Status.UpgradeInProgress != apiv1.UpgradeStrategyNoOp {
-					return false
-				}
-				return true
-			}
-
-			Consistently(verifyNotPausing, 30*time.Second).Should(BeTrue())
-		}
-
-		verifyISBServiceSpec(Namespace, isbServiceRolloutName, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		updateISBServiceRollout(isbServiceRolloutName, pipelineRolloutName, ISBServiceSpecNoDataLossField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream != nil &&
 				retrievedISBServiceSpec.JetStream.ContainerTemplate != nil &&
 				retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() != nil &&
 				*retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() == updatedMemLimit
-		})
-
-		verifyISBSvcRolloutReady(isbServiceRolloutName)
-
-		verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)
-
-		verifyPipelineRunning(Namespace, pipelineRolloutName, numPipelineVertices)
+		}, false)
 
 	})
 
@@ -706,315 +478,29 @@ var _ = Describe("Functional e2e", Serial, func() {
 		updatedMonoVertexSpec.Source.UDSource = nil
 		rpu := int64(10)
 		updatedMonoVertexSpec.Source.Generator = &numaflowv1.GeneratorSource{RPU: &rpu}
-		rawSpec, err := json.Marshal(updatedMonoVertexSpec)
-		Expect(err).ShouldNot(HaveOccurred())
 
-		updateMonoVertexRolloutInK8S(monoVertexRolloutName, func(rollout apiv1.MonoVertexRollout) (apiv1.MonoVertexRollout, error) {
-			rollout.Spec.MonoVertex.Spec.Raw = rawSpec
-			return rollout, nil
-		})
+		updateMonoVertexRollout(monoVertexRolloutName, updatedMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning)
 
 		verifyMonoVertexSpec(Namespace, monoVertexRolloutName, func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec) bool {
 			return retrievedMonoVertexSpec.Source.Generator != nil && retrievedMonoVertexSpec.Source.UDSource == nil
 		})
 
-		verifyMonoVertexRolloutReady(monoVertexRolloutName)
-
-		verifyMonoVertexReady(Namespace, monoVertexRolloutName)
-
 	})
 
 	It("Should delete the PipelineRollout and child Pipeline", func() {
-
-		document("Deleting PipelineRollout")
-
-		err := pipelineRolloutClient.Delete(ctx, pipelineRolloutName, metav1.DeleteOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		document("Verifying PipelineRollout deletion")
-		Eventually(func() bool {
-			_, err := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					Fail("An unexpected error occurred when fetching the PipelineRollout: " + err.Error())
-				}
-				return false
-			}
-			return true
-		}).WithTimeout(testTimeout).Should(BeFalse(), "The PipelineRollout should have been deleted but it was found.")
-
-		document("Verifying Pipeline deletion")
-
-		Eventually(func() bool {
-			list, err := dynamicClient.Resource(pipelinegvr).Namespace(Namespace).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				return false
-			}
-			if len(list.Items) == 0 {
-				return true
-			}
-			return false
-		}).WithTimeout(testTimeout).Should(BeTrue(), "The Pipeline should have been deleted but it was found.")
-
+		deletePipelineRollout(pipelineRolloutName)
 	})
 
 	It("Should delete the MonoVertexRollout and child MonoVertex", func() {
-
-		document("Deleting MonoVertexRollout")
-
-		err := monoVertexRolloutClient.Delete(ctx, monoVertexRolloutName, metav1.DeleteOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		document("Verifying MonoVertexRollout deletion")
-
-		Eventually(func() bool {
-			_, err := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					Fail("An unexpected error occurred when fetching the MonoVertexRollout: " + err.Error())
-				}
-				return false
-			}
-			return true
-		}).WithTimeout(testTimeout).Should(BeFalse(), "The MonoVertexRollout should have been deleted but it was found.")
-
-		document("Verifying MonoVertex deletion")
-
-		Eventually(func() bool {
-			list, err := dynamicClient.Resource(monovertexgvr).Namespace(Namespace).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				return false
-			}
-			if len(list.Items) == 0 {
-				return true
-			}
-			return false
-		}).WithTimeout(testTimeout).Should(BeTrue(), "The MonoVertex should have been deleted but it was found.")
+		deleteMonoVertexRollout(monoVertexRolloutName)
 	})
 
 	It("Should delete the ISBServiceRollout and child ISBService", func() {
-
-		document("Deleting ISBServiceRollout")
-
-		err := isbServiceRolloutClient.Delete(ctx, isbServiceRolloutName, metav1.DeleteOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		document("Verifying ISBServiceRollout deletion")
-
-		Eventually(func() bool {
-			_, err := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					Fail("An unexpected error occurred when fetching the ISBServiceRollout: " + err.Error())
-				}
-				return false
-			}
-			return true
-		}).WithTimeout(testTimeout).Should(BeFalse(), "The ISBServiceRollout should have been deleted but it was found.")
-
-		document("Verifying ISBService deletion")
-
-		Eventually(func() bool {
-			list, err := dynamicClient.Resource(isbservicegvr).Namespace(Namespace).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				return false
-			}
-			if len(list.Items) == 0 {
-				return true
-			}
-			return false
-		}).WithTimeout(testTimeout).Should(BeTrue(), "The ISBService should have been deleted but it was found.")
-
+		deleteISBServiceRollout(isbServiceRolloutName)
 	})
 
 	It("Should delete the NumaflowControllerRollout and child NumaflowController", func() {
-		document("Deleting NumaflowControllerRollout")
-
-		err := numaflowControllerRolloutClient.Delete(ctx, numaflowControllerRolloutName, metav1.DeleteOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		document("Verifying NumaflowControllerRollout deletion")
-		Eventually(func() bool {
-			_, err := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					Fail("An unexpected error occurred when fetching the NumaflowControllerRollout: " + err.Error())
-				}
-				return false
-			}
-			return true
-		}).WithTimeout(testTimeout).Should(BeFalse(), "The NumaflowControllerRollout should have been deleted but it was found.")
-
-		document("Verifying Numaflow Controller deletion")
-
-		Eventually(func() bool {
-			_, err := kubeClient.AppsV1().Deployments(Namespace).Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					Fail("An unexpected error occurred when fetching the deployment: " + err.Error())
-				}
-				return false
-			}
-			return true
-		}).WithTimeout(testTimeout).Should(BeFalse(), "The deployment should have been deleted but it was found.")
-
+		deleteNumaflowControllerRollout()
 	})
 
 })
-
-func updateNumaflowControllerRolloutVersion(originalVersion, newVersion string, valid bool) {
-	// new NumaflowController spec
-	updatedNumaflowControllerROSpec := apiv1.NumaflowControllerRolloutSpec{
-		Controller: apiv1.Controller{Version: newVersion},
-	}
-
-	updateNumaflowControllerRolloutInK8S(func(rollout apiv1.NumaflowControllerRollout) (apiv1.NumaflowControllerRollout, error) {
-		rollout.Spec = updatedNumaflowControllerROSpec
-		return rollout, nil
-	})
-
-	// NOTE: we are only checking the "valid" case because in the "non-valid" case the pipeline pausing conditions on
-	// the NumaflowController and Pipeline rollouts change too rapidly making the test flaky (intermittently pass or fail)
-	if upgradeStrategy == config.PPNDStrategyID && valid {
-
-		document("Verify that in-progress-strategy gets set to PPND")
-		verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyPPND)
-		verifyPipelinePaused(Namespace, pipelineRolloutName)
-
-		document("Verify that the pipelines are unpaused by checking the PPND conditions on NumaflowController Rollout and PipelineRollout")
-		Eventually(func() bool {
-			ncRollout, _ := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
-			ncCondStatus := getRolloutConditionStatus(ncRollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-			plRollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-			plCondStatus := getRolloutConditionStatus(plRollout.Status.Conditions, apiv1.ConditionPipelinePausingOrPaused)
-			if ncCondStatus != metav1.ConditionTrue || plCondStatus != metav1.ConditionTrue {
-				return false
-			}
-			return true
-		}, testTimeout).Should(BeTrue())
-	}
-
-	var versionToCheck string
-	if valid {
-		versionToCheck = newVersion
-	} else {
-		versionToCheck = originalVersion
-	}
-	verifyNumaflowControllerDeployment(Namespace, func(d appsv1.Deployment) bool {
-		colon := strings.Index(d.Spec.Template.Spec.Containers[0].Image, ":")
-		return colon != -1 && d.Spec.Template.Spec.Containers[0].Image[colon+1:] == "v"+versionToCheck
-	})
-
-	if valid {
-		verifyNumaflowControllerRolloutReady()
-	} else {
-		// verify NumaflowControllerRollout ChildResourcesHealthy condition == false but NumaflowControllerRollout itself is marked "Deployed"
-		verifyNumaflowControllerRollout(Namespace, func(rollout apiv1.NumaflowControllerRollout) bool {
-			healthCondition := getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-			return rollout.Status.Phase == apiv1.PhaseDeployed && healthCondition != nil && healthCondition.Status == metav1.ConditionFalse && healthCondition.Reason == "Failed"
-		})
-	}
-
-	verifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
-	verifyPipelineRunning(Namespace, pipelineRolloutName, numPipelineVertices)
-}
-
-func createPipelineRolloutSpec(name, namespace string, pipelineSpec numaflowv1.PipelineSpec) *apiv1.PipelineRollout {
-
-	pipelineSpecRaw, err := json.Marshal(pipelineSpec)
-	Expect(err).ShouldNot(HaveOccurred())
-
-	pipelineRollout := &apiv1.PipelineRollout{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "numaplane.numaproj.io/v1alpha1",
-			Kind:       "PipelineRollout",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		Spec: apiv1.PipelineRolloutSpec{
-			Pipeline: apiv1.Pipeline{
-				Spec: runtime.RawExtension{
-					Raw: pipelineSpecRaw,
-				},
-			},
-		},
-	}
-
-	return pipelineRollout
-
-}
-
-func createNumaflowControllerRolloutSpec(name, namespace string) *apiv1.NumaflowControllerRollout {
-
-	controllerRollout := &apiv1.NumaflowControllerRollout{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "numaplane.numaproj.io/v1alpha1",
-			Kind:       "NumaflowControllerRollout",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: apiv1.NumaflowControllerRolloutSpec{
-			Controller: apiv1.Controller{Version: initialNumaflowControllerVersion},
-		},
-	}
-
-	return controllerRollout
-
-}
-
-func createISBServiceRolloutSpec(name, namespace string) *apiv1.ISBServiceRollout {
-
-	rawSpec, err := json.Marshal(isbServiceSpec)
-	Expect(err).ShouldNot(HaveOccurred())
-
-	isbServiceRollout := &apiv1.ISBServiceRollout{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "numaplane.numaproj.io/v1alpha1",
-			Kind:       "ISBServiceRollout",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: apiv1.ISBServiceRolloutSpec{
-			InterStepBufferService: apiv1.InterStepBufferService{
-				Spec: runtime.RawExtension{
-					Raw: rawSpec,
-				},
-			},
-		},
-	}
-
-	return isbServiceRollout
-
-}
-
-func createMonoVertexRolloutSpec(name, namespace string) *apiv1.MonoVertexRollout {
-
-	rawSpec, err := json.Marshal(initialMonoVertexSpec)
-	Expect(err).ShouldNot(HaveOccurred())
-
-	monoVertexRollout := &apiv1.MonoVertexRollout{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "numaplane.numaproj.io/v1alpha1",
-			Kind:       "MonoVertexRollout",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: apiv1.MonoVertexRolloutSpec{
-			MonoVertex: apiv1.MonoVertex{
-				Spec: runtime.RawExtension{
-					Raw: rawSpec,
-				},
-			},
-		},
-	}
-
-	return monoVertexRollout
-}

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -264,7 +264,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should update the child Pipeline if the PipelineRollout is updated", func() {
 
-		updatePipelineRollout(pipelineRolloutName, updatedPipelineSpec, numaflowv1.PipelinePhaseRunning)
+		updatePipelineRollout(pipelineRolloutName, updatedPipelineSpec, numaflowv1.PipelinePhaseRunning, true)
 
 	})
 
@@ -359,7 +359,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		document("setting desiredPhase=Paused")
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhasePaused
 
-		updatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhasePaused)
+		updatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhasePaused, false)
 
 		document("verifying Pipeline stays in paused or otherwise pausing")
 		Consistently(func() bool {
@@ -381,13 +381,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	time.Sleep(2 * time.Second)
 
-	// how to use update pipelinerollout function in the same fashion here
 	It("Should resume the Pipeline if user requests it", func() {
 
 		document("setting desiredPhase=Running")
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhaseRunning
 
-		updatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhaseRunning)
+		updatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhaseRunning, false)
 	})
 
 	It("Should pause the MonoVertex if user requests it", func() {

--- a/tests/e2e/functional_test.go
+++ b/tests/e2e/functional_test.go
@@ -185,6 +185,7 @@ func TestFunctionalE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	BeforeSuite(func() {
+		// this must be set for all tests to run
 		upgradeStrategy = getUpgradeStrategy()
 		Expect(upgradeStrategy.IsValid()).To(BeTrue())
 		beforeSuiteSetup()

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -322,7 +322,7 @@ func updateISBServiceRollout(isbServiceRolloutName, pipelineRolloutName string, 
 		return rollout, nil
 	})
 
-	if upgradeStrategy == config.PPNDStrategyID && dataLoss == true {
+	if upgradeStrategy == config.PPNDStrategyID && dataLoss {
 
 		document("Verify that in-progress-strategy gets set to PPND")
 		verifyInProgressStrategyISBService(Namespace, isbServiceRolloutName, apiv1.UpgradeStrategyPPND)
@@ -343,7 +343,7 @@ func updateISBServiceRollout(isbServiceRolloutName, pipelineRolloutName string, 
 
 	}
 
-	if upgradeStrategy == config.PPNDStrategyID && dataLoss == false {
+	if upgradeStrategy == config.PPNDStrategyID && !dataLoss {
 		document("Verify that dependent Pipeline is not paused when an update to ISBService not requiring pause is made")
 		verifyNotPausing := func() bool {
 			_, _, retrievedPipelineStatus, err := getPipelineSpecAndStatus(Namespace, pipelineRolloutName)

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -312,7 +312,13 @@ func deleteISBServiceRollout(name string) {
 	}).WithTimeout(testTimeout).Should(BeTrue(), "The ISBService should have been deleted but it was found.")
 }
 
-func updateISBServiceRollout(isbServiceRolloutName, pipelineRolloutName string, newSpec numaflowv1.InterStepBufferServiceSpec, f func(numaflowv1.InterStepBufferServiceSpec) bool, dataLoss bool) {
+// TODO: replace pipelineRolloutName with an array of names to check that each is paused
+// pipelineRolloutName is pipelinerollout and child pipeline that may be checked to see if it is pausing or not after update
+// newSpec is the updated spec of the ISBService defined in the rollout
+// verifySpecFunc is passed to the verifyISBServiceSpec func which verifies the ISBService spec defined in the updated rollout
+// matches what we expect
+// dataLoss determines if we will need to check if pipelines pause or not for the update
+func updateISBServiceRollout(isbServiceRolloutName, pipelineRolloutName string, newSpec numaflowv1.InterStepBufferServiceSpec, verifySpecFunc func(numaflowv1.InterStepBufferServiceSpec) bool, dataLoss bool) {
 
 	rawSpec, err := json.Marshal(newSpec)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -365,7 +371,7 @@ func updateISBServiceRollout(isbServiceRolloutName, pipelineRolloutName string, 
 		Consistently(verifyNotPausing, 30*time.Second).Should(BeTrue())
 	}
 
-	verifyISBServiceSpec(Namespace, isbServiceRolloutName, f)
+	verifyISBServiceSpec(Namespace, isbServiceRolloutName, verifySpecFunc)
 
 	verifyISBSvcRolloutReady(isbServiceRolloutName)
 	verifyISBSvcReady(Namespace, isbServiceRolloutName, 3)

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -2,9 +2,12 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -263,4 +266,114 @@ func startMonoVertexRolloutWatches() {
 
 	wg.Add(1)
 	go watchMonoVertex()
+}
+
+// shared functions
+
+// creates MonoVertexRollout of a given spec/name and makes sure it's running
+func createMonoVertexRollout(name, namespace string, spec numaflowv1.MonoVertexSpec) {
+
+	monoVertexRolloutSpec := createMonoVertexRolloutSpec(name, namespace, spec)
+	_, err := monoVertexRolloutClient.Create(ctx, monoVertexRolloutSpec, metav1.CreateOptions{})
+	Expect(err).ShouldNot(HaveOccurred())
+
+	document("Verifying that the MonoVertexRollout was created")
+	Eventually(func() error {
+		_, err := monoVertexRolloutClient.Get(ctx, name, metav1.GetOptions{})
+		return err
+	}, testTimeout, testPollingInterval).Should(Succeed())
+
+	document("Verifying that the MonoVertex was created")
+	verifyMonoVertexSpec(Namespace, name, func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec) bool {
+		return spec.Source != nil
+	})
+
+	verifyMonoVertexRolloutReady(name)
+
+	verifyMonoVertexReady(namespace, name)
+
+}
+
+func createMonoVertexRolloutSpec(name, namespace string, spec numaflowv1.MonoVertexSpec) *apiv1.MonoVertexRollout {
+
+	rawSpec, err := json.Marshal(spec)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	monoVertexRollout := &apiv1.MonoVertexRollout{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "numaplane.numaproj.io/v1alpha1",
+			Kind:       "MonoVertexRollout",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: apiv1.MonoVertexRolloutSpec{
+			MonoVertex: apiv1.MonoVertex{
+				Spec: runtime.RawExtension{
+					Raw: rawSpec,
+				},
+			},
+		},
+	}
+
+	return monoVertexRollout
+}
+
+// delete MonoVertexRollout and verify deletion
+func deleteMonoVertexRollout(name string) {
+	document("Deleting MonoVertexRollout")
+	err := monoVertexRolloutClient.Delete(ctx, name, metav1.DeleteOptions{})
+	Expect(err).ShouldNot(HaveOccurred())
+
+	document("Verifying MonoVertexRollout deletion")
+	Eventually(func() bool {
+		_, err := monoVertexRolloutClient.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				Fail("An unexpected error occurred when fetching the MonoVertexRollout: " + err.Error())
+			}
+			return false
+		}
+		return true
+	}).WithTimeout(testTimeout).Should(BeFalse(), "The MonoVertexRollout should have been deleted but it was found.")
+
+	document("Verifying MonoVertex deletion")
+	Eventually(func() bool {
+		list, err := dynamicClient.Resource(getGVRForMonoVertex()).Namespace(Namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false
+		}
+		if len(list.Items) == 0 {
+			return true
+		}
+		return false
+	}).WithTimeout(testTimeout).Should(BeTrue(), "The MonoVertex should have been deleted but it was found.")
+}
+
+func updateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, expectedPhase numaflowv1.MonoVertexPhase) {
+
+	rawSpec, err := json.Marshal(newSpec)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	// update the MonoVertexRollout
+	updateMonoVertexRolloutInK8S(name, func(rollout apiv1.MonoVertexRollout) (apiv1.MonoVertexRollout, error) {
+		rollout.Spec.MonoVertex.Spec.Raw = rawSpec
+		return rollout, nil
+	})
+
+	document("verifying MonoVertexRollout spec deployed")
+	verifyMonoVertexRolloutDeployed(name)
+	if expectedPhase == numaflowv1.MonoVertexPhaseRunning {
+		verifyMonoVertexRolloutHealthy(name)
+	}
+
+	verifyInProgressStrategy(name, apiv1.UpgradeStrategyNoOp)
+
+	if expectedPhase == numaflowv1.MonoVertexPhasePaused {
+		verifyMonoVertexPaused(Namespace, name)
+	} else {
+		verifyMonoVertexReady(Namespace, name)
+	}
+
 }

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -351,7 +351,7 @@ func deleteMonoVertexRollout(name string) {
 	}).WithTimeout(testTimeout).Should(BeTrue(), "The MonoVertex should have been deleted but it was found.")
 }
 
-func updateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, expectedPhase numaflowv1.MonoVertexPhase) {
+func updateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, expectedFinalPhase numaflowv1.MonoVertexPhase) {
 
 	rawSpec, err := json.Marshal(newSpec)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -364,13 +364,13 @@ func updateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, exp
 
 	document("verifying MonoVertexRollout spec deployed")
 	verifyMonoVertexRolloutDeployed(name)
-	if expectedPhase == numaflowv1.MonoVertexPhaseRunning {
+	if expectedFinalPhase == numaflowv1.MonoVertexPhaseRunning {
 		verifyMonoVertexRolloutHealthy(name)
 	}
 
 	verifyInProgressStrategy(name, apiv1.UpgradeStrategyNoOp)
 
-	if expectedPhase == numaflowv1.MonoVertexPhasePaused {
+	if expectedFinalPhase == numaflowv1.MonoVertexPhasePaused {
 		verifyMonoVertexPaused(Namespace, name)
 	} else {
 		verifyMonoVertexReady(Namespace, name)

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -193,6 +193,11 @@ func deleteNumaflowControllerRollout() {
 	}).WithTimeout(testTimeout).Should(BeFalse(), "The deployment should have been deleted but it was found.")
 }
 
+// TODO: pipelinerolloutname should be an array of names to verify multiple pipelines should be paused
+// originalVersion is the original version of the current NumaflowController defined in the rollout
+// newVersion is the new version the updated NumaflowController should have if it is a valid version
+// pipelineRolloutName is the pipeline we check to be sure that it is pausing during the update
+// valid boolean indicates if newVersion is a valid version or not which will change the check we make
 func updateNumaflowControllerRollout(originalVersion, newVersion, pipelineRolloutName string, valid bool) {
 	// new NumaflowController spec
 	updatedNumaflowControllerROSpec := apiv1.NumaflowControllerRolloutSpec{

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -428,7 +428,7 @@ func deletePipelineRollout(name string) {
 }
 
 // update PipelineRollout and verify correct process
-func updatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expectedPhase numaflowv1.PipelinePhase, dataLoss bool) {
+func updatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expectedFinalPhase numaflowv1.PipelinePhase, dataLoss bool) {
 
 	document("Updating Pipeline spec in PipelineRollout")
 	rawSpec, err := json.Marshal(newSpec)
@@ -462,13 +462,13 @@ func updatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expecte
 	})
 
 	verifyPipelineRolloutDeployed(name)
-	if expectedPhase == numaflowv1.PipelinePhaseRunning {
+	if expectedFinalPhase == numaflowv1.PipelinePhaseRunning {
 		verifyPipelineRolloutHealthy(name)
 	}
 
 	verifyInProgressStrategy(name, apiv1.UpgradeStrategyNoOp)
 
-	if expectedPhase == numaflowv1.PipelinePhasePaused {
+	if expectedFinalPhase == numaflowv1.PipelinePhasePaused {
 		verifyPipelinePaused(Namespace, name)
 	} else {
 		verifyPipelineRunning(Namespace, name)

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -428,7 +428,7 @@ func deletePipelineRollout(name string) {
 }
 
 // update PipelineRollout and verify correct process
-func updatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expectedPhase numaflowv1.PipelinePhase) {
+func updatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expectedPhase numaflowv1.PipelinePhase, dataLoss bool) {
 
 	document("Updating Pipeline spec in PipelineRollout")
 	rawSpec, err := json.Marshal(newSpec)
@@ -440,7 +440,8 @@ func updatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expecte
 		return rollout, nil
 	})
 
-	if upgradeStrategy == config.PPNDStrategyID {
+	// no data loss OR system pause
+	if upgradeStrategy == config.PPNDStrategyID && dataLoss {
 
 		document("Verify that in-progress-strategy gets set to PPND")
 		verifyInProgressStrategy(name, apiv1.UpgradeStrategyPPND)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #528 

### Modifications

This PR largely breaks down the current functional test suite and moves the create/update/deletion functions for each respective rollout to their own file. These functions are now able to be used in different test suites we can build out for different upgrade strategies or any other cases that shouldn't require us to run the whole functional test.

We can further improve on this by introducing new shared functions but these should be sufficient to create new test suites now.

### Verification

Running `make test-e2e` multiple times locally with no strategy and PPND. Using CI for final verification.

### Backward incompatibilities

None.
