### PR TITLE
fix: Set foreground deletion policy for rollout deletion

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35 # If we start getting error in CI as "The operation was canceled", we need to increase this value.
     strategy:
       fail-fast: false
       matrix:

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -202,7 +202,7 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 		numaLogger.Info("Deleting ISBServiceRollout")
 		if controllerutil.ContainsFinalizer(isbServiceRollout, common.FinalizerName) {
 			ppnd.GetPauseModule().DeletePauseRequest(isbsvcKey)
-			// Set the foreground deletion policy
+			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
 			foreground := metav1.DeletePropagationForeground
 			if err := r.client.Delete(ctx, isbServiceRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return ctrl.Result{}, err

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -202,6 +202,11 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 		numaLogger.Info("Deleting ISBServiceRollout")
 		if controllerutil.ContainsFinalizer(isbServiceRollout, common.FinalizerName) {
 			ppnd.GetPauseModule().DeletePauseRequest(isbsvcKey)
+			// Set the foreground deletion policy
+			foreground := metav1.DeletePropagationForeground
+			if err := r.client.Delete(ctx, isbServiceRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
+				return ctrl.Result{}, err
+			}
 			controllerutil.RemoveFinalizer(isbServiceRollout, common.FinalizerName)
 		}
 		// generate metrics for ISB Service deletion.

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -195,6 +195,11 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 	if !monoVertexRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting MonoVertexRollout")
 		if controllerutil.ContainsFinalizer(monoVertexRollout, common.FinalizerName) {
+			// Set the foreground deletion policy
+			foreground := metav1.DeletePropagationForeground
+			if err := r.client.Delete(ctx, monoVertexRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
+				return ctrl.Result{}, err
+			}
 			controllerutil.RemoveFinalizer(monoVertexRollout, common.FinalizerName)
 		}
 		// generate metrics for MonoVertex deletion

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -195,7 +195,7 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 	if !monoVertexRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting MonoVertexRollout")
 		if controllerutil.ContainsFinalizer(monoVertexRollout, common.FinalizerName) {
-			// Set the foreground deletion policy
+			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
 			foreground := metav1.DeletePropagationForeground
 			if err := r.client.Delete(ctx, monoVertexRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return ctrl.Result{}, err

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -230,9 +230,9 @@ func (r *NumaflowControllerReconciler) reconcile(
 		numaLogger.Info("Deleting NumaflowController")
 		r.recorder.Eventf(controller, corev1.EventTypeNormal, "Deleting", "Deleting NumaflowController")
 		if controllerutil.ContainsFinalizer(controller, common.FinalizerName) {
-			// Check if dependent resources are deleted, if not then requeue after 5 seconds
+			// Check if dependent resources are deleted, if not then requeue
 			if !r.areDependentResourcesDeleted(ctx, controller) {
-				numaLogger.Warn("Dependent resources are not deleted yet, requeue after 5 seconds")
+				numaLogger.Warn("Dependent resources are not deleted yet, requeue...")
 				return ctrl.Result{Requeue: true}, nil
 			}
 			controllerutil.RemoveFinalizer(controller, common.FinalizerName)
@@ -719,17 +719,17 @@ func (r *NumaflowControllerReconciler) ErrorHandler(numaflowController *apiv1.Nu
 
 // areDependentResourcesDeleted checks if dependent resources are deleted.
 func (r *NumaflowControllerReconciler) areDependentResourcesDeleted(ctx context.Context, controller *apiv1.NumaflowController) bool {
-	pipelineList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "pipelines",
+	pipelineList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, common.NumaflowPipelineKind,
 		controller.Namespace, common.LabelKeyParentRollout, "")
 	if err != nil {
 		return false
 	}
-	monoVertexList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "monovertices",
+	monoVertexList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, common.NumaflowMonoVertexKind,
 		controller.Namespace, common.LabelKeyParentRollout, "")
 	if err != nil {
 		return false
 	}
-	isbServiceList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, "interstepbufferservices",
+	isbServiceList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, common.NumaflowISBServiceKind,
 		controller.Namespace, common.LabelKeyParentRollout, "")
 	if err != nil {
 		return false

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -722,17 +722,26 @@ func (r *NumaflowControllerReconciler) areDependentResourcesDeleted(ctx context.
 	pipelineList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, common.NumaflowPipelineKind,
 		controller.Namespace, common.LabelKeyParentRollout, "")
 	if err != nil {
-		return false
+		if !apierrors.IsNotFound(err) {
+			return false
+		}
+		pipelineList = &unstructured.UnstructuredList{} // Assume it as an empty list
 	}
 	monoVertexList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, common.NumaflowMonoVertexKind,
 		controller.Namespace, common.LabelKeyParentRollout, "")
 	if err != nil {
-		return false
+		if !apierrors.IsNotFound(err) {
+			return false
+		}
+		monoVertexList = &unstructured.UnstructuredList{} // Assume it as an empty list
 	}
 	isbServiceList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, common.NumaflowISBServiceKind,
 		controller.Namespace, common.LabelKeyParentRollout, "")
 	if err != nil {
-		return false
+		if !apierrors.IsNotFound(err) {
+			return false
+		}
+		isbServiceList = &unstructured.UnstructuredList{} // Assume it as an empty list
 	}
 	if len(pipelineList.Items)+len(monoVertexList.Items)+len(isbServiceList.Items) == 0 {
 		return true

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -34,6 +34,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	yamlserializer "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
@@ -230,6 +231,11 @@ func (r *NumaflowControllerReconciler) reconcile(
 		numaLogger.Info("Deleting NumaflowController")
 		r.recorder.Eventf(controller, corev1.EventTypeNormal, "Deleting", "Deleting NumaflowController")
 		if controllerutil.ContainsFinalizer(controller, common.FinalizerName) {
+			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
+			foreground := metav1.DeletePropagationForeground
+			if err := r.client.Delete(ctx, controller, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
+				return ctrl.Result{}, err
+			}
 			// Check if dependent resources are deleted, if not then requeue
 			if ok, err := r.areDependentResourcesDeleted(ctx, controller); !ok || err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete dependent resources: %v", err)

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -199,7 +199,7 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 		r.recorder.Eventf(nfcRollout, corev1.EventTypeNormal, "Deleting", "Deleting NumaflowControllerRollout")
 		if controllerutil.ContainsFinalizer(nfcRollout, common.FinalizerName) {
 			ppnd.GetPauseModule().DeletePauseRequest(controllerKey)
-			// Set the foreground deletion policy
+			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
 			foreground := metav1.DeletePropagationForeground
 			if err := r.client.Delete(ctx, nfcRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return ctrl.Result{}, err

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -199,6 +199,11 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 		r.recorder.Eventf(nfcRollout, corev1.EventTypeNormal, "Deleting", "Deleting NumaflowControllerRollout")
 		if controllerutil.ContainsFinalizer(nfcRollout, common.FinalizerName) {
 			ppnd.GetPauseModule().DeletePauseRequest(controllerKey)
+			// Set the foreground deletion policy
+			foreground := metav1.DeletePropagationForeground
+			if err := r.client.Delete(ctx, nfcRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
+				return ctrl.Result{}, err
+			}
 			controllerutil.RemoveFinalizer(nfcRollout, common.FinalizerName)
 		}
 

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -342,6 +342,11 @@ func (r *PipelineRolloutReconciler) reconcile(
 	if !pipelineRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting PipelineRollout")
 		if controllerutil.ContainsFinalizer(pipelineRollout, common.FinalizerName) {
+			// Set the foreground deletion policy
+			foreground := metav1.DeletePropagationForeground
+			if err := r.client.Delete(ctx, pipelineRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
+				return 0, nil, err
+			}
 			controllerutil.RemoveFinalizer(pipelineRollout, common.FinalizerName)
 		}
 		// generate the metrics for the Pipeline deletion.

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -342,7 +342,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 	if !pipelineRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting PipelineRollout")
 		if controllerutil.ContainsFinalizer(pipelineRollout, common.FinalizerName) {
-			// Set the foreground deletion policy
+			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
 			foreground := metav1.DeletePropagationForeground
 			if err := r.client.Delete(ctx, pipelineRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return 0, nil, err

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -45,7 +45,7 @@ var (
 	testEnv             *envtest.Environment
 	ctx                 context.Context
 	cancel              context.CancelFunc
-	suiteTimeout        = 30 * time.Minute // Note: if we start seeing "client rate limiter: context deadline exceeded", we need to increase this value
+	suiteTimeout        = 35 * time.Minute // Note: if we start seeing "client rate limiter: context deadline exceeded", we need to increase this value
 	testTimeout         = 4 * time.Minute  // Note: this timeout needs to be large enough to allow for delayed child resource healthiness assessment (current delay is 2 minutes with a 1 minute reassess window)
 	testPollingInterval = 10 * time.Millisecond
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/510

### Modifications
- Set foreground deletion policy for pipeline, monovertex, isbService and Numaflow Controller

### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->
- Verified in local Kubernetes cluster

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
