### PR TITLE
feat: Be able to define ConfigMap LogLevel as a user-friendly string

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
+	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -255,7 +256,7 @@ func loadConfigs() {
 	}
 
 	// anything we need to set based on our main Numaplane Config?
-	numaLogger.SetLevel(config.LogLevel)
+	numaLogger.SetLevel(logger.LogLevelMap[strings.ToUpper(config.LogLevel)])
 	logger.SetBaseLogger(numaLogger)
 	clog.SetLogger(*numaLogger.LogrLogger)
 

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -2151,7 +2151,7 @@ subjects:
 apiVersion: v1
 data:
   config.yaml: |
-    logLevel: 3
+    logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -2151,7 +2151,7 @@ subjects:
 apiVersion: v1
 data:
   config.yaml: |
-    logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
+    logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"

--- a/config/manager/controller-config.yaml
+++ b/config/manager/controller-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: numaplane-controller-config
 data:
   config.yaml: |
-    logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
+    logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"

--- a/config/manager/controller-config.yaml
+++ b/config/manager/controller-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: numaplane-controller-config
 data:
   config.yaml: |
-    logLevel: 3
+    logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -89,7 +89,7 @@ func (*ConfigManager) GetControllerDefinitionsMgr() *NumaflowControllerDefinitio
 // supposed to be populated from the configmap attached to the
 // controller manager.
 type GlobalConfig struct {
-	LogLevel          int    `json:"logLevel" mapstructure:"logLevel"`
+	LogLevel          string `json:"logLevel" mapstructure:"logLevel"`
 	IncludedResources string `json:"includedResources" mapstructure:"includedResources"`
 	// List of Numaflow Controller image names to look for
 	NumaflowControllerImageNames []string `json:"numaflowControllerImageNames" mapstructure:"numaflowControllerImageNames"`

--- a/internal/controller/config/config_test.go
+++ b/internal/controller/config/config_test.go
@@ -41,7 +41,7 @@ func TestLoadConfigMatchValues(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Nil(t, err, "Failed to load configuration")
-	assert.Equal(t, 3, config.LogLevel, "Log Level does not match")
+	assert.Equal(t, "INFO", config.LogLevel, "Log Level does not match")
 	assert.Contains(t, config.NumaflowControllerImageNames, "numaflow")
 	assert.Contains(t, config.NumaflowControllerImageNames, "numaflow-rc")
 	// now verify that if we modify the file, it will still be okay
@@ -163,7 +163,7 @@ func TestGetConfigManagerInstanceSingleton(t *testing.T) {
 
 func TestCloneWithSerialization(t *testing.T) {
 	original := &GlobalConfig{
-		LogLevel:               0,
+		LogLevel:               "ERROR",
 		DefaultUpgradeStrategy: NoStrategyID,
 	}
 
@@ -179,15 +179,15 @@ func TestCloneWithSerialization(t *testing.T) {
 		t.Errorf("Cloned object is not deeply equal to the original")
 	}
 
-	cloned.LogLevel = 1
-	if original.LogLevel == 1 {
+	cloned.LogLevel = "INFO"
+	if original.LogLevel == "INFO" {
 		t.Errorf("Modifying clone affected the original object")
 	}
 }
 
 func createGlobalConfigForBenchmarking() *GlobalConfig {
 	return &GlobalConfig{
-		LogLevel: 0,
+		LogLevel: "ERROR",
 	}
 }
 

--- a/internal/util/logger/base_logger.go
+++ b/internal/util/logger/base_logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/numaproj/numaplane/internal/controller/config"
@@ -35,13 +36,13 @@ func GetBaseLogger() *NumaLogger {
 func refreshBaseLoggerLevel(newConfig config.GlobalConfig) {
 
 	// if it changed, propagate it to our Base Logger
-	if newConfig.LogLevel != baseLogger.LogLevel {
+	if LogLevelMap[strings.ToUpper(newConfig.LogLevel)] != baseLogger.LogLevel {
 
 		baseLoggerMutex.Lock()
 		defer baseLoggerMutex.Unlock()
 
 		// update the logger with the new log level
-		baseLogger.SetLevel(newConfig.LogLevel)
-		baseLogger.Infof("log level=%d\n", newConfig.LogLevel)
+		baseLogger.SetLevel(LogLevelMap[strings.ToUpper(newConfig.LogLevel)])
+		baseLogger.Infof("updated log level=%s", newConfig.LogLevel)
 	}
 }

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -49,7 +49,6 @@ const (
 
 // LogLevelMap maps the log level string to the logr verbosity level.
 var LogLevelMap = map[string]int{
-	"ERROR":   FatalLevel,
 	"WARN":    WarnLevel,
 	"INFO":    InfoLevel,
 	"DEBUG":   DebugLevel,

--- a/internal/util/logger/logger.go
+++ b/internal/util/logger/logger.go
@@ -265,6 +265,7 @@ func (nl *NumaLogger) Verbosef(msg string, args ...any) {
 func (nl *NumaLogger) SetLevel(level int) {
 	// default if not defined
 	if level == 0 {
+		log.Printf("LogLevel is not set or unsupported, using default level: INFO")
 		level = defaultLevel
 	}
 

--- a/tests/config/testconfig.yaml
+++ b/tests/config/testconfig.yaml
@@ -1,4 +1,4 @@
-logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
+logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
 numaflowControllerImageNames:
   - numaflow
   - numaflow-rc

--- a/tests/config/testconfig.yaml
+++ b/tests/config/testconfig.yaml
@@ -1,4 +1,4 @@
-logLevel: 3
+logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
 numaflowControllerImageNames:
   - numaflow
   - numaflow-rc

--- a/tests/config/testconfig2.yaml
+++ b/tests/config/testconfig2.yaml
@@ -1,3 +1,3 @@
-logLevel: DEBUG # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
+logLevel: DEBUG # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
 defaultUpgradeStrategy: "progressive"
 childStatusAssessmentSchedule: "30,90,5"

--- a/tests/config/testconfig2.yaml
+++ b/tests/config/testconfig2.yaml
@@ -1,3 +1,3 @@
-logLevel: 4
+logLevel: DEBUG # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
 defaultUpgradeStrategy: "progressive"
 childStatusAssessmentSchedule: "30,90,5"

--- a/tests/manifests/default/config.yaml
+++ b/tests/manifests/default/config.yaml
@@ -1,4 +1,4 @@
-logLevel: 4
+logLevel: DEBUG # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
 numaflowControllerImageNames:
   - numaflow
   - numaflow-rc

--- a/tests/manifests/default/config.yaml
+++ b/tests/manifests/default/config.yaml
@@ -1,4 +1,4 @@
-logLevel: DEBUG # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
+logLevel: DEBUG # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
 numaflowControllerImageNames:
   - numaflow
   - numaflow-rc

--- a/tests/manifests/special-cases/no-strategy/controller-config.yaml
+++ b/tests/manifests/special-cases/no-strategy/controller-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: numaplane-controller-config
 data:
   config.yaml: |
-    logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
+    logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"

--- a/tests/manifests/special-cases/no-strategy/controller-config.yaml
+++ b/tests/manifests/special-cases/no-strategy/controller-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: numaplane-controller-config
 data:
   config.yaml: |
-    logLevel: 3
+    logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"

--- a/tests/manifests/special-cases/progressive/controller-config.yaml
+++ b/tests/manifests/special-cases/progressive/controller-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: numaplane-controller-config
 data:
   config.yaml: |
-    logLevel: DEBUG # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
+    logLevel: DEBUG # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"

--- a/tests/manifests/special-cases/progressive/controller-config.yaml
+++ b/tests/manifests/special-cases/progressive/controller-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: numaplane-controller-config
 data:
   config.yaml: |
-    logLevel: 4
+    logLevel: DEBUG # Supported log levels are: VERBOSE, DEBUG, INFO, WARN, and ERROR
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/43

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

- Define configmap LogLevel as user-friendly string, which supports: "ERROR", "WARN", "INFO", "DEBUG" and "VERBOSE"


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->
- Verified in local k8s cluster

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
- Yes, with this version `LogLevel` should be defined as string instead of `Number`
