### PR TITLE
fix: pipelinerollout deletion sequence

### DIFF
--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -347,6 +347,12 @@ func (r *PipelineRolloutReconciler) reconcile(
 			if err := r.client.Delete(ctx, pipelineRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return 0, nil, err
 			}
+			// Get the PipelineRollout live resource
+			livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
+			if err != nil {
+				return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
+			}
+			*pipelineRollout = *livePipelineRollout
 			controllerutil.RemoveFinalizer(pipelineRollout, common.FinalizerName)
 		}
 		// generate the metrics for the Pipeline deletion.

--- a/tests/e2e/ppnd-e2e/ppnd_test.go
+++ b/tests/e2e/ppnd-e2e/ppnd_test.go
@@ -264,35 +264,35 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 
 	time.Sleep(5 * time.Second)
 
-	// It("Should update an ISBService even if the Pipeline is failed", func() {
+	It("Should update an ISBService even if the Pipeline is failed", func() {
 
-	// 	// add bad edge to automatically fail Pipeline
-	// 	failedPipelineSpec := initialPipelineSpec
-	// 	failedPipelineSpec.Edges = append(failedPipelineSpec.Edges, numaflowv1.Edge{From: "not", To: "valid"})
+		// add bad edge to automatically fail Pipeline
+		failedPipelineSpec := initialPipelineSpec
+		failedPipelineSpec.Edges = append(failedPipelineSpec.Edges, numaflowv1.Edge{From: "not", To: "valid"})
 
-	// 	CreatePipelineRollout(failedPipelineRolloutName, Namespace, failedPipelineSpec, true)
-	// 	VerifyPipelineFailed(Namespace, failedPipelineRolloutName)
+		CreatePipelineRollout(failedPipelineRolloutName, Namespace, failedPipelineSpec, true)
+		VerifyPipelineFailed(Namespace, failedPipelineRolloutName)
 
-	// 	time.Sleep(5 * time.Second)
+		time.Sleep(5 * time.Second)
 
-	// 	// update ISBService to have data loss update
-	// 	Document("Updating ISBService to cause a PPND change")
-	// 	updatedISBServiceSpec := isbServiceSpec
-	// 	updatedISBServiceSpec.JetStream.Version = initialJetstreamVersion
+		// update ISBService to have data loss update
+		Document("Updating ISBService to cause a PPND change")
+		updatedISBServiceSpec := isbServiceSpec
+		updatedISBServiceSpec.JetStream.Version = initialJetstreamVersion
 
-	// 	// need to update function
-	// 	// update would normally cause data loss
-	// 	UpdateISBServiceRollout(isbServiceRolloutName, failedPipelineRolloutName, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
-	// 		return retrievedISBServiceSpec.JetStream.Version == initialJetstreamVersion
-	// 	}, true, false, false, true)
+		// need to update function
+		// update would normally cause data loss
+		UpdateISBServiceRollout(isbServiceRolloutName, failedPipelineRolloutName, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+			return retrievedISBServiceSpec.JetStream.Version == initialJetstreamVersion
+		}, true, false, false, true)
 
-	// 	time.Sleep(5 * time.Second)
+		time.Sleep(5 * time.Second)
 
-	// 	DeletePipelineRollout(failedPipelineRolloutName)
+		DeletePipelineRollout(failedPipelineRolloutName)
 
-	// })
+	})
 
-	// time.Sleep(5 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	It("Should update a NumaflowController even if the Pipeline is failed", func() {
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #559 

### Modifications

By performing a `Get()` after adding the `foregroundDeletion` finalizer, we can eliminate the resource version conflict issue that occurs. 


### Verification

Running the CI, it seems to pass all of the tests for confirming deletion has occurred.

However, @chandankumar4 will follow up with another PR to address our other CRDs and to do additional testing for different cases. 

### Backward incompatibilities

N/A
