### PR TITLE
fix: promoted child status was only being copied partially from live rollout to in-memory rollout

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -418,13 +418,16 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 	case apiv1.UpgradeStrategyProgressive:
 		numaLogger.Debug("processing InterstepBufferService with Progressive")
 
-		// Get the ISBServiceRollout live resource
+		// Get the ISBServiceRollout live resource so we can grab the ProgressiveStatus from that for our own local isbServiceRollout
+		// (Note we don't copy the entire Status in case we've updated something locally)
 		liveISBServiceRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().ISBServiceRollouts(isbServiceRollout.Namespace).Get(ctx, isbServiceRollout.Name, metav1.GetOptions{})
 		if err != nil {
 			return 0, fmt.Errorf("error getting the live ISBServiceRollout for assessment processing: %w", err)
 		}
 
-		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, isbServiceRollout, liveISBServiceRollout, existingISBServiceDef, isbServiceNeedsToUpdate, r, r.client)
+		isbServiceRollout.Status.ProgressiveStatus = *liveISBServiceRollout.Status.ProgressiveStatus.DeepCopy()
+
+		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, isbServiceRollout, existingISBServiceDef, isbServiceNeedsToUpdate, r, r.client)
 		if err != nil {
 			return 0, fmt.Errorf("Error processing isbsvc with progressive: %s", err.Error())
 		}

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -328,11 +328,14 @@ func (r *MonoVertexRolloutReconciler) processExistingMonoVertex(ctx context.Cont
 	case apiv1.UpgradeStrategyProgressive:
 		numaLogger.Debug("processing MonoVertex with Progressive")
 
-		// Get the MonoVertexRollout live resource
+		// Get the MonoVertexRollout live resource so we can grab the ProgressiveStatus from that for our own local monoVertexRollout
+		// (Note we don't copy the entire Status in case we've updated something locally)
 		liveMonoVertexRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().MonoVertexRollouts(monoVertexRollout.Namespace).Get(ctx, monoVertexRollout.Name, metav1.GetOptions{})
 		if err != nil {
 			return 0, fmt.Errorf("error getting the live MonoVertexRollout for assessment processing: %w", err)
 		}
+
+		monoVertexRollout.Status.ProgressiveStatus = *liveMonoVertexRollout.Status.ProgressiveStatus.DeepCopy()
 
 		// don't risk out-of-date cache while performing Progressive strategy - get
 		// the most current version of the MonoVertex just in case
@@ -345,7 +348,7 @@ func (r *MonoVertexRolloutReconciler) processExistingMonoVertex(ctx context.Cont
 			}
 		}
 
