### PR TITLE
fix: various bugs related to progressive rollout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,8 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 35 # If we start getting error in CI as "The operation was canceled", we need to increase this value.
+    # We already have a timeout in "go test" call: we don't also need this
+    #timeout-minutes: 35 # If we start getting error in CI as "The operation was canceled", we need to increase this value.
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ test: codegen fmt vet envtest ## Run tests.
 test-functional-e2e:
 test-ppnd-e2e:
 test-%: codegen fmt vet envtest ## Run e2e tests.
-	GOFLAGS="-count=1" go test -timeout 20m -v ./tests/e2e/$*
+	GOFLAGS="-count=1" go test -v ./tests/e2e/$*
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -122,14 +122,14 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-.PHONY: test
-test: codegen fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -p 1 -race -short -v $$(go list ./... | grep -v /tests/e2e) 
+#.PHONY: test
+#test: codegen fmt vet envtest ## Run tests.
+#	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -p 1 -race -short -v $$(go list ./... | grep -v /tests/e2e) 
 
 test-functional-e2e:
 test-ppnd-e2e:
 test-%: codegen fmt vet envtest ## Run e2e tests.
-	GOFLAGS="-count=1" go test -v ./tests/e2e/$*
+	GOFLAGS="-count=1" go test -timeout 35 -v ./tests/e2e/$* 
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ test: codegen fmt vet envtest ## Run unit tests.
 
 test-functional-e2e:
 test-ppnd-e2e:
-test-%: codegen fmt vet envtest ## Run e2e tests.
+test-%: codegen fmt vet envtest ## Run e2e tests. Note we may need to increase the timeout in the future.
 	GOFLAGS="-count=1" go test -timeout 35m -v ./tests/e2e/$* 
 
 

--- a/Makefile
+++ b/Makefile
@@ -122,14 +122,14 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-#.PHONY: test
-#test: codegen fmt vet envtest ## Run tests.
-#	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -p 1 -race -short -v $$(go list ./... | grep -v /tests/e2e) 
+.PHONY: test
+test: codegen fmt vet envtest ## Run unit tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -p 1 -race -short -v $$(go list ./... | grep -v /tests/e2e) 
 
 test-functional-e2e:
 test-ppnd-e2e:
 test-%: codegen fmt vet envtest ## Run e2e tests.
-	GOFLAGS="-count=1" go test -timeout 35 -v ./tests/e2e/$* 
+	GOFLAGS="-count=1" go test -timeout 35m -v ./tests/e2e/$* 
 
 
 

