### PR TITLE
fix: Update Numaplane health metrics

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -189,11 +189,7 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 	numaLogger := logger.FromContext(ctx)
 
 	defer func() {
-		if isbServiceRollout.Status.IsHealthy() {
-			r.customMetrics.ISBServicesRolloutHealth.WithLabelValues(isbServiceRollout.Namespace, isbServiceRollout.Name, string(isbServiceRollout.Status.Phase)).Set(1)
-		} else {
-			r.customMetrics.ISBServicesRolloutHealth.WithLabelValues(isbServiceRollout.Namespace, isbServiceRollout.Name, string(isbServiceRollout.Status.Phase)).Set(0)
-		}
+		r.customMetrics.SetISBServicesRolloutHealth(isbServiceRollout.Namespace, isbServiceRollout.Name, string(isbServiceRollout.Status.Phase))
 	}()
 
 	isbsvcKey := ppnd.GetPauseModule().GetISBServiceKey(isbServiceRollout.Namespace, isbServiceRollout.Name)
@@ -209,7 +205,7 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 		// generate metrics for ISB Service deletion.
 		r.customMetrics.DecISBServiceRollouts(isbServiceRollout.Name, isbServiceRollout.Namespace)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerISBSVCRollout, "delete").Observe(time.Since(startTime).Seconds())
-		r.customMetrics.ISBServicesRolloutHealth.DeleteLabelValues(isbServiceRollout.Namespace, isbServiceRollout.Name, string(isbServiceRollout.Status.Phase))
+		r.customMetrics.DeleteISBServicesRolloutHealth(isbServiceRollout.Namespace, isbServiceRollout.Name)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -187,11 +187,7 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 	numaLogger := logger.FromContext(ctx)
 
 	defer func() {
-		if monoVertexRollout.Status.IsHealthy() {
-			r.customMetrics.MonoVerticesRolloutHealth.WithLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name, string(monoVertexRollout.Status.Phase)).Set(1)
-		} else {
-			r.customMetrics.MonoVerticesRolloutHealth.WithLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name, string(monoVertexRollout.Status.Phase)).Set(0)
-		}
+		r.customMetrics.SetMonoVerticesRolloutHealth(monoVertexRollout.Namespace, monoVertexRollout.Name, string(monoVertexRollout.Status.Phase))
 	}()
 
 	// remove finalizers if monoVertexRollout is being deleted
@@ -203,7 +199,7 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 		// generate metrics for MonoVertex deletion
 		r.customMetrics.DecMonoVertexRollouts(monoVertexRollout.Name, monoVertexRollout.Namespace)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerMonoVertexRollout, "delete").Observe(time.Since(startTime).Seconds())