-		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, monoVertexRollout, liveMonoVertexRollout, existingMonoVertexDef, mvNeedsToUpdate, r, r.client)
+		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, monoVertexRollout, existingMonoVertexDef, mvNeedsToUpdate, r, r.client)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -79,7 +79,7 @@ func Test_processUpgradingChild(t *testing.T) {
 
 	testCases := []struct {
 		name                      string
-		liveRolloutObject         ProgressiveRolloutObject
+		rolloutObject             ProgressiveRolloutObject
 		existingUpgradingChildDef *unstructured.Unstructured
 		expectedDone              bool
 		expectedNewChildCreated   bool
@@ -88,7 +88,7 @@ func Test_processUpgradingChild(t *testing.T) {
 	}{
 		{
 			name:                      "no upgrading child status on the live rollout",
-			liveRolloutObject:         defaultMonoVertexRollout.DeepCopy(),
+			rolloutObject:             defaultMonoVertexRollout.DeepCopy(),
 			existingUpgradingChildDef: &unstructured.Unstructured{Object: map[string]any{"metadata": map[string]any{"name": "test"}}},
 			expectedDone:              false,
 			expectedNewChildCreated:   false,
@@ -97,7 +97,7 @@ func Test_processUpgradingChild(t *testing.T) {
 		},
 		{
 			name: "preset upgrading child status on the live rollout - different name",
-			liveRolloutObject: setMonoVertexProgressiveStatus(
+			rolloutObject: setMonoVertexProgressiveStatus(
 				defaultMonoVertexRollout.DeepCopy(),
 				&apiv1.UpgradingMonoVertexStatus{UpgradingChildStatus: apiv1.UpgradingChildStatus{Name: "test"}},
 				nil),
@@ -110,7 +110,7 @@ func Test_processUpgradingChild(t *testing.T) {
 		},
 		{
 			name: "preset upgrading child status on the live rollout - same name, can assess, success",
-			liveRolloutObject: setMonoVertexProgressiveStatus(
+			rolloutObject: setMonoVertexProgressiveStatus(
 				defaultMonoVertexRollout.DeepCopy(),
 				&apiv1.UpgradingMonoVertexStatus{
 					UpgradingChildStatus: apiv1.UpgradingChildStatus{
@@ -129,7 +129,7 @@ func Test_processUpgradingChild(t *testing.T) {
 		},
 		{
 			name: "preset upgrading child status on the live rollout - same name, failure",
-			liveRolloutObject: setMonoVertexProgressiveStatus(
+			rolloutObject: setMonoVertexProgressiveStatus(
 				defaultMonoVertexRollout.DeepCopy(),
 				&apiv1.UpgradingMonoVertexStatus{
 					UpgradingChildStatus: apiv1.UpgradingChildStatus{
@@ -158,7 +158,7 @@ func Test_processUpgradingChild(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualDone, actualNewChildCreated, actualRequeueDelay, actualErr := processUpgradingChild(
-				ctx, defaultMonoVertexRollout, tc.liveRolloutObject, fakeProgressiveController{}, defaultExistingPromotedChildDef, tc.existingUpgradingChildDef, client)
+				ctx, tc.rolloutObject, fakeProgressiveController{}, defaultExistingPromotedChildDef, tc.existingUpgradingChildDef, client)
 
 			if tc.expectedError != nil {
 				assert.Error(t, actualErr)

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -303,7 +303,9 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Document("setting desiredPhase=Paused")
 		currentMonoVertexSpec.Lifecycle.DesiredPhase = numaflowv1.MonoVertexPhasePaused
 
-		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhasePaused)
+		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhasePaused, func(spec numaflowv1.MonoVertexSpec) bool {
+			return spec.Lifecycle.DesiredPhase == numaflowv1.MonoVertexPhasePaused
+		})
 
 		VerifyMonoVertexStaysPaused(monoVertexRolloutName)
 	})
@@ -315,7 +317,9 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Document("setting desiredPhase=Running")
 		currentMonoVertexSpec.Lifecycle.DesiredPhase = numaflowv1.MonoVertexPhaseRunning
 
-		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning)
+		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning, func(spec numaflowv1.MonoVertexSpec) bool {
+			return spec.Lifecycle.DesiredPhase == numaflowv1.MonoVertexPhaseRunning
+		})
 
 	})
 
@@ -378,7 +382,9 @@ var _ = Describe("Functional e2e", Serial, func() {
 		rpu := int64(10)
 		updatedMonoVertexSpec.Source.Generator = &numaflowv1.GeneratorSource{RPU: &rpu}
 
-		UpdateMonoVertexRollout(monoVertexRolloutName, updatedMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning)
+		UpdateMonoVertexRollout(monoVertexRolloutName, updatedMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning, func(spec numaflowv1.MonoVertexSpec) bool {
+			return spec.Source != nil && spec.Source.Generator != nil && *spec.Source.Generator.RPU == rpu
+		})
 
 		VerifyMonoVertexSpec(Namespace, monoVertexRolloutName, func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec) bool {
 			return retrievedMonoVertexSpec.Source.Generator != nil && retrievedMonoVertexSpec.Source.UDSource == nil

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -352,7 +352,7 @@ func DeleteMonoVertexRollout(name string) {
 	}).WithTimeout(testTimeout).Should(BeTrue(), "The MonoVertex should have been deleted but it was found.")
 }
 
-func UpdateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, expectedFinalPhase numaflowv1.MonoVertexPhase) {
+func UpdateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, expectedFinalPhase numaflowv1.MonoVertexPhase, verifySpecFunc func(numaflowv1.MonoVertexSpec) bool) {
 
 	rawSpec, err := json.Marshal(newSpec)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -362,8 +362,11 @@ func UpdateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, exp
 		rollout.Spec.MonoVertex.Spec.Raw = rawSpec
 		return rollout, nil
 	})
+	Document("Verifying MonoVertex spec got updated")
+	// get Pipeline to check that spec has been updated to correct spec
+	VerifyMonoVertexSpec(Namespace, name, verifySpecFunc)
 
-	Document("verifying MonoVertexRollout spec deployed")
+	Document("verifying MonoVertexRollout Phase=Deployed")
 	verifyMonoVertexRolloutDeployed(name)
 	if expectedFinalPhase == numaflowv1.MonoVertexPhaseRunning {
 		verifyMonoVertexRolloutHealthy(name)

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -516,7 +516,7 @@ func UpdatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expecte
 	}
 
 	// rollout phase will be pending if we are expecting a long pausing state and Pipeline will not be fully updated
-	if expectedFinalPhase != numaflowv1.PipelinePhasePausing {
+	if !(UpgradeStrategy == config.PPNDStrategyID && expectedFinalPhase == numaflowv1.PipelinePhasePausing) {
 		Document("Verifying Pipeline got updated")
 		// get Pipeline to check that spec has been updated to correct spec
 		VerifyPipelineSpec(Namespace, name, verifySpecFunc)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

There's a bug in which the entire `PromotedPipelineStatus` and `PromotedMonoVertexStatus` is no longer being propagated from the `liveRolloutObject` to the in-memory `rolloutObject` during Progressive update. This happened when I refactored the ProgressiveStatus struct to separate it into multiple. 

To remedy that, I made it so that the individual Rollout objects copy the liveRolloutObject's ProgressiveStatus over to the in-memory object each time we reconcile progressively, and then from there we only use that.  

Also fixes a flakey e2e test for MonoVertexRollout which had potential to fail for progressive case (described inline).

### Verification

I did some manual tests of the Pipeline and figured given that the MonoVertex was changed in the exact same way, it should hopefully be okay as well:

- good pipeline -> bad pipeline -> good pipeline
- good pipeline -> good pipeline

I observed each time that it took the promoted one down to the correct number of vertices before upgrading, and then back up on failure.

I also ran the e2e tests 4 times in a row, and it passed every time.

### Backward incompatibilities

N/A