--- a/internal/controller/common/rollout_controller.go
+++ b/internal/controller/common/rollout_controller.go
@@ -167,7 +167,7 @@ func FindMostCurrentChildOfUpgradeState(ctx context.Context, rolloutObject Rollo
 func UpdateUpgradeState(ctx context.Context, c client.Client, upgradeState common.UpgradeState, upgradeStateReason *common.UpgradeStateReason, childObject *unstructured.Unstructured) error {
 	numaLogger := logger.FromContext(ctx)
 
-	numaLogger.WithValues("upgradeState", upgradeState, "upgradeStateReason", util.OptionalString(upgradeStateReason)).Debug("patching upgradeState and upgradeStateReason to %s:%s/%s",
+	numaLogger.WithValues("upgradeState", upgradeState, "upgradeStateReason", util.OptionalString(upgradeStateReason)).Debugf("patching upgradeState and upgradeStateReason to %s:%s/%s",
 		childObject.GetKind(), childObject.GetNamespace(), childObject.GetName())
 	var patchJson string
 	labels := childObject.GetLabels()
@@ -191,7 +191,7 @@ func GetUpgradeState(ctx context.Context, c client.Client, childObject *unstruct
 		return nil, nil
 	} else {
 		reasonStr, found := childObject.GetLabels()[common.LabelKeyUpgradeStateReason]
-		numaLogger.WithValues("upgradeState", upgradeStateStr, "upgradeStateReason", util.OptionalString(reasonStr)).Debug("reading upgradeState and upgradeStateReason for %s:%s/%s",
+		numaLogger.WithValues("upgradeState", upgradeStateStr, "upgradeStateReason", util.OptionalString(reasonStr)).Debugf("reading upgradeState and upgradeStateReason for %s:%s/%s",
 			childObject.GetKind(), childObject.GetNamespace(), childObject.GetName())
 		if !found {
 			upgradeState := common.UpgradeState(upgradeStateStr)

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -418,13 +418,16 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 	case apiv1.UpgradeStrategyProgressive:
 		numaLogger.Debug("processing InterstepBufferService with Progressive")
 
-		// Get the ISBServiceRollout live resource
+		// Get the ISBServiceRollout live resource so we can grab the ProgressiveStatus from that for our own local isbServiceRollout
+		// (Note we don't copy the entire Status in case we've updated something locally)
 		liveISBServiceRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().ISBServiceRollouts(isbServiceRollout.Namespace).Get(ctx, isbServiceRollout.Name, metav1.GetOptions{})
 		if err != nil {
 			return 0, fmt.Errorf("error getting the live ISBServiceRollout for assessment processing: %w", err)
 		}
 
-		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, isbServiceRollout, liveISBServiceRollout, existingISBServiceDef, isbServiceNeedsToUpdate, r, r.client)
+		isbServiceRollout.Status.ProgressiveStatus = *liveISBServiceRollout.Status.ProgressiveStatus.DeepCopy()
+
+		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, isbServiceRollout, existingISBServiceDef, isbServiceNeedsToUpdate, r, r.client)
 		if err != nil {
 			return 0, fmt.Errorf("Error processing isbsvc with progressive: %s", err.Error())
 		}

--- a/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
@@ -426,7 +426,7 @@ func Test_reconcile_isbservicerollout_Progressive(t *testing.T) {
 		expectedISBServices map[string]common.UpgradeState // after reconcile(), these are the only interstepbufferservices we expect to exist along with their expected UpgradeState
 
 	}{
-		{
+		/*{
 			// the Rollout's specified jetstream version - 2.10.11 - differs from the running one - 2.10.3
 			// that's a data loss field
 			name:                           "spec difference results in Progressive",
@@ -448,7 +448,7 @@ func Test_reconcile_isbservicerollout_Progressive(t *testing.T) {
 				defaultPromotedISBSvcName:  common.LabelValueUpgradePromoted,
 				defaultUpgradingISBSvcName: common.LabelValueUpgradeInProgress,
 			},
-		},
+		},*/
 		{
 			// the "upgrading" isbsvc succeeds (given that its pipeline succeeded)
 			// the original pipeline was deleted, so the isbsvc in turn can also be deleted
@@ -463,6 +463,7 @@ func Test_reconcile_isbservicerollout_Progressive(t *testing.T) {
 				&apiv1.PipelineRolloutStatus{
 					ProgressiveStatus: apiv1.PipelineProgressiveStatus{
 						UpgradingPipelineStatus: &apiv1.UpgradingPipelineStatus{
+							InterStepBufferServiceName: defaultUpgradingISBSvc.GetName(),
 							UpgradingChildStatus: apiv1.UpgradingChildStatus{
 								Name:             defaultUpgradingPipelineName,
 								AssessmentResult: apiv1.AssessmentResultSuccess,

--- a/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
@@ -426,7 +426,7 @@ func Test_reconcile_isbservicerollout_Progressive(t *testing.T) {
 		expectedISBServices map[string]common.UpgradeState // after reconcile(), these are the only interstepbufferservices we expect to exist along with their expected UpgradeState
 
 	}{
-		/*{
+		{
 			// the Rollout's specified jetstream version - 2.10.11 - differs from the running one - 2.10.3
 			// that's a data loss field
 			name:                           "spec difference results in Progressive",
@@ -448,7 +448,7 @@ func Test_reconcile_isbservicerollout_Progressive(t *testing.T) {
 				defaultPromotedISBSvcName:  common.LabelValueUpgradePromoted,
 				defaultUpgradingISBSvcName: common.LabelValueUpgradeInProgress,
 			},
-		},*/
+		},
 		{
 			// the "upgrading" isbsvc succeeds (given that its pipeline succeeded)
 			// the original pipeline was deleted, so the isbsvc in turn can also be deleted
@@ -512,6 +512,7 @@ func Test_reconcile_isbservicerollout_Progressive(t *testing.T) {
 				&apiv1.PipelineRolloutStatus{
 					ProgressiveStatus: apiv1.PipelineProgressiveStatus{
 						UpgradingPipelineStatus: &apiv1.UpgradingPipelineStatus{
+							InterStepBufferServiceName: defaultUpgradingISBSvc.GetName(),
 							UpgradingChildStatus: apiv1.UpgradingChildStatus{
 								Name:             defaultUpgradingPipelineName,
 								AssessmentResult: apiv1.AssessmentResultFailure,
@@ -553,6 +554,7 @@ func Test_reconcile_isbservicerollout_Progressive(t *testing.T) {
 				&apiv1.PipelineRolloutStatus{
 					ProgressiveStatus: apiv1.PipelineProgressiveStatus{
 						UpgradingPipelineStatus: &apiv1.UpgradingPipelineStatus{
+							InterStepBufferServiceName: defaultUpgradingISBSvc.GetName(),
 							UpgradingChildStatus: apiv1.UpgradingChildStatus{
 								Name:             defaultUpgradingPipelineName,
 								AssessmentResult: apiv1.AssessmentResultFailure,

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -63,7 +63,7 @@ func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 	for _, pipelineRollout := range pipelineRollouts {
 		upgradingPipelineStatus := pipelineRollout.Status.ProgressiveStatus.UpgradingPipelineStatus
 		if upgradingPipelineStatus == nil || upgradingPipelineStatus.InterStepBufferServiceName != existingUpgradingChildDef.GetName() {
-			numaLogger.WithValues("pipeline", upgradingPipelineStatus.Name).Debug("can't assess ISBService; pipeline is not yet upgrading with this ISBService")
+			numaLogger.WithValues("pipelinerollout", pipelineRollout.GetName()).Debug("can't assess ISBService; pipeline is not yet upgrading with this ISBService")
 			return apiv1.AssessmentResultUnknown, nil
 		}
 		switch pipelineRollout.Status.ProgressiveStatus.UpgradingPipelineStatus.AssessmentResult {
@@ -73,8 +73,12 @@ func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 		case apiv1.AssessmentResultUnknown:
 			numaLogger.WithValues("pipeline", upgradingPipelineStatus.Name).Debug("pipeline assessment is unknown")
 			return apiv1.AssessmentResultUnknown, nil
+		case apiv1.AssessmentResultSuccess:
+			numaLogger.WithValues("pipeline", upgradingPipelineStatus.Name).Debug("pipeline succeeded")
+
 		}
 	}
+
 	return apiv1.AssessmentResultSuccess, nil
 }
 

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -123,7 +123,7 @@ func (r *ISBServiceRolloutReconciler) ProcessPromotedChildPreUpgrade(
 	return false, nil
 }
 
-func (r *ISBServiceRolloutReconciler) ProcessPromotedChildPostUpgrade(
+func (r *ISBServiceRolloutReconciler) ProcessPromotedChildPostFailure(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
 	promotedChildDef *unstructured.Unstructured,

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -328,11 +328,14 @@ func (r *MonoVertexRolloutReconciler) processExistingMonoVertex(ctx context.Cont
 	case apiv1.UpgradeStrategyProgressive:
 		numaLogger.Debug("processing MonoVertex with Progressive")
 
-		// Get the MonoVertexRollout live resource
+		// Get the MonoVertexRollout live resource so we can grab the ProgressiveStatus from that for our own local monoVertexRollout
+		// (Note we don't copy the entire Status in case we've updated something locally)
 		liveMonoVertexRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().MonoVertexRollouts(monoVertexRollout.Namespace).Get(ctx, monoVertexRollout.Name, metav1.GetOptions{})
 		if err != nil {
 			return 0, fmt.Errorf("error getting the live MonoVertexRollout for assessment processing: %w", err)
 		}
+
+		monoVertexRollout.Status.ProgressiveStatus = *liveMonoVertexRollout.Status.ProgressiveStatus.DeepCopy()
 
 		// don't risk out-of-date cache while performing Progressive strategy - get
 		// the most current version of the MonoVertex just in case
@@ -345,7 +348,7 @@ func (r *MonoVertexRolloutReconciler) processExistingMonoVertex(ctx context.Cont
 			}
 		}
 
-		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, monoVertexRollout, liveMonoVertexRollout, existingMonoVertexDef, mvNeedsToUpdate, r, r.client)
+		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, monoVertexRollout, existingMonoVertexDef, mvNeedsToUpdate, r, r.client)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -114,7 +114,7 @@ func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPreUpgrade(
 }
 
 /*
-ProcessPromotedChildPostFailure handles the post-upgrade processing of a promoted monovertex.
+ProcessPromotedChildPostFailure andles the post-upgrade processing of the promoted monovertex after the "upgrading" child has failed.
 It performs the following post-upgrade operations:
 - it restores the promoted monovertex scale values to the desired values retrieved from the rollout status.
 

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -114,7 +114,7 @@ func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPreUpgrade(
 }
 
 /*
-ProcessPromotedChildPostUpgrade handles the post-upgrade processing of a promoted monovertex.
+ProcessPromotedChildPostFailure handles the post-upgrade processing of a promoted monovertex.
 It performs the following post-upgrade operations:
 - it restores the promoted monovertex scale values to the desired values retrieved from the rollout status.
 
@@ -128,7 +128,7 @@ Returns:
   - A boolean indicating whether we should requeue.
   - An error if any issues occur during processing.
 */
-func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPostUpgrade(
+func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPostFailure(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
 	promotedChildDef *unstructured.Unstructured,

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -209,6 +209,8 @@ func scaleDownMonoVertex(
 	// If for the vertex we already set a Scaled scale value, we only need to update the actual pods count
 	// to later verify that the pods were actually scaled down.
 	// We want to skip scaling down again.
+	// TODO: why do we concern ourselves if vertexScaleValues.ScaleTo != 0? If we scale 1 Pod to 0, we go past here even if the scale values
+	// were found
 	if vertexScaleValues, exist := scaleValuesMap[promotedChildDef.GetName()]; exist && vertexScaleValues.ScaleTo != 0 {
 		vertexScaleValues.Actual = actualPodsCount
 		scaleValuesMap[promotedChildDef.GetName()] = vertexScaleValues

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -132,7 +132,7 @@ func (r *PipelineRolloutReconciler) ProcessPromotedChildPreUpgrade(
 }
 
 /*
-ProcessPromotedChildPostFailure handles the post-upgrade processing of a promoted pipeline.
+ProcessPromotedChildPostFailure handles the post-upgrade processing of the promoted pipeline after the "upgrading" child has failed.
 It performs the following post-upgrade operations:
 - it restores the promoted pipeline source vertices scale values to the desired values retrieved from the rollout status.
 

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -132,7 +132,7 @@ func (r *PipelineRolloutReconciler) ProcessPromotedChildPreUpgrade(
 }
 
 /*
-ProcessPromotedChildPostUpgrade handles the post-upgrade processing of a promoted pipeline.
+ProcessPromotedChildPostFailure handles the post-upgrade processing of a promoted pipeline.
 It performs the following post-upgrade operations:
 - it restores the promoted pipeline source vertices scale values to the desired values retrieved from the rollout status.
 
@@ -146,7 +146,7 @@ Returns:
   - A boolean indicating whether we should requeue.
   - An error if any issues occur during processing.
 */
-func (r *PipelineRolloutReconciler) ProcessPromotedChildPostUpgrade(
+func (r *PipelineRolloutReconciler) ProcessPromotedChildPostFailure(
 	ctx context.Context,
 	pipelineRollout progressive.ProgressiveRolloutObject,
 	promotedPipelineDef *unstructured.Unstructured,

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -279,12 +279,6 @@ func processUpgradingChild(
 
 		// if so, mark the existing one for garbage collection and then create a new upgrading one
 		if needsUpdating {
-			// this shouldn't happen but just in case the PromotedChildStatus isn't there or is identifying the wrong Pipeline, reset it
-			//promotedChildStatus := rolloutObject.GetPromotedChildStatus()
-			//if promotedChildStatus == nil || promotedChildStatus.Name != existingPromotedChildDef.GetName() {
-			//	rolloutObject.ResetPromotedChildStatus(existingPromotedChildDef)
-			//}
-
 			requeue, err := controller.ProcessPromotedChildPreUpgrade(ctx, rolloutObject, existingPromotedChildDef, c)
 			if err != nil {
 				return false, false, 0, err
@@ -309,12 +303,6 @@ func processUpgradingChild(
 			err = kubernetes.CreateResource(ctx, c, newUpgradingChildDef)
 			return false, true, 0, err
 		} else {
-			// this shouldn't happen but just in case the PromotedChildStatus isn't there or is identifying the wrong Pipeline, reset it
-			//promotedChildStatus := rolloutObject.GetPromotedChildStatus()
-			//if promotedChildStatus == nil || promotedChildStatus.Name != existingPromotedChildDef.GetName() {
-			//	rolloutObject.ResetPromotedChildStatus(existingPromotedChildDef)
-			//}
-
 			requeue, err := controller.ProcessPromotedChildPostFailure(ctx, rolloutObject, existingPromotedChildDef, c)
 			if err != nil {
 				return false, false, 0, err

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -220,15 +220,14 @@ func processUpgradingChild(
 			numaLogger.WithValues("name", existingUpgradingChildDef.GetName()).Debug("the live upgrading child status has not been set yet, initializing it")
 		}
 
-		// TODO: replace this with ResetUpgradingChild()
-		childStatus = &apiv1.UpgradingChildStatus{
-			Name:             existingUpgradingChildDef.GetName(),
-			AssessmentResult: apiv1.AssessmentResultUnknown,
+		err = rolloutObject.ResetUpgradingChildStatus(existingUpgradingChildDef)
+		if err != nil {
+			return false, false, 0, fmt.Errorf("processing upgrading child, failed to reset the upgrading child status for child %s/%s", existingUpgradingChildDef.GetNamespace(), existingUpgradingChildDef.GetName())
 		}
-		childStatus.InitAssessUntil()
 	} else {
 		numaLogger.WithValues("childStatus", *childStatus).Debug("live upgrading child previously set")
 	}
+	childStatus = rolloutObject.GetUpgradingChildStatus()
 
 	// If no NextAssessmentTime has been set already, calculate it and set it
 	if childStatus.NextAssessmentTime == nil {

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -106,7 +106,10 @@ func ProcessResource(
 		if currentUpgradingChildDef == nil {
 			promotedChildStatus := rolloutObject.GetPromotedChildStatus()
 			if promotedChildStatus == nil || promotedChildStatus.Name != existingPromotedChild.GetName() {
-				rolloutObject.ResetPromotedChildStatus(existingPromotedChild)
+				err = rolloutObject.ResetPromotedChildStatus(existingPromotedChild)
+				if err != nil {
+					return false, false, 0, err
+				}
 			}
 
 			requeue, err := controller.ProcessPromotedChildPreUpgrade(ctx, rolloutObject, existingPromotedChild, c)
@@ -217,6 +220,7 @@ func processUpgradingChild(
 			numaLogger.WithValues("name", existingUpgradingChildDef.GetName()).Debug("the live upgrading child status has not been set yet, initializing it")
 		}
 
+		// TODO: replace this with ResetUpgradingChild()
 		childStatus = &apiv1.UpgradingChildStatus{
 			Name:             existingUpgradingChildDef.GetName(),
 			AssessmentResult: apiv1.AssessmentResultUnknown,

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -321,7 +321,7 @@ func processUpgradingChild(
 		if childStatus.CanDeclareSuccess() {
 
 			// Label the new child as promoted and then remove the label from the old one
-			numaLogger.WithValues("old child", existingPromotedChildDef.GetName(), "new child", existingUpgradingChildDef.GetName(), "replacing 'promoted' child")
+			numaLogger.WithValues("old child", existingPromotedChildDef.GetName(), "new child", existingUpgradingChildDef.GetName()).Debug("replacing 'promoted' child")
 			reasonSuccess := common.LabelValueProgressiveSuccess
 			err := ctlrcommon.UpdateUpgradeState(ctx, c, common.LabelValueUpgradePromoted, &reasonSuccess, existingUpgradingChildDef)
 			if err != nil {

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -79,7 +79,7 @@ func Test_processUpgradingChild(t *testing.T) {
 
 	testCases := []struct {
 		name                      string
-		liveRolloutObject         ProgressiveRolloutObject
+		rolloutObject             ProgressiveRolloutObject
 		existingUpgradingChildDef *unstructured.Unstructured
 		expectedDone              bool
 		expectedNewChildCreated   bool
@@ -88,7 +88,7 @@ func Test_processUpgradingChild(t *testing.T) {
 	}{
 		{
 			name:                      "no upgrading child status on the live rollout",
-			liveRolloutObject:         defaultMonoVertexRollout.DeepCopy(),
+			rolloutObject:             defaultMonoVertexRollout.DeepCopy(),
 			existingUpgradingChildDef: &unstructured.Unstructured{Object: map[string]any{"metadata": map[string]any{"name": "test"}}},
 			expectedDone:              false,
 			expectedNewChildCreated:   false,
@@ -97,7 +97,7 @@ func Test_processUpgradingChild(t *testing.T) {
 		},
 		{
 			name: "preset upgrading child status on the live rollout - different name",
-			liveRolloutObject: setMonoVertexProgressiveStatus(
+			rolloutObject: setMonoVertexProgressiveStatus(
 				defaultMonoVertexRollout.DeepCopy(),
 				&apiv1.UpgradingMonoVertexStatus{UpgradingChildStatus: apiv1.UpgradingChildStatus{Name: "test"}},
 				nil),
@@ -110,7 +110,7 @@ func Test_processUpgradingChild(t *testing.T) {
 		},
 		{
 			name: "preset upgrading child status on the live rollout - same name, can assess, success",
-			liveRolloutObject: setMonoVertexProgressiveStatus(
+			rolloutObject: setMonoVertexProgressiveStatus(
 				defaultMonoVertexRollout.DeepCopy(),
 				&apiv1.UpgradingMonoVertexStatus{
 					UpgradingChildStatus: apiv1.UpgradingChildStatus{
@@ -129,7 +129,7 @@ func Test_processUpgradingChild(t *testing.T) {
 		},
 		{
 			name: "preset upgrading child status on the live rollout - same name, failure",
-			liveRolloutObject: setMonoVertexProgressiveStatus(
+			rolloutObject: setMonoVertexProgressiveStatus(
 				defaultMonoVertexRollout.DeepCopy(),
 				&apiv1.UpgradingMonoVertexStatus{
 					UpgradingChildStatus: apiv1.UpgradingChildStatus{
@@ -158,7 +158,7 @@ func Test_processUpgradingChild(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualDone, actualNewChildCreated, actualRequeueDelay, actualErr := processUpgradingChild(
-				ctx, defaultMonoVertexRollout, tc.liveRolloutObject, fakeProgressiveController{}, defaultExistingPromotedChildDef, tc.existingUpgradingChildDef, client)
+				ctx, tc.rolloutObject, fakeProgressiveController{}, defaultExistingPromotedChildDef, tc.existingUpgradingChildDef, client)
 
 			if tc.expectedError != nil {
 				assert.Error(t, actualErr)

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -51,7 +51,7 @@ func (fpc fakeProgressiveController) ProcessPromotedChildPreUpgrade(ctx context.
 	return false, nil
 }
 
-func (fpc fakeProgressiveController) ProcessPromotedChildPostUpgrade(ctx context.Context, rolloutObject ProgressiveRolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
+func (fpc fakeProgressiveController) ProcessPromotedChildPostFailure(ctx context.Context, rolloutObject ProgressiveRolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
 	return false, nil
 }
 

--- a/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
@@ -143,9 +143,12 @@ func (isbServiceRollout *ISBServiceRollout) GetPromotedChildStatus() *PromotedCh
 // ResetUpgradingChildStatus is a function of the progressiveRolloutObject
 // note this resets the entire Upgrading status struct which encapsulates the UpgradingChildStatus struct
 func (isbServiceRollout *ISBServiceRollout) ResetUpgradingChildStatus(upgradingISBService *unstructured.Unstructured) error {
+	assessUntil := metav1.NewTime(assessUntilInitValue)
 	isbServiceRollout.Status.ProgressiveStatus.UpgradingISBServiceStatus = &UpgradingISBServiceStatus{
 		UpgradingChildStatus: UpgradingChildStatus{
-			Name: upgradingISBService.GetName(),
+			Name:             upgradingISBService.GetName(),
+			AssessUntil:      &assessUntil,
+			AssessmentResult: AssessmentResultUnknown,
 		},
 	}
 

--- a/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -105,8 +106,8 @@ func (isbServiceRollout *ISBServiceRollout) GetRolloutGVK() schema.GroupVersionK
 
 func (isbServiceRollout *ISBServiceRollout) GetChildGVR() metav1.GroupVersionResource {
 	return metav1.GroupVersionResource{
-		Group:    numaflowv1.PipelineGroupVersionKind.Group,
-		Version:  numaflowv1.PipelineGroupVersionKind.Version,
+		Group:    numaflowv1.ISBGroupVersionKind.Group,
+		Version:  numaflowv1.ISBGroupVersionKind.Version,
 		Resource: "interstepbufferservices",
 	}
 }
@@ -139,12 +140,36 @@ func (isbServiceRollout *ISBServiceRollout) GetPromotedChildStatus() *PromotedCh
 	return &isbServiceRollout.Status.ProgressiveStatus.PromotedISBServiceStatus.PromotedChildStatus
 }
 
+// ResetUpgradingChildStatus is a function of the progressiveRolloutObject
+// note this resets the entire Upgrading status struct which encapsulates the UpgradingChildStatus struct
+func (isbServiceRollout *ISBServiceRollout) ResetUpgradingChildStatus(upgradingISBService *unstructured.Unstructured) error {
+	isbServiceRollout.Status.ProgressiveStatus.UpgradingISBServiceStatus = &UpgradingISBServiceStatus{
+		UpgradingChildStatus: UpgradingChildStatus{
+			Name: upgradingISBService.GetName(),
+		},
+	}
+
+	return nil
+}
+
 // SetUpgradingChildStatus is a function of the progressiveRolloutObject
 func (isbServiceRollout *ISBServiceRollout) SetUpgradingChildStatus(status *UpgradingChildStatus) {
 	if isbServiceRollout.Status.ProgressiveStatus.UpgradingISBServiceStatus == nil {
 		isbServiceRollout.Status.ProgressiveStatus.UpgradingISBServiceStatus = &UpgradingISBServiceStatus{}
 	}
 	isbServiceRollout.Status.ProgressiveStatus.UpgradingISBServiceStatus.UpgradingChildStatus = *status.DeepCopy()
+}
+
+// ResetPromotedChildStatus is a function of the progressiveRolloutObject
+// note this resets the entire Promoted status struct which encapsulates the PromotedChildStatus struct
+func (isbServiceRollout *ISBServiceRollout) ResetPromotedChildStatus(promotedISBService *unstructured.Unstructured) error {
+	isbServiceRollout.Status.ProgressiveStatus.PromotedISBServiceStatus = &PromotedISBServiceStatus{
+		PromotedChildStatus: PromotedChildStatus{
+			Name: promotedISBService.GetName(),
+		},
+	}
+
+	return nil
 }
 
 // SetPromotedChildStatus is a function of the progressiveRolloutObject

--- a/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -132,6 +133,17 @@ func (monoVertexRollout *MonoVertexRollout) GetUpgradingChildStatus() *Upgrading
 	return &monoVertexRollout.Status.ProgressiveStatus.UpgradingMonoVertexStatus.UpgradingChildStatus
 }
 
+// ResetUpgradingChildStatus is a function of the progressiveRolloutObject
+// note this resets the entire Upgrading status struct which encapsulates the UpgradingChildStatus struct
+func (monoVertexRollout *MonoVertexRollout) ResetUpgradingChildStatus(upgradingMonoVertex *unstructured.Unstructured) error {
+	monoVertexRollout.Status.ProgressiveStatus.UpgradingMonoVertexStatus = &UpgradingMonoVertexStatus{
+		UpgradingChildStatus: UpgradingChildStatus{
+			Name: upgradingMonoVertex.GetName(),
+		},
+	}
+	return nil
+}
+
 // GetPromotedChildStatus is a function of the progressiveRolloutObject
 func (monoVertexRollout *MonoVertexRollout) GetPromotedChildStatus() *PromotedChildStatus {
 	if monoVertexRollout.Status.ProgressiveStatus.PromotedMonoVertexStatus == nil {
@@ -146,6 +158,19 @@ func (monoVertexRollout *MonoVertexRollout) SetUpgradingChildStatus(status *Upgr
 		monoVertexRollout.Status.ProgressiveStatus.UpgradingMonoVertexStatus = &UpgradingMonoVertexStatus{}
 	}
 	monoVertexRollout.Status.ProgressiveStatus.UpgradingMonoVertexStatus.UpgradingChildStatus = *status.DeepCopy()
+}
+
+// ResetPromotedChildStatus is a function of the progressiveRolloutObject
+// note this resets the entire Promoted status struct which encapsulates the PromotedChildStatus struct
+func (monoVertexRollout *MonoVertexRollout) ResetPromotedChildStatus(promotedMonoVertex *unstructured.Unstructured) error {
+	monoVertexRollout.Status.ProgressiveStatus.PromotedMonoVertexStatus = &PromotedMonoVertexStatus{
+		PromotedPipelineTypeStatus: PromotedPipelineTypeStatus{
+			PromotedChildStatus: PromotedChildStatus{
+				Name: promotedMonoVertex.GetName(),
+			},
+		},
+	}
+	return nil
 }
 
 // SetPromotedChildStatus is a function of the progressiveRolloutObject

--- a/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
@@ -136,9 +136,12 @@ func (monoVertexRollout *MonoVertexRollout) GetUpgradingChildStatus() *Upgrading
 // ResetUpgradingChildStatus is a function of the progressiveRolloutObject
 // note this resets the entire Upgrading status struct which encapsulates the UpgradingChildStatus struct
 func (monoVertexRollout *MonoVertexRollout) ResetUpgradingChildStatus(upgradingMonoVertex *unstructured.Unstructured) error {
+	assessUntil := metav1.NewTime(assessUntilInitValue)
 	monoVertexRollout.Status.ProgressiveStatus.UpgradingMonoVertexStatus = &UpgradingMonoVertexStatus{
 		UpgradingChildStatus: UpgradingChildStatus{
-			Name: upgradingMonoVertex.GetName(),
+			Name:             upgradingMonoVertex.GetName(),
+			AssessUntil:      &assessUntil,
+			AssessmentResult: AssessmentResultUnknown,
 		},
 	}
 	return nil

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -157,12 +157,16 @@ func (pipelineRollout *PipelineRollout) ResetUpgradingChildStatus(upgradingPipel
 	if !found {
 		isbsvcName = "default" // if not set, the default value is "default"
 	}
+	assessUntil := metav1.NewTime(assessUntilInitValue)
 	pipelineRollout.Status.ProgressiveStatus.UpgradingPipelineStatus = &UpgradingPipelineStatus{
 		InterStepBufferServiceName: isbsvcName,
 		UpgradingChildStatus: UpgradingChildStatus{
-			Name: upgradingPipeline.GetName(),
+			Name:             upgradingPipeline.GetName(),
+			AssessUntil:      &assessUntil,
+			AssessmentResult: AssessmentResultUnknown,
 		},
 	}
+
 	return nil
 }
 

--- a/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
@@ -80,31 +80,29 @@ type PromotedPipelineTypeStatus struct {
 // assessUntilInitValue is an arbitrary value in the far future to use as a maximum value for AssessUntil
 var assessUntilInitValue = time.Date(2222, 2, 2, 2, 2, 2, 0, time.UTC)
 
-/*
-// InitAssessUntil initializes the AssessUntil field to a large value.
-func (ucs *UpgradingChildStatus) InitAssessUntil() {
-	if ucs == nil {
-		ucs = &UpgradingChildStatus{}
-	}
-
-	assessUntil := metav1.NewTime(assessUntilInitValue)
-	ucs.AssessUntil = &assessUntil
-}*/
-
 // IsAssessUntilSet checks if the AssessUntil field is not nil nor set to a maximum arbitrary value in the far future.
 func (ucs *UpgradingChildStatus) IsAssessUntilSet() bool {
 	return ucs != nil && ucs.AssessUntil != nil && !ucs.AssessUntil.Time.Equal(assessUntilInitValue)
 }
 
 // CanAssess determines if the UpgradingChildStatus instance is eligible for assessment.
-// It checks that the current time is after the NextAssessmentTime and
-// before the AssessUntil time, and that it hasn't already previously failed
+// It checks that the current time is after the NextAssessmentTime and that it hasn't already previously failed
 // (all checks within the time period must succeed, so if we previously failed, we maintain that failed status).
 func (ucs *UpgradingChildStatus) CanAssess() bool {
 	return ucs != nil &&
 		ucs.NextAssessmentTime != nil && time.Now().After(ucs.NextAssessmentTime.Time) &&
-		ucs.AssessUntil != nil && time.Now().Before(ucs.AssessUntil.Time) &&
+		//ucs.AssessUntil != nil && time.Now().Before(ucs.AssessUntil.Time) &&
 		ucs.AssessmentResult != AssessmentResultFailure
+}
+
+// CanDeclareSuccess() determines if it's okay to declare success:
+// We must have arrived at the AssessUntil time
+// Note that if we've arrived at the AssessUntil time, then the assumption is that it never failed within the window;
+// otherwise we would've stopped assessing
+func (ucs *UpgradingChildStatus) CanDeclareSuccess() bool {
+	return ucs != nil &&
+		ucs.AssessUntil != nil &&
+		time.Now().After(ucs.AssessUntil.Time)
 }
 
 func (ucs *UpgradingChildStatus) IsFailed() bool {

--- a/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
@@ -91,7 +91,6 @@ func (ucs *UpgradingChildStatus) IsAssessUntilSet() bool {
 func (ucs *UpgradingChildStatus) CanAssess() bool {
 	return ucs != nil &&
 		ucs.NextAssessmentTime != nil && time.Now().After(ucs.NextAssessmentTime.Time) &&
-		//ucs.AssessUntil != nil && time.Now().Before(ucs.AssessUntil.Time) &&
 		ucs.AssessmentResult != AssessmentResultFailure
 }
 

--- a/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
@@ -80,6 +80,7 @@ type PromotedPipelineTypeStatus struct {
 // assessUntilInitValue is an arbitrary value in the far future to use as a maximum value for AssessUntil
 var assessUntilInitValue = time.Date(2222, 2, 2, 2, 2, 2, 0, time.UTC)
 
+/*
 // InitAssessUntil initializes the AssessUntil field to a large value.
 func (ucs *UpgradingChildStatus) InitAssessUntil() {
 	if ucs == nil {
@@ -88,7 +89,7 @@ func (ucs *UpgradingChildStatus) InitAssessUntil() {
 
 	assessUntil := metav1.NewTime(assessUntilInitValue)
 	ucs.AssessUntil = &assessUntil
-}
+}*/
 
 // IsAssessUntilSet checks if the AssessUntil field is not nil nor set to a maximum arbitrary value in the far future.
 func (ucs *UpgradingChildStatus) IsAssessUntilSet() bool {

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -45,8 +45,7 @@ var (
 	testEnv             *envtest.Environment
 	ctx                 context.Context
 	cancel              context.CancelFunc
-	suiteTimeout        = 35 * time.Minute // Note: if we start seeing "client rate limiter: context deadline exceeded", we need to increase this value
-	testTimeout         = 4 * time.Minute  // Note: this timeout needs to be large enough to allow for delayed child resource healthiness assessment (current delay is 2 minutes with a 1 minute reassess window)
+	testTimeout         = 4 * time.Minute // Note: this timeout needs to be large enough to allow for delayed child resource healthiness assessment (current delay is 2 minutes with a 1 minute reassess window)
 	testPollingInterval = 10 * time.Millisecond
 
 	pipelineRolloutClient           planepkg.PipelineRolloutInterface
@@ -438,7 +437,7 @@ func BeforeSuiteSetup() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
-	ctx, cancel = context.WithTimeout(context.Background(), suiteTimeout) // Note: if we start seeing "client rate limiter: context deadline exceeded", we need to increase this value
+	ctx = context.Background()
 
 	scheme := runtime.NewScheme()
 	err = apiv1.AddToScheme(scheme)

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -44,7 +44,6 @@ var (
 	dynamicClient       dynamic.DynamicClient
 	testEnv             *envtest.Environment
 	ctx                 context.Context
-	cancel              context.CancelFunc
 	testTimeout         = 4 * time.Minute // Note: this timeout needs to be large enough to allow for delayed child resource healthiness assessment (current delay is 2 minutes with a 1 minute reassess window)
 	testPollingInterval = 10 * time.Millisecond
 

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -510,7 +510,6 @@ func BeforeSuiteSetup() {
 
 var _ = AfterSuite(func() {
 
-	cancel()
 	By("tearing down test environment")
 	close(stopCh)
 

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -303,7 +303,9 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Document("setting desiredPhase=Paused")
 		currentMonoVertexSpec.Lifecycle.DesiredPhase = numaflowv1.MonoVertexPhasePaused
 
-		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhasePaused)
+		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhasePaused, func(spec numaflowv1.MonoVertexSpec) bool {
+			return spec.Lifecycle.DesiredPhase == numaflowv1.MonoVertexPhasePaused
+		})
 
 		VerifyMonoVertexStaysPaused(monoVertexRolloutName)
 	})
@@ -315,7 +317,9 @@ var _ = Describe("Functional e2e", Serial, func() {
 		Document("setting desiredPhase=Running")
 		currentMonoVertexSpec.Lifecycle.DesiredPhase = numaflowv1.MonoVertexPhaseRunning
 
-		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning)
+		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning, func(spec numaflowv1.MonoVertexSpec) bool {
+			return spec.Lifecycle.DesiredPhase == numaflowv1.MonoVertexPhaseRunning
+		})
 
 	})
 
@@ -378,7 +382,9 @@ var _ = Describe("Functional e2e", Serial, func() {
 		rpu := int64(10)
 		updatedMonoVertexSpec.Source.Generator = &numaflowv1.GeneratorSource{RPU: &rpu}
 
-		UpdateMonoVertexRollout(monoVertexRolloutName, updatedMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning)
+		UpdateMonoVertexRollout(monoVertexRolloutName, updatedMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning, func(spec numaflowv1.MonoVertexSpec) bool {
+			return spec.Source != nil && spec.Source.Generator != nil && *spec.Source.Generator.RPU == rpu
+		})
 
 		VerifyMonoVertexSpec(Namespace, monoVertexRolloutName, func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec) bool {
 			return retrievedMonoVertexSpec.Source.Generator != nil && retrievedMonoVertexSpec.Source.UDSource == nil

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -69,7 +69,7 @@ func VerifyISBServiceSpec(namespace string, isbServiceRolloutName string, f func
 		}
 
 		return f(retrievedISBServiceSpec)
-	}, testTimeout, testPollingInterval).Should(BeTrue())
+	}, 8*time.Minute, testPollingInterval).Should(BeTrue())
 }
 
 func verifyISBSvcRolloutReady(isbServiceRolloutName string) {

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -352,7 +352,7 @@ func DeleteMonoVertexRollout(name string) {
 	}).WithTimeout(testTimeout).Should(BeTrue(), "The MonoVertex should have been deleted but it was found.")
 }
 
-func UpdateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, expectedFinalPhase numaflowv1.MonoVertexPhase) {
+func UpdateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, expectedFinalPhase numaflowv1.MonoVertexPhase, verifySpecFunc func(numaflowv1.MonoVertexSpec) bool) {
 
 	rawSpec, err := json.Marshal(newSpec)
 	Expect(err).ShouldNot(HaveOccurred())
@@ -362,8 +362,11 @@ func UpdateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, exp
 		rollout.Spec.MonoVertex.Spec.Raw = rawSpec
 		return rollout, nil
 	})
+	Document("Verifying MonoVertex spec got updated")
+	// get Pipeline to check that spec has been updated to correct spec
+	VerifyMonoVertexSpec(Namespace, name, verifySpecFunc)
 
-	Document("verifying MonoVertexRollout spec deployed")
+	Document("verifying MonoVertexRollout Phase=Deployed")
 	verifyMonoVertexRolloutDeployed(name)
 	if expectedFinalPhase == numaflowv1.MonoVertexPhaseRunning {
 		verifyMonoVertexRolloutHealthy(name)

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -516,7 +516,7 @@ func UpdatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expecte
 	}
 
 	// rollout phase will be pending if we are expecting a long pausing state and Pipeline will not be fully updated
-	if expectedFinalPhase != numaflowv1.PipelinePhasePausing {
+	if !(UpgradeStrategy == config.PPNDStrategyID && expectedFinalPhase == numaflowv1.PipelinePhasePausing) {
 		Document("Verifying Pipeline got updated")
 		// get Pipeline to check that spec has been updated to correct spec
 		VerifyPipelineSpec(Namespace, name, verifySpecFunc)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #550 

### Modifications

This fixes a few issues (all of them are described inline):
- Reset the entire Upgrading Child Status and Promoted Child Status instead of just setting the inner structs that are common to all Rollouts
- Make sure to reset the Promoted Child Set if there's a new promoted child (it didn't look like we were)
- Make sure the Assessment of ISBService isn't dependent on the Pipeline still being there (it could be deleted)
- Premature success was being declared if it succeeded just once within the time window
- copy/paste error
- functional test bug for progressive case

### Verification

Ran e2e test many times, all passing.

**Manual testing:**
For **MonoVertex**, I did a test in which I:
1. Create MonoVertexRollout with scale.min/max=3,6
2. Update image to a bad one
3. Observe initial MonoVertex scale down to 1 Pod
4. Observe NextAssessmentTime gets set, then AssessUntil after the first assessment is made
5. Observe it's marked Failed as soon as the first failure is recorded
6. Observed promoted MonoVertex gets scaled back up
7. Restore MonoVertexRollout back to original image 
8. Observe same steps as above happen except that determination of "Success" happens only once "AssessUntil" time is reached

For **InterstepBufferService** and **Pipeline**, I did a test in which I:
1. Create ISBServiceRollout and PipelineRollout
2. Update ISBServiceRollout to a different version
3. Observe initial Pipeline scale down
4. Observe that Successful assessment is only made for each after the AssessUntil time is reached
5. Observe new pipeline and new isbservice get promoted


### Backward incompatibilities

None
