### PR TITLE
fix: rollout deletion sequence

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -207,6 +207,12 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 			if err := r.client.Delete(ctx, isbServiceRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return ctrl.Result{}, err
 			}
+			// Get the nfcRollout live resource
+			LiveISBServiceRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().ISBServiceRollouts(isbServiceRollout.Namespace).Get(ctx, isbServiceRollout.Name, metav1.GetOptions{})
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("error getting the live ISB Service rollout: %w", err)
+			}
+			*isbServiceRollout = *LiveISBServiceRollout
 			controllerutil.RemoveFinalizer(isbServiceRollout, common.FinalizerName)
 		}
 		// generate metrics for ISB Service deletion.

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -208,11 +208,11 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 				return ctrl.Result{}, err
 			}
 			// Get the nfcRollout live resource
-			LiveISBServiceRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().ISBServiceRollouts(isbServiceRollout.Namespace).Get(ctx, isbServiceRollout.Name, metav1.GetOptions{})
+			liveISBServiceRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().ISBServiceRollouts(isbServiceRollout.Namespace).Get(ctx, isbServiceRollout.Name, metav1.GetOptions{})
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("error getting the live ISB Service rollout: %w", err)
 			}
-			*isbServiceRollout = *LiveISBServiceRollout
+			*isbServiceRollout = *liveISBServiceRollout
 			controllerutil.RemoveFinalizer(isbServiceRollout, common.FinalizerName)
 		}
 		// generate metrics for ISB Service deletion.

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -200,6 +200,12 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 			if err := r.client.Delete(ctx, monoVertexRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return ctrl.Result{}, err
 			}
+			// Get the monoVertexRollout live resource
+			liveMonoVertexRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().MonoVertexRollouts(monoVertexRollout.Namespace).Get(ctx, monoVertexRollout.Name, metav1.GetOptions{})
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("error getting the live monoVertex rollout: %w", err)
+			}
+			*monoVertexRollout = *liveMonoVertexRollout
 			controllerutil.RemoveFinalizer(monoVertexRollout, common.FinalizerName)
 		}
 		// generate metrics for MonoVertex deletion

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -236,6 +236,12 @@ func (r *NumaflowControllerReconciler) reconcile(
 			if err := r.client.Delete(ctx, controller, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return ctrl.Result{}, err
 			}
+			// Get the controller live resource
+			liveController, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().NumaflowControllers(controller.Namespace).Get(ctx, controller.Name, metav1.GetOptions{})
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("error getting the live controller: %w", err)
+			}
+			*controller = *liveController
 			// Check if dependent resources are deleted, if not then requeue
 			if ok, err := r.areDependentResourcesDeleted(ctx, controller); !ok || err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete dependent resources: %v", err)

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -51,6 +51,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	sigsyaml "sigs.k8s.io/yaml"
 
+	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaplane/internal/common"
 	ctlrcommon "github.com/numaproj/numaplane/internal/controller/common"
 	"github.com/numaproj/numaplane/internal/controller/config"
@@ -730,7 +731,7 @@ func (r *NumaflowControllerReconciler) ErrorHandler(numaflowController *apiv1.Nu
 
 // areDependentResourcesDeleted checks if dependent resources are deleted.
 func (r *NumaflowControllerReconciler) areDependentResourcesDeleted(ctx context.Context, controller *apiv1.NumaflowController) (bool, error) {
-	pipelineList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, common.NumaflowPipelineKind,
+	pipelineList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, numaflowv1.PipelineGroupVersionResource.Resource,
 		controller.Namespace, common.LabelKeyParentRollout, "")
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -738,7 +739,7 @@ func (r *NumaflowControllerReconciler) areDependentResourcesDeleted(ctx context.
 		}
 		pipelineList = &unstructured.UnstructuredList{} // Assume it as an empty list
 	}
-	monoVertexList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, common.NumaflowMonoVertexKind,
+	monoVertexList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, numaflowv1.MonoVertexGroupVersionResource.Resource,
 		controller.Namespace, common.LabelKeyParentRollout, "")
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -746,7 +747,7 @@ func (r *NumaflowControllerReconciler) areDependentResourcesDeleted(ctx context.
 		}
 		monoVertexList = &unstructured.UnstructuredList{} // Assume it as an empty list
 	}
-	isbServiceList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, common.NumaflowISBServiceKind,
+	isbServiceList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, numaflowv1.ISBGroupVersionResource.Resource,
 		controller.Namespace, common.LabelKeyParentRollout, "")
 	if err != nil {
 		if !apierrors.IsNotFound(err) {

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -205,11 +205,11 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 				return ctrl.Result{}, err
 			}
 			// Get the nfcRollout live resource
-			nfcLiveRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().NumaflowControllerRollouts(nfcRollout.Namespace).Get(ctx, nfcRollout.Name, metav1.GetOptions{})
+			liveControllerRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().NumaflowControllerRollouts(nfcRollout.Namespace).Get(ctx, nfcRollout.Name, metav1.GetOptions{})
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("error getting the live numaflow controller rollout: %w", err)
 			}
-			*nfcRollout = *nfcLiveRollout
+			*nfcRollout = *liveControllerRollout
 			controllerutil.RemoveFinalizer(nfcRollout, common.FinalizerName)
 		}
 

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -204,6 +204,12 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 			if err := r.client.Delete(ctx, nfcRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return ctrl.Result{}, err
 			}
+			// Get the nfcRollout live resource
+			nfcLiveRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().NumaflowControllerRollouts(nfcRollout.Namespace).Get(ctx, nfcRollout.Name, metav1.GetOptions{})
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("error getting the live numaflow controller rollout: %w", err)
+			}
+			*nfcRollout = *nfcLiveRollout
 			controllerutil.RemoveFinalizer(nfcRollout, common.FinalizerName)
 		}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/567

### Modifications

- Fixed Rollout deletion sequence for isbService, MonoVertex and NumaflowController
- Fixes `areDependentResourcesDeleted` resources which are listing the child resources - Replaced Kind with Plural

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