-		r.customMetrics.MonoVerticesRolloutHealth.DeleteLabelValues(monoVertexRollout.Namespace, monoVertexRollout.Name, string(monoVertexRollout.Status.Phase))
+		r.customMetrics.DeleteMonoVerticesRolloutHealth(monoVertexRollout.Namespace, monoVertexRollout.Name)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -223,11 +223,7 @@ func (r *NumaflowControllerReconciler) reconcile(
 	numaLogger := logger.FromContext(ctx)
 
 	defer func() {
-		if controller.Status.IsHealthy() {
-			r.customMetrics.NumaflowControllersHealth.WithLabelValues(controller.Namespace, controller.Name, string(controller.Status.Phase)).Set(1)
-		} else {
-			r.customMetrics.NumaflowControllersHealth.WithLabelValues(controller.Namespace, controller.Name, string(controller.Status.Phase)).Set(0)
-		}
+		r.customMetrics.SetNumaflowControllersHealth(controller.Namespace, controller.Name, string(controller.Status.Phase))
 	}()
 
 	if !controller.DeletionTimestamp.IsZero() {
@@ -244,7 +240,7 @@ func (r *NumaflowControllerReconciler) reconcile(
 
 		// generate the metrics for the numaflow controller deletion
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerNumaflowController, "delete").Observe(time.Since(syncStartTime).Seconds())
-		r.customMetrics.NumaflowControllersHealth.DeleteLabelValues(controller.Namespace, controller.Name, string(controller.Status.Phase))
+		r.customMetrics.DeleteNumaflowControllersHealth(controller.Namespace, controller.Name)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -189,11 +189,7 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 	numaLogger := logger.FromContext(ctx)
 
 	defer func() {
-		if nfcRollout.Status.IsHealthy() {
-			r.customMetrics.NumaflowControllerRolloutsHealth.WithLabelValues(nfcRollout.Namespace, nfcRollout.Name, string(nfcRollout.Status.Phase)).Set(1)
-		} else {
-			r.customMetrics.NumaflowControllerRolloutsHealth.WithLabelValues(nfcRollout.Namespace, nfcRollout.Name, string(nfcRollout.Status.Phase)).Set(0)
-		}
+		r.customMetrics.SetNumaflowControllerRolloutsHealth(nfcRollout.Namespace, nfcRollout.Name, string(nfcRollout.Status.Phase))
 	}()
 
 	controllerKey := ppnd.GetPauseModule().GetNumaflowControllerKey(namespace)
@@ -209,8 +205,7 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 		// generate the metrics for the numaflow controller rollout deletion.
 		r.customMetrics.NumaflowControllerRolloutsRunning.DeleteLabelValues(nfcRollout.Name, nfcRollout.Namespace, nfcRollout.Spec.Controller.Version)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerNumaflowControllerRollout, "delete").Observe(time.Since(startTime).Seconds())
-		r.customMetrics.NumaflowControllerRolloutsHealth.DeleteLabelValues(nfcRollout.Namespace, nfcRollout.Name, string(nfcRollout.Status.Phase))
-
+		r.customMetrics.DeleteNumaflowControllerRolloutsHealth(nfcRollout.Namespace, nfcRollout.Name)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -334,11 +334,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 ) (time.Duration, *unstructured.Unstructured, error) {
 	numaLogger := logger.FromContext(ctx)
 	defer func() {
-		if pipelineRollout.Status.IsHealthy() {
-			r.customMetrics.PipelinesRolloutHealth.WithLabelValues(pipelineRollout.Namespace, pipelineRollout.Name, string(pipelineRollout.Status.Phase)).Set(1)
-		} else {
-			r.customMetrics.PipelinesRolloutHealth.WithLabelValues(pipelineRollout.Namespace, pipelineRollout.Name, string(pipelineRollout.Status.Phase)).Set(0)
-		}
+		r.customMetrics.SetPipelineRolloutHealth(pipelineRollout.Namespace, pipelineRollout.Name, string(pipelineRollout.Status.Phase))
 	}()
 
 	// is PipelineRollout being deleted? need to remove the finalizer, so it can
@@ -351,7 +347,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 		// generate the metrics for the Pipeline deletion.
 		r.customMetrics.DecPipelineROsRunning(pipelineRollout.Name, pipelineRollout.Namespace)
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerPipelineRollout, "delete").Observe(time.Since(syncStartTime).Seconds())
-		r.customMetrics.PipelinesRolloutHealth.DeleteLabelValues(pipelineRollout.Namespace, pipelineRollout.Name, string(pipelineRollout.Status.Phase))
+		r.customMetrics.DeletePipelineRolloutHealth(pipelineRollout.Namespace, pipelineRollout.Name)
 		return 0, nil, nil
 	}
 

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -6,6 +6,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
 type CustomMetrics struct {
@@ -99,6 +101,7 @@ const (
 )
 
 var (
+	phases         = []string{apiv1.PhasePending.String(), apiv1.PhaseDeployed.String(), apiv1.PhaseFailed.String()}
 	defaultLabels  = prometheus.Labels{LabelIntuit: "true"}
 	pipelineLock   sync.Mutex
 	isbServiceLock sync.Mutex
@@ -429,5 +432,95 @@ func (m *CustomMetrics) DecMonoVertexRollouts(name, namespace string) {
 	delete(m.MonoVerticesCounterMap[namespace], name)
 	for ns, monoVertices := range m.MonoVerticesCounterMap {
 		m.MonoVertexRolloutsRunning.WithLabelValues(ns).Set(float64(len(monoVertices)))
+	}
+}
+
+// SetPipelineRolloutHealth sets the health of the pipeline rollout
+func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase string) {
+	for _, phase := range phases {
+		if phase == currentPhase {
+			m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase).Set(1)
+		} else {
+			m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase).Set(0)
+		}
+	}
+}
+
+// DeletePipelineRolloutHealth deletes the pipeline rollout health metric
+func (m *CustomMetrics) DeletePipelineRolloutHealth(namespace, name string) {
+	for _, phase := range phases {
+		m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase)
+	}
+}
+
+// SetISBServicesRolloutHealth sets the health of the ISB service rollout
+func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhase string) {
+	for _, phase := range phases {
+		if phase == currentPhase {
+			m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase).Set(1)
+		} else {
+			m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase).Set(0)
+		}
+	}
+}
+
+// DeleteISBServicesRolloutHealth deletes the ISB service rollout health metric
+func (m *CustomMetrics) DeleteISBServicesRolloutHealth(namespace, name string) {
+	for _, phase := range phases {
+		m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase)
+	}
+}
+
+// SetMonoVerticesRolloutHealth sets the health of the monovertex rollout
+func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPhase string) {
+	for _, phase := range phases {
+		if phase == currentPhase {
+			m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase).Set(1)
+		} else {
+			m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase).Set(0)
+		}
+	}
+}
+
+// DeleteMonoVerticesRolloutHealth deletes the monovertex rollout health metric
+func (m *CustomMetrics) DeleteMonoVerticesRolloutHealth(namespace, name string) {
+	for _, phase := range phases {
+		m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase)
+	}
+}
+
+// SetNumaflowControllerRolloutsHealth sets the health of the numaflow controller rollout
+func (m *CustomMetrics) SetNumaflowControllerRolloutsHealth(namespace, name, currentPhase string) {
+	for _, phase := range phases {
+		if phase == currentPhase {
+			m.NumaflowControllerRolloutsHealth.WithLabelValues(namespace, name, phase).Set(1)
+		} else {
+			m.NumaflowControllerRolloutsHealth.WithLabelValues(namespace, name, phase).Set(0)
+		}
+	}
+}
+
+// DeleteNumaflowControllerRolloutsHealth deletes the numaflow controller rollout health metric
+func (m *CustomMetrics) DeleteNumaflowControllerRolloutsHealth(namespace, name string) {
+	for _, phase := range phases {
+		m.NumaflowControllerRolloutsHealth.DeleteLabelValues(namespace, name, phase)
+	}
+}
+
+// SetNumaflowControllersHealth sets the health of the numaflow controller
+func (m *CustomMetrics) SetNumaflowControllersHealth(namespace, name, currentPhase string) {
+	for _, phase := range phases {
+		if phase == currentPhase {
+			m.NumaflowControllersHealth.WithLabelValues(namespace, name, phase).Set(1)
+		} else {
+			m.NumaflowControllersHealth.WithLabelValues(namespace, name, phase).Set(0)
+		}
+	}
+}
+
+// DeleteNumaflowControllersHealth deletes the numaflow controller health metric
+func (m *CustomMetrics) DeleteNumaflowControllersHealth(namespace, name string) {
+	for _, phase := range phases {
+		m.NumaflowControllersHealth.DeleteLabelValues(namespace, name, phase)
 	}
 }

