### PR TITLE
chore: promoted MonoVertex/Pipeline scaling logic adjustments and fixes

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -419,7 +419,7 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 			return 0, fmt.Errorf("error getting the live ISBServiceRollout for assessment processing: %w", err)
 		}
 
-		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, isbServiceRollout, liveISBServiceRollout, existingISBServiceDef, isbServiceNeedsToUpdate, true, r, r.client)
+		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, isbServiceRollout, liveISBServiceRollout, existingISBServiceDef, isbServiceNeedsToUpdate, r, r.client)
 		if err != nil {
 			return 0, fmt.Errorf("Error processing isbsvc with progressive: %s", err.Error())
 		}

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -2,7 +2,6 @@ package isbservicerollout
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/numaproj/numaplane/internal/common"
@@ -114,22 +113,22 @@ func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 	return apiv1.AssessmentResultSuccess, nil
 }
 
-// This does not need to be implemented for ISBServiceRollout
-func (r *ISBServiceRolloutReconciler) ScaleDownPromotedChildSourceVertices(
+func (r *ISBServiceRolloutReconciler) PreUpgradePromotedChildProcessing(
 	ctx context.Context,
 	rolloutObject ctlrcommon.RolloutObject,
+	liveRolloutObject ctlrcommon.RolloutObject,
 	promotedChildDef *unstructured.Unstructured,
 	c client.Client,
-) (map[string]apiv1.ScaleValues, bool, error) {
-	return nil, false, errors.New("not implemented for ISBServiceRollout")
+) (bool, error) {
+	return false, nil
 }
 
-// This does not need to be implemented for ISBServiceRollout
-func (r *ISBServiceRolloutReconciler) ScalePromotedChildSourceVerticesToDesiredValues(
+func (r *ISBServiceRolloutReconciler) PostUpgradePromotedChildProcessing(
 	ctx context.Context,
 	rolloutObject ctlrcommon.RolloutObject,
+	liveRolloutObject ctlrcommon.RolloutObject,
 	promotedChildDef *unstructured.Unstructured,
 	c client.Client,
-) error {
-	return errors.New("not implemented for ISBServiceRollout")
+) (bool, error) {
+	return false, nil
 }

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -115,8 +115,7 @@ func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 
 func (r *ISBServiceRolloutReconciler) PreUpgradePromotedChildProcessing(
 	ctx context.Context,
-	rolloutObject ctlrcommon.RolloutObject,
-	liveRolloutObject ctlrcommon.RolloutObject,
+	rolloutPromotedChildStatus *apiv1.PromotedChildStatus,
 	promotedChildDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
@@ -125,8 +124,7 @@ func (r *ISBServiceRolloutReconciler) PreUpgradePromotedChildProcessing(
 
 func (r *ISBServiceRolloutReconciler) PostUpgradePromotedChildProcessing(
 	ctx context.Context,
-	rolloutObject ctlrcommon.RolloutObject,
-	liveRolloutObject ctlrcommon.RolloutObject,
+	rolloutPromotedChildStatus *apiv1.PromotedChildStatus,
 	promotedChildDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -113,7 +113,7 @@ func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 	return apiv1.AssessmentResultSuccess, nil
 }
 
-func (r *ISBServiceRolloutReconciler) PreUpgradePromotedChildProcessing(
+func (r *ISBServiceRolloutReconciler) ProcessPromotedChildPreUpgrade(
 	ctx context.Context,
 	rolloutPromotedChildStatus *apiv1.PromotedChildStatus,
 	promotedChildDef *unstructured.Unstructured,
@@ -122,7 +122,7 @@ func (r *ISBServiceRolloutReconciler) PreUpgradePromotedChildProcessing(
 	return false, nil
 }
 
-func (r *ISBServiceRolloutReconciler) PostUpgradePromotedChildProcessing(
+func (r *ISBServiceRolloutReconciler) ProcessPromotedChildPostUpgrade(
 	ctx context.Context,
 	rolloutPromotedChildStatus *apiv1.PromotedChildStatus,
 	promotedChildDef *unstructured.Unstructured,

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -340,7 +340,7 @@ func (r *MonoVertexRolloutReconciler) processExistingMonoVertex(ctx context.Cont
 			}
 		}
 
-		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, monoVertexRollout, liveMonoVertexRollout, existingMonoVertexDef, mvNeedsToUpdate, false, r, r.client)
+		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, monoVertexRollout, liveMonoVertexRollout, existingMonoVertexDef, mvNeedsToUpdate, r, r.client)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -95,7 +95,7 @@ func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPreUpgrade(
 	numaLogger.Debug("started pre-upgrade processing of promoted monovertex")
 
 	if rolloutPromotedChildStatus == nil {
-		rolloutPromotedChildStatus = &apiv1.PromotedChildStatus{Name: promotedChildDef.GetName()}
+		return true, errors.New("unable to perform pre-upgrade operations because the rollout does not have promotedChildStatus set")
 	}
 
 	// scaleDownMonoVertex either updates the promoted monovertex to scale down the pods or
@@ -142,14 +142,14 @@ func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPostUpgrade(
 		return true, errors.New("unable to perform post-upgrade operations because the rollout does not have promotedChildStatus set")
 	}
 
-	scaledToDesired, err := scaleMonoVertexToDesiredValues(ctx, rolloutPromotedChildStatus, promotedChildDef, c)
+	performedScaling, err := scaleMonoVertexToDesiredValues(ctx, rolloutPromotedChildStatus, promotedChildDef, c)
 	if err != nil {
 		return true, err
 	}
 
 	numaLogger.Debug("completed post-upgrade processing of promoted monovertex")
 
-	return scaledToDesired, nil
+	return performedScaling, nil
 }
 
 /*

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -102,14 +102,14 @@ func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPreUpgrade(
 	// retrieves the currently running pods to update the rolloutPromotedChildStatus scaleValues.
 	// This serves to make sure that the pods have been really scaled down before proceeding
 	// with the progressive upgrade.
-	scaledDown, err := scaleDownMonoVertex(ctx, rolloutPromotedChildStatus, promotedChildDef, c)
+	performedScaling, err := scaleDownMonoVertex(ctx, rolloutPromotedChildStatus, promotedChildDef, c)
 	if err != nil {
 		return true, err
 	}
 
 	numaLogger.Debug("completed pre-upgrade processing of promoted monovertex")
 
-	return scaledDown, nil
+	return performedScaling, nil
 }
 
 /*

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -153,7 +153,7 @@ func (r *MonoVertexRolloutReconciler) PostUpgradePromotedChildProcessing(
 
 /*
 scaleDownMonoVertex scales down the pods of a monovertex to half of the current count if not already scaled down.
-It checks if all source vertices are already scaled down and skips the operation if true.
+It checks if the monovertex was already scaled down and skips the operation if true.
 The function updates the scale values in the rollout status and adjusts the scale configuration
 of the promoted child definition. It ensures that the scale.min does not exceed the new scale.max.
 Returns a boolean indicating if scaling was performed and an error if any operation fails.

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -69,7 +69,7 @@ func (r *MonoVertexRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 }
 
 /*
-PreUpgradePromotedChildProcessing handles the pre-upgrade processing of a promoted monovertex.
+ProcessPromotedChildPreUpgrade handles the pre-upgrade processing of a promoted monovertex.
 It performs the following pre-upgrade operations:
 - it ensures that the promoted monovertex is scaled down before proceeding with a progressive upgrade.
 
@@ -83,14 +83,14 @@ Returns:
   - A boolean indicating whether we should requeue.
   - An error if any issues occur during processing.
 */
-func (r *MonoVertexRolloutReconciler) PreUpgradePromotedChildProcessing(
+func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPreUpgrade(
 	ctx context.Context,
 	rolloutPromotedChildStatus *apiv1.PromotedChildStatus,
 	promotedChildDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("PreUpgradePromotedChildProcessing").WithName("MonoVertexRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPreUpgrade").WithName("MonoVertexRollout")
 
 	numaLogger.Debug("started pre-upgrade processing of promoted monovertex")
 
@@ -113,7 +113,7 @@ func (r *MonoVertexRolloutReconciler) PreUpgradePromotedChildProcessing(
 }
 
 /*
-PostUpgradePromotedChildProcessing handles the post-upgrade processing of a promoted monovertex.
+ProcessPromotedChildPostUpgrade handles the post-upgrade processing of a promoted monovertex.
 It performs the following post-upgrade operations:
 - it restores the promoted monovertex scale values to the desired values retrieved from the rollout status.
 
@@ -127,14 +127,14 @@ Returns:
   - A boolean indicating whether we should requeue.
   - An error if any issues occur during processing.
 */
-func (r *MonoVertexRolloutReconciler) PostUpgradePromotedChildProcessing(
+func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPostUpgrade(
 	ctx context.Context,
 	rolloutPromotedChildStatus *apiv1.PromotedChildStatus,
 	promotedChildDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("PostUpgradePromotedChildProcessing").WithName("MonoVertexRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPostUpgrade").WithName("MonoVertexRollout")
 
 	numaLogger.Debug("started post-upgrade processing of promoted monovertex")
 

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -585,7 +585,7 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 			return 0, fmt.Errorf("error getting the live PipelineRollout for assessment processing: %w", err)
 		}
 
-		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, pipelineRollout, livePipelineRollout, existingPipelineDef, pipelineNeedsToUpdate, false, r, r.client)
+		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, pipelineRollout, livePipelineRollout, existingPipelineDef, pipelineNeedsToUpdate, r, r.client)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -114,7 +114,7 @@ func (r *PipelineRolloutReconciler) ProcessPromotedChildPreUpgrade(
 	numaLogger.Debug("started pre-upgrade processing of promoted pipeline")
 
 	if rolloutPromotedChildStatus == nil {
-		rolloutPromotedChildStatus = &apiv1.PromotedChildStatus{Name: promotedChildDef.GetName()}
+		return true, errors.New("unable to perform pre-upgrade operations because the rollout does not have promotedChildStatus set")
 	}
 
 	// scaleDownPipelineSourceVertices either updates the promoted pipeline to scale down the source vertices
@@ -161,14 +161,14 @@ func (r *PipelineRolloutReconciler) ProcessPromotedChildPostUpgrade(
 		return true, errors.New("unable to perform post-upgrade operations because the rollout does not have promotedChildStatus set")
 	}
 
-	scaledToDesired, err := scalePipelineSourceVerticesToDesiredValues(ctx, rolloutPromotedChildStatus, promotedChildDef, c)
+	performedScaling, err := scalePipelineSourceVerticesToDesiredValues(ctx, rolloutPromotedChildStatus, promotedChildDef, c)
 	if err != nil {
 		return true, err
 	}
 
 	numaLogger.Debug("completed post-upgrade processing of promoted pipeline")
 
-	return scaledToDesired, nil
+	return performedScaling, nil
 }
 
 /*

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -121,14 +121,14 @@ func (r *PipelineRolloutReconciler) ProcessPromotedChildPreUpgrade(
 	// pods or retrieves the currently running pods to update the rolloutPromotedChildStatus scaleValues.
 	// This serves to make sure that the source vertices pods have been really scaled down before proceeding
 	// with the progressive upgrade.
-	scaledDown, err := scaleDownPipelineSourceVertices(ctx, rolloutPromotedChildStatus, promotedChildDef, c)
+	performedScaling, err := scaleDownPipelineSourceVertices(ctx, rolloutPromotedChildStatus, promotedChildDef, c)
 	if err != nil {
 		return true, err
 	}
 
 	numaLogger.Debug("completed pre-upgrade processing of promoted pipeline")
 
-	return scaledDown, nil
+	return performedScaling, nil
 }
 
 /*

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -88,7 +88,7 @@ func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, ex
 }
 
 /*
-PreUpgradePromotedChildProcessing handles the pre-upgrade processing of a promoted pipeline.
+ProcessPromotedChildPreUpgrade handles the pre-upgrade processing of a promoted pipeline.
 It performs the following pre-upgrade operations:
 - it ensures that the promoted pipeline source vertices are scaled down before proceeding with a progressive upgrade.
 
@@ -102,14 +102,14 @@ Returns:
   - A boolean indicating whether we should requeue.
   - An error if any issues occur during processing.
 */
-func (r *PipelineRolloutReconciler) PreUpgradePromotedChildProcessing(
+func (r *PipelineRolloutReconciler) ProcessPromotedChildPreUpgrade(
 	ctx context.Context,
 	rolloutPromotedChildStatus *apiv1.PromotedChildStatus,
 	promotedChildDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("PreUpgradePromotedChildProcessing").WithName("PipelineRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPreUpgrade").WithName("PipelineRollout")
 
 	numaLogger.Debug("started pre-upgrade processing of promoted pipeline")
 
@@ -132,7 +132,7 @@ func (r *PipelineRolloutReconciler) PreUpgradePromotedChildProcessing(
 }
 
 /*
-PostUpgradePromotedChildProcessing handles the post-upgrade processing of a promoted pipeline.
+ProcessPromotedChildPostUpgrade handles the post-upgrade processing of a promoted pipeline.
 It performs the following post-upgrade operations:
 - it restores the promoted pipeline source vertices scale values to the desired values retrieved from the rollout status.
 
@@ -146,14 +146,14 @@ Returns:
   - A boolean indicating whether we should requeue.
   - An error if any issues occur during processing.
 */
-func (r *PipelineRolloutReconciler) PostUpgradePromotedChildProcessing(
+func (r *PipelineRolloutReconciler) ProcessPromotedChildPostUpgrade(
 	ctx context.Context,
 	rolloutPromotedChildStatus *apiv1.PromotedChildStatus,
 	promotedChildDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("PostUpgradePromotedChildProcessing").WithName("PipelineRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPostUpgrade").WithName("PipelineRollout")
 
 	numaLogger.Debug("started post-upgrade processing of promoted pipeline")
 

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -47,11 +47,11 @@ type progressiveController interface {
 	// AssessUpgradingChild determines if upgrading child is determined to be healthy, unhealthy, or unknown
 	AssessUpgradingChild(ctx context.Context, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error)
 
-	// ScaleDownPromotedChildSourceVertices scales down by half the promoted child source vertices pods
-	ScaleDownPromotedChildSourceVertices(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (map[string]apiv1.ScaleValues, bool, error)
+	// PreUpgradePromotedChildProcessing performs operations on the promoted child prior to the upgrade
+	PreUpgradePromotedChildProcessing(ctx context.Context, rolloutObject, liveRolloutObject ctlrcommon.RolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error)
 
-	// ScalePromotedChildSourceVerticesToDesiredValues scales back up to the desired scale values the promoted child source vertices pods
-	ScalePromotedChildSourceVerticesToDesiredValues(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) error
+	// PostUpgradePromotedChildProcessing performs operations on the promoted child after the upgrade
+	PostUpgradePromotedChildProcessing(ctx context.Context, rolloutObject, liveRolloutObject ctlrcommon.RolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error)
 }
 
 // return:
@@ -86,12 +86,11 @@ func ProcessResource(
 			return false, false, 0, fmt.Errorf("error getting %s: %v", currentUpgradingChildDef.GetKind(), err)
 		}
 		if currentUpgradingChildDef == nil {
-			// Scale down the promoted child first
-			scaledDown, err := scaleDownPromotedChild(ctx, rolloutObject, liveRolloutObject, existingPromotedChild, skipPromotedChildSourceVerticesScaling, controller, c)
+			requeue, err := controller.PreUpgradePromotedChildProcessing(ctx, rolloutObject, liveRolloutObject, existingPromotedChild, c)
 			if err != nil {
 				return false, false, 0, err
 			}
-			if scaledDown {
+			if requeue {
 				return false, false, common.DefaultRequeueDelay, nil
 			}
 
@@ -255,11 +254,11 @@ func processUpgradingChild(
 
 		// if so, mark the existing one for garbage collection and then create a new upgrading one
 		if needsUpdating {
-			scaledDown, err := scaleDownPromotedChild(ctx, rolloutObject, liveRolloutObject, existingPromotedChildDef, skipPromotedChildSourceVerticesScaling, controller, c)
+			requeue, err := controller.PreUpgradePromotedChildProcessing(ctx, rolloutObject, liveRolloutObject, existingPromotedChildDef, c)
 			if err != nil {
 				return false, false, 0, err
 			}
-			if scaledDown {
+			if requeue {
 				return false, false, common.DefaultRequeueDelay, nil
 			}
 
@@ -279,11 +278,11 @@ func processUpgradingChild(
 			err = kubernetes.CreateResource(ctx, c, newUpgradingChildDef)
 			return false, true, 0, err
 		} else {
-			scaledUp, err := scaleUpPromotedChild(ctx, rolloutObject, liveRolloutObject, existingPromotedChildDef, skipPromotedChildSourceVerticesScaling, controller, c)
+			requeue, err := controller.PostUpgradePromotedChildProcessing(ctx, rolloutObject, liveRolloutObject, existingPromotedChildDef, c)
 			if err != nil {
 				return false, false, 0, err
 			}
-			if scaledUp {
+			if requeue {
 				return false, false, common.DefaultRequeueDelay, nil
 			}
 		}
@@ -330,122 +329,4 @@ func IsNumaflowChildReady(upgradingObjectStatus *kubernetes.GenericStatus) bool 
 		}
 	}
 	return true
-}
-
-/*
-scaleDownPromotedChild attempts to scale down the source vertices of a promoted child.
-// It checks if scaling is required based on the rollout
-status and performs the scaling operation if necessary. The function updates the rollout
-status with the new scale values and returns whether scaling was performed.
-
-Parameters:
-  - ctx: The context for managing request-scoped values, cancellation, and timeouts.
-  - rolloutObject: The rollout object containing the current rollout status.
-  - liveRolloutObject: The live rollout object representing the current state.
-  - existingPromotedChild: The unstructured object of the promoted child to be scaled down.
-  - skipPromotedChildSourceVerticesScaling: A flag to skip scaling if set to true.
-  - controller: The progressive controller handling the scaling logic.
-  - c: The Kubernetes client for interacting with the cluster.
-
-Returns:
-  - A boolean indicating if scaling was performed.
-  - An error if any issues occur during the scaling process.
-*/
-func scaleDownPromotedChild(
-	ctx context.Context,
-	rolloutObject ctlrcommon.RolloutObject,
-	liveRolloutObject ctlrcommon.RolloutObject,
-	existingPromotedChild *unstructured.Unstructured,
-	skipPromotedChildSourceVerticesScaling bool,
-	controller progressiveController,
-	c client.Client,
-) (bool, error) {
-
-	if skipPromotedChildSourceVerticesScaling {
-		return false, nil
-	}
-
-	if liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus.AreAllSourceVerticesScaledDown(existingPromotedChild.GetName()) {
-		// Return that scaling down was NOT performed
-		return false, nil
-	}
-
-	// ScaleDownPromotedChildSourceVertices either updates the existingPromotedChild to scale down the source vertices pods or
-	// retrieves the currently running pods to update the scaleValuesMap used on the rollout status.
-	// This serves to make sure that the pods for each vertex have been really scaled down before proceeding with the progressive update.
-	scaleValuesMap, promotedChildNeedsUpdate, err := controller.ScaleDownPromotedChildSourceVertices(ctx, liveRolloutObject, existingPromotedChild, c)
-	if err != nil {
-		return false, fmt.Errorf("error updating scaling properties to the existing promoted child definition: %w", err)
-	}
-
-	if promotedChildNeedsUpdate {
-		if err = kubernetes.UpdateResource(ctx, c, existingPromotedChild); err != nil {
-			return false, fmt.Errorf("error scaling down the existing promoted child: %w", err)
-		}
-	}
-
-	if rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus == nil {
-		rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus = &apiv1.PromotedChildStatus{}
-	}
-	rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus.Name = existingPromotedChild.GetName()
-	rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus.ScaleValues = scaleValuesMap
-	rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus.MarkAllSourceVerticesScaledDown()
-
-	// Set ScaleValuesRestoredToDesired to false in case previously set to true and now scaling back down to recover from a previous failure
-	rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus.ScaleValuesRestoredToDesired = false
-
-	// Return that scaling down was performed
-	return true, nil
-}
-
-/*
-scaleUpPromotedChild scales up the promoted child of a rollout object to its desired scale values if not already done.
-
-Parameters:
-  - ctx: The context for managing request-scoped values, cancellation, and timeouts.
-  - rolloutObject: The rollout object containing the desired state and status.
-  - liveRolloutObject: The current live state of the rollout object.
-  - existingPromotedChild: The promoted child resource to be scaled.
-  - skipPromotedChildSourceVerticesScaling: Flag to skip scaling if set to true.
-  - controller: The progressive controller responsible for scaling operations.
-  - c: The Kubernetes client for interacting with the cluster.
-
-Returns:
-  - A boolean indicating whether scaling was performed.
-  - An error if scaling fails.
-*/
-func scaleUpPromotedChild(
-	ctx context.Context,
-	rolloutObject ctlrcommon.RolloutObject,
-	liveRolloutObject ctlrcommon.RolloutObject,
-	existingPromotedChild *unstructured.Unstructured,
-	skipPromotedChildSourceVerticesScaling bool,
-	controller progressiveController,
-	c client.Client,
-) (bool, error) {
-
-	if skipPromotedChildSourceVerticesScaling {
-		return false, nil
-	}
-
-	if liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus.AreScaleValuesRestoredToDesired(existingPromotedChild.GetName()) {
-		// Return that scaling up was NOT performed
-		return false, nil
-	}
-
-	if err := controller.ScalePromotedChildSourceVerticesToDesiredValues(ctx, liveRolloutObject, existingPromotedChild, c); err != nil {
-		return false, err
-	}
-
-	if err := kubernetes.UpdateResource(ctx, c, existingPromotedChild); err != nil {
-		return false, fmt.Errorf("error scaling back to desired min and max values the existing promoted child: %w", err)
-	}
-
-	rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus.ScaleValuesRestoredToDesired = true
-
-	rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus.AllSourceVerticesScaledDown = false
-	rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus.ScaleValues = nil
-
-	// Return that scaling up was performed
-	return true, nil
 }

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -47,11 +47,11 @@ type progressiveController interface {
 	// AssessUpgradingChild determines if upgrading child is determined to be healthy, unhealthy, or unknown
 	AssessUpgradingChild(ctx context.Context, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error)
 
-	// PreUpgradePromotedChildProcessing performs operations on the promoted child prior to the upgrade
-	PreUpgradePromotedChildProcessing(ctx context.Context, rolloutPromotedChildStatus *apiv1.PromotedChildStatus, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error)
+	// ProcessPromotedChildPreUpgrade performs operations on the promoted child prior to the upgrade
+	ProcessPromotedChildPreUpgrade(ctx context.Context, rolloutPromotedChildStatus *apiv1.PromotedChildStatus, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error)
 
-	// PostUpgradePromotedChildProcessing performs operations on the promoted child after the upgrade
-	PostUpgradePromotedChildProcessing(ctx context.Context, rolloutPromotedChildStatus *apiv1.PromotedChildStatus, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error)
+	// ProcessPromotedChildPostUpgrade performs operations on the promoted child after the upgrade
+	ProcessPromotedChildPostUpgrade(ctx context.Context, rolloutPromotedChildStatus *apiv1.PromotedChildStatus, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error)
 }
 
 // return:
@@ -98,7 +98,7 @@ func ProcessResource(
 				return false, true, 0, err
 			}
 
-			requeue, err := controller.PreUpgradePromotedChildProcessing(ctx, liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChild, c)
+			requeue, err := controller.ProcessPromotedChildPreUpgrade(ctx, liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChild, c)
 			if err != nil {
 				return false, false, 0, err
 			}
@@ -276,7 +276,7 @@ func processUpgradingChild(
 				return false, true, 0, err
 			}
 
-			requeue, err := controller.PreUpgradePromotedChildProcessing(ctx, liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChildDef, c)
+			requeue, err := controller.ProcessPromotedChildPreUpgrade(ctx, liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChildDef, c)
 			if err != nil {
 				return false, false, 0, err
 			}
@@ -286,7 +286,7 @@ func processUpgradingChild(
 
 			return false, true, 0, nil
 		} else {
-			requeue, err := controller.PostUpgradePromotedChildProcessing(ctx, liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChildDef, c)
+			requeue, err := controller.ProcessPromotedChildPostUpgrade(ctx, liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChildDef, c)
 			if err != nil {
 				return false, false, 0, err
 			}

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -85,7 +85,11 @@ func ProcessResource(
 			return false, false, 0, fmt.Errorf("error getting %s: %v", currentUpgradingChildDef.GetKind(), err)
 		}
 		if currentUpgradingChildDef == nil {
-			requeue, err := controller.ProcessPromotedChildPreUpgrade(ctx, liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChild, c)
+			if liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus == nil {
+				rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus = &apiv1.PromotedChildStatus{Name: existingPromotedChild.GetName()}
+			}
+
+			requeue, err := controller.ProcessPromotedChildPreUpgrade(ctx, rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChild, c)
 			if err != nil {
 				return false, false, 0, err
 			}
@@ -252,7 +256,7 @@ func processUpgradingChild(
 
 		// if so, mark the existing one for garbage collection and then create a new upgrading one
 		if needsUpdating {
-			requeue, err := controller.ProcessPromotedChildPreUpgrade(ctx, liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChildDef, c)
+			requeue, err := controller.ProcessPromotedChildPreUpgrade(ctx, rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChildDef, c)
 			if err != nil {
 				return false, false, 0, err
 			}
@@ -276,7 +280,7 @@ func processUpgradingChild(
 			err = kubernetes.CreateResource(ctx, c, newUpgradingChildDef)
 			return false, true, 0, err
 		} else {
-			requeue, err := controller.ProcessPromotedChildPostUpgrade(ctx, liveRolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChildDef, c)
+			requeue, err := controller.ProcessPromotedChildPostUpgrade(ctx, rolloutObject.GetRolloutStatus().ProgressiveStatus.PromotedChildStatus, existingPromotedChildDef, c)
 			if err != nil {
 				return false, false, 0, err
 			}

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -146,7 +146,7 @@ func Test_processUpgradingChild(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualDone, actualNewChildCreated, actualRequeueDelay, actualErr := processUpgradingChild(
-				ctx, defaultMonoVertexRollout, tc.liveRolloutObject, fakeProgressiveController{}, defaultExistingPromotedChildDef, tc.existingUpgradingChildDef, false, client)
+				ctx, defaultMonoVertexRollout, tc.liveRolloutObject, fakeProgressiveController{}, defaultExistingPromotedChildDef, tc.existingUpgradingChildDef, client)
 
 			if tc.expectedError != nil {
 				assert.Error(t, actualErr)

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -47,11 +47,11 @@ func (fpc fakeProgressiveController) AssessUpgradingChild(ctx context.Context, e
 	}
 }
 
-func (fpc fakeProgressiveController) PreUpgradePromotedChildProcessing(ctx context.Context, rolloutObject, liveRolloutObject ctlrcommon.RolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
+func (fpc fakeProgressiveController) PreUpgradePromotedChildProcessing(ctx context.Context, rolloutPromotedChildStatus *apiv1.PromotedChildStatus, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
 	return false, nil
 }
 
-func (fpc fakeProgressiveController) PostUpgradePromotedChildProcessing(ctx context.Context, rolloutObject, liveRolloutObject ctlrcommon.RolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
+func (fpc fakeProgressiveController) PostUpgradePromotedChildProcessing(ctx context.Context, rolloutPromotedChildStatus *apiv1.PromotedChildStatus, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
 	return false, nil
 }
 

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -47,12 +47,12 @@ func (fpc fakeProgressiveController) AssessUpgradingChild(ctx context.Context, e
 	}
 }
 
-func (fpc fakeProgressiveController) ScaleDownPromotedChildSourceVertices(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (map[string]apiv1.ScaleValues, bool, error) {
-	return nil, false, nil
+func (fpc fakeProgressiveController) PreUpgradePromotedChildProcessing(ctx context.Context, rolloutObject, liveRolloutObject ctlrcommon.RolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
+	return false, nil
 }
 
-func (fpc fakeProgressiveController) ScalePromotedChildSourceVerticesToDesiredValues(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) error {
-	return nil
+func (fpc fakeProgressiveController) PostUpgradePromotedChildProcessing(ctx context.Context, rolloutObject, liveRolloutObject ctlrcommon.RolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
+	return false, nil
 }
 
 func Test_processUpgradingChild(t *testing.T) {

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -47,11 +47,11 @@ func (fpc fakeProgressiveController) AssessUpgradingChild(ctx context.Context, e
 	}
 }
 
-func (fpc fakeProgressiveController) PreUpgradePromotedChildProcessing(ctx context.Context, rolloutPromotedChildStatus *apiv1.PromotedChildStatus, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
+func (fpc fakeProgressiveController) ProcessPromotedChildPreUpgrade(ctx context.Context, rolloutPromotedChildStatus *apiv1.PromotedChildStatus, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
 	return false, nil
 }
 
-func (fpc fakeProgressiveController) PostUpgradePromotedChildProcessing(ctx context.Context, rolloutPromotedChildStatus *apiv1.PromotedChildStatus, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
+func (fpc fakeProgressiveController) ProcessPromotedChildPostUpgrade(ctx context.Context, rolloutPromotedChildStatus *apiv1.PromotedChildStatus, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
 	return false, nil
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Changes relative to comments on PR [540](https://github.com/numaproj/numaplane/pull/540):
- Updated scaling up/down logic and renamed shared functions
- Moved logic to perform scaling after creating the upgrading resource
- using PatchResource instead of UpdateResource

### Verification

E2E and unit tests.

### Backward incompatibilities

None.