--- a/pkg/apis/numaplane/v1alpha1/status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/status_types.go
@@ -30,6 +30,10 @@ type ConditionType string
 // +kubebuilder:validation:Enum="";Pending;Deployed;Failed
 type Phase string
 
+func (p Phase) String() string {
+	return string(p)
+}
+
 const (
 	// PhasePending indicates that a reconciliation operation on the rollout spec has started.
 	// In this phase, the reconciliation process could take some time and/or happen with multiple reconciliation calls.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

- Update Pipeline, ISBService, MonoVertex, NumaflowController_rollout and NumaflowController health metrics according to below format:
```
    // Example: Set the state to "deployed"
    pipelineRolloutHealth.WithLabelValues("deployed",...).Set(1)
    pipelineRolloutHealth.WithLabelValues("pending",...).Set(0)
    pipelineRolloutHealth.WithLabelValues("failed",...).Set(0)

    // Example: Change the state to "pending"
    pipelineRolloutHealth.WithLabelValues("deployed",...).Set(0)
    pipelineRolloutHealth.WithLabelValues("pending",...).Set(1)
    pipelineRolloutHealth.WithLabelValues("failed",...).Set(0)

    // Example: Change the state to "failed"
    pipelineRolloutHealth.WithLabelValues("deployed",...).Set(0)
    pipelineRolloutHealth.WithLabelValues("pending",...).Set(0)
    pipelineRolloutHealth.WithLabelValues("failed",...).Set(1)
```


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
