### PR TITLE
feat: make all e2e tests functions public

### DIFF
--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -367,7 +367,7 @@ func UpdateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, exp
 	VerifyMonoVertexSpec(Namespace, name, verifySpecFunc)
 
 	Document("verifying MonoVertexRollout Phase=Deployed")
-  VerifyMonoVertexRolloutDeployed(name)
+	VerifyMonoVertexRolloutDeployed(name)
 	if expectedFinalPhase == numaflowv1.MonoVertexPhaseRunning {
 		VerifyMonoVertexRolloutHealthy(name)
 	}

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -23,11 +23,11 @@ import (
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
-func getMonoVertex(namespace, monoVertexRolloutName string) (*unstructured.Unstructured, error) {
-	return getChildResource(getGVRForMonoVertex(), namespace, monoVertexRolloutName)
+func GetMonoVertex(namespace, monoVertexRolloutName string) (*unstructured.Unstructured, error) {
+	return getChildResource(GetGVRForMonoVertex(), namespace, monoVertexRolloutName)
 }
 
-func getGVRForMonoVertex() schema.GroupVersionResource {
+func GetGVRForMonoVertex() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    "numaflow.numaproj.io",
 		Version:  "v1alpha1",
@@ -48,7 +48,7 @@ func VerifyMonoVertexSpec(namespace, monoVertexRolloutName string, f func(numafl
 	Document("verifying MonoVertex Spec")
 	var retrievedMonoVertexSpec numaflowv1.MonoVertexSpec
 	Eventually(func() bool {
-		unstruct, err := getMonoVertex(namespace, monoVertexRolloutName)
+		unstruct, err := GetMonoVertex(namespace, monoVertexRolloutName)
 		if err != nil {
 			return false
 		}
@@ -60,7 +60,7 @@ func VerifyMonoVertexSpec(namespace, monoVertexRolloutName string, f func(numafl
 
 }
 
-func verifyMonoVertexRolloutReady(monoVertexRolloutName string) {
+func VerifyMonoVertexRolloutReady(monoVertexRolloutName string) {
 	Document("verifying that the MonoVertexRollout is ready")
 
 	Eventually(func() bool {
@@ -79,10 +79,10 @@ func verifyMonoVertexRolloutReady(monoVertexRolloutName string) {
 	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 }
 
-func verifyMonoVertexReady(namespace, monoVertexRolloutName string) {
+func VerifyMonoVertexReady(namespace, monoVertexRolloutName string) {
 
 	Document("Verifying that the MonoVertex is running")
-	monoVertexName := verifyMonoVertexStatus(namespace, monoVertexRolloutName,
+	monoVertexName := VerifyMonoVertexStatus(namespace, monoVertexRolloutName,
 		func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec, retrievedMonoVertexStatus kubernetes.GenericStatus) bool {
 			return retrievedMonoVertexStatus.Phase == string(numaflowv1.MonoVertexPhaseRunning)
 		})
@@ -96,14 +96,14 @@ func verifyMonoVertexReady(namespace, monoVertexRolloutName string) {
 
 }
 
-func verifyMonoVertexStatus(namespace, monoVertexRolloutName string, f func(numaflowv1.MonoVertexSpec, kubernetes.GenericStatus) bool) string {
+func VerifyMonoVertexStatus(namespace, monoVertexRolloutName string, f func(numaflowv1.MonoVertexSpec, kubernetes.GenericStatus) bool) string {
 
 	Document("verifying MonoVertexStatus")
 	var retrievedMonoVertexSpec numaflowv1.MonoVertexSpec
 	var retrievedMonoVertexStatus kubernetes.GenericStatus
 	var monoVertexName string
 	Eventually(func() bool {
-		unstruct, err := getMonoVertex(namespace, monoVertexRolloutName)
+		unstruct, err := GetMonoVertex(namespace, monoVertexRolloutName)
 		if err != nil {
 			return false
 		}
@@ -120,7 +120,7 @@ func verifyMonoVertexStatus(namespace, monoVertexRolloutName string, f func(numa
 	return monoVertexName
 }
 
-func updateMonoVertexRolloutInK8S(name string, f func(apiv1.MonoVertexRollout) (apiv1.MonoVertexRollout, error)) {
+func UpdateMonoVertexRolloutInK8S(name string, f func(apiv1.MonoVertexRollout) (apiv1.MonoVertexRollout, error)) {
 
 	Document("updating MonoVertexRollout")
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -164,7 +164,7 @@ func watchMonoVertexRollout() {
 func watchMonoVertex() {
 
 	watchResourceType(func() (watch.Interface, error) {
-		watcher, err := dynamicClient.Resource(getGVRForMonoVertex()).Namespace(Namespace).Watch(context.Background(), metav1.ListOptions{})
+		watcher, err := dynamicClient.Resource(GetGVRForMonoVertex()).Namespace(Namespace).Watch(context.Background(), metav1.ListOptions{})
 		return watcher, err
 	}, func(o runtime.Object) Output {
 		if obj, ok := o.(*unstructured.Unstructured); ok {
@@ -188,7 +188,7 @@ func watchMonoVertex() {
 
 }
 
-func verifyMonoVertexPaused(namespace string, monoVertexRolloutName string) {
+func VerifyMonoVertexPaused(namespace string, monoVertexRolloutName string) {
 
 	Document("Verify that MonoVertex Rollout condition is Pausing/Paused")
 	Eventually(func() metav1.ConditionStatus {
@@ -197,24 +197,24 @@ func verifyMonoVertexPaused(namespace string, monoVertexRolloutName string) {
 	}, testTimeout).Should(Equal(metav1.ConditionTrue))
 
 	Document("Verify that MonoVertex is paused")
-	verifyMonoVertexStatusEventually(namespace, monoVertexRolloutName,
+	VerifyMonoVertexStatusEventually(namespace, monoVertexRolloutName,
 		func(retrievedMonoVertexSpec numaflowv1.MonoVertexSpec, retrievedMonoVertexStatus numaflowv1.MonoVertexStatus) bool {
 			return retrievedMonoVertexStatus.Phase == numaflowv1.MonoVertexPhasePaused
 		})
 }
 
-func verifyMonoVertexStatusEventually(namespace string, monoVertexRolloutName string, f func(numaflowv1.MonoVertexSpec, numaflowv1.MonoVertexStatus) bool) {
+func VerifyMonoVertexStatusEventually(namespace string, monoVertexRolloutName string, f func(numaflowv1.MonoVertexSpec, numaflowv1.MonoVertexStatus) bool) {
 	Eventually(func() bool {
-		_, retrievedMonoVertexSpec, retrievedMonoVertexStatus, err := getMonoVertexFromK8S(namespace, monoVertexRolloutName)
+		_, retrievedMonoVertexSpec, retrievedMonoVertexStatus, err := GetMonoVertexFromK8S(namespace, monoVertexRolloutName)
 		return err == nil && f(retrievedMonoVertexSpec, retrievedMonoVertexStatus)
 	}, testTimeout).Should(BeTrue())
 }
 
-func getMonoVertexFromK8S(namespace string, monoVertexRolloutName string) (*unstructured.Unstructured, numaflowv1.MonoVertexSpec, numaflowv1.MonoVertexStatus, error) {
+func GetMonoVertexFromK8S(namespace string, monoVertexRolloutName string) (*unstructured.Unstructured, numaflowv1.MonoVertexSpec, numaflowv1.MonoVertexStatus, error) {
 	var retrievedMonoVertexSpec numaflowv1.MonoVertexSpec
 	var retrievedMonoVertexStatus numaflowv1.MonoVertexStatus
 
-	unstruct, err := getMonoVertex(namespace, monoVertexRolloutName)
+	unstruct, err := GetMonoVertex(namespace, monoVertexRolloutName)
 	if err != nil {
 		return nil, retrievedMonoVertexSpec, retrievedMonoVertexStatus, err
 	}
@@ -224,7 +224,7 @@ func getMonoVertexFromK8S(namespace string, monoVertexRolloutName string) (*unst
 		return unstruct, retrievedMonoVertexSpec, retrievedMonoVertexStatus, err
 	}
 
-	retrievedMonoVertexStatus, err = getMonoVertexStatus(unstruct)
+	retrievedMonoVertexStatus, err = GetMonoVertexStatus(unstruct)
 
 	if err != nil {
 		return unstruct, retrievedMonoVertexSpec, retrievedMonoVertexStatus, err
@@ -232,14 +232,14 @@ func getMonoVertexFromK8S(namespace string, monoVertexRolloutName string) (*unst
 	return unstruct, retrievedMonoVertexSpec, retrievedMonoVertexStatus, nil
 }
 
-func getMonoVertexStatus(u *unstructured.Unstructured) (numaflowv1.MonoVertexStatus, error) {
+func GetMonoVertexStatus(u *unstructured.Unstructured) (numaflowv1.MonoVertexStatus, error) {
 	statusMap := u.Object["status"]
 	var status numaflowv1.MonoVertexStatus
 	err := util.StructToStruct(&statusMap, &status)
 	return status, err
 }
 
-func verifyMonoVertexRolloutHealthy(monoVertexRolloutName string) {
+func VerifyMonoVertexRolloutHealthy(monoVertexRolloutName string) {
 	Document("Verifying that the MonoVertexRollout Child Condition is Healthy")
 	Eventually(func() metav1.ConditionStatus {
 		rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
@@ -247,7 +247,7 @@ func verifyMonoVertexRolloutHealthy(monoVertexRolloutName string) {
 	}, testTimeout, testPollingInterval).Should(Equal(metav1.ConditionTrue))
 }
 
-func verifyMonoVertexRolloutDeployed(monoVertexRolloutName string) {
+func VerifyMonoVertexRolloutDeployed(monoVertexRolloutName string) {
 	Document("Verifying that the MonoVertexRollout is Deployed")
 	Eventually(func() bool {
 		rollout, _ := monoVertexRolloutClient.Get(ctx, monoVertexRolloutName, metav1.GetOptions{})
@@ -289,9 +289,9 @@ func CreateMonoVertexRollout(name, namespace string, spec numaflowv1.MonoVertexS
 		return spec.Source != nil
 	})
 
-	verifyMonoVertexRolloutReady(name)
+	VerifyMonoVertexRolloutReady(name)
 
-	verifyMonoVertexReady(namespace, name)
+	VerifyMonoVertexReady(namespace, name)
 
 }
 
@@ -341,7 +341,7 @@ func DeleteMonoVertexRollout(name string) {
 
 	Document("Verifying MonoVertex deletion")
 	Eventually(func() bool {
-		list, err := dynamicClient.Resource(getGVRForMonoVertex()).Namespace(Namespace).List(ctx, metav1.ListOptions{})
+		list, err := dynamicClient.Resource(GetGVRForMonoVertex()).Namespace(Namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false
 		}
@@ -358,23 +358,23 @@ func UpdateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, exp
 	Expect(err).ShouldNot(HaveOccurred())
 
 	// update the MonoVertexRollout
-	updateMonoVertexRolloutInK8S(name, func(rollout apiv1.MonoVertexRollout) (apiv1.MonoVertexRollout, error) {
+	UpdateMonoVertexRolloutInK8S(name, func(rollout apiv1.MonoVertexRollout) (apiv1.MonoVertexRollout, error) {
 		rollout.Spec.MonoVertex.Spec.Raw = rawSpec
 		return rollout, nil
 	})
 
 	Document("verifying MonoVertexRollout spec deployed")
-	verifyMonoVertexRolloutDeployed(name)
+	VerifyMonoVertexRolloutDeployed(name)
 	if expectedFinalPhase == numaflowv1.MonoVertexPhaseRunning {
-		verifyMonoVertexRolloutHealthy(name)
+		VerifyMonoVertexRolloutHealthy(name)
 	}
 
 	VerifyInProgressStrategy(name, apiv1.UpgradeStrategyNoOp)
 
 	if expectedFinalPhase == numaflowv1.MonoVertexPhasePaused {
-		verifyMonoVertexPaused(Namespace, name)
+		VerifyMonoVertexPaused(Namespace, name)
 	} else {
-		verifyMonoVertexReady(Namespace, name)
+		VerifyMonoVertexReady(Namespace, name)
 	}
 
 }
@@ -383,7 +383,7 @@ func VerifyMonoVertexStaysPaused(name string) {
 	Document("verifying MonoVertex stays in paused or otherwise pausing")
 	Consistently(func() bool {
 		rollout, _ := monoVertexRolloutClient.Get(ctx, name, metav1.GetOptions{})
-		_, _, retrievedMonoVertexStatus, err := getMonoVertexFromK8S(Namespace, name)
+		_, _, retrievedMonoVertexStatus, err := GetMonoVertexFromK8S(Namespace, name)
 		if err != nil {
 			return false
 		}

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -34,7 +34,7 @@ func VerifyNumaflowControllerDeployment(namespace string, f func(appsv1.Deployme
 	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
-func verifyNumaflowControllerRolloutReady() {
+func VerifyNumaflowControllerRolloutReady() {
 	Document("Verifying that the NumaflowControllerRollout is ready")
 
 	Eventually(func() bool {
@@ -63,7 +63,7 @@ func verifyNumaflowControllerRolloutReady() {
 }
 
 // verify that the NumaflowControllerRollout matches some criteria
-func verifyNumaflowControllerRollout(namespace string, f func(apiv1.NumaflowControllerRollout) bool) {
+func VerifyNumaflowControllerRollout(namespace string, f func(apiv1.NumaflowControllerRollout) bool) {
 	Document("verifying Numaflow Controller Rollout")
 	Eventually(func() bool {
 		rollout, err := numaflowControllerRolloutClient.Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
@@ -74,7 +74,7 @@ func verifyNumaflowControllerRollout(namespace string, f func(apiv1.NumaflowCont
 	}, testTimeout, testPollingInterval).Should(BeTrue())
 }
 
-func verifyNumaflowControllerExists(namespace string) {
+func VerifyNumaflowControllerExists(namespace string) {
 	Document("Verifying that the Numaflow Controller Deployment exists")
 	Eventually(func() error {
 		_, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
@@ -136,9 +136,9 @@ func CreateNumaflowControllerRollout(version string) {
 		return err
 	}, testTimeout, testPollingInterval).Should(Succeed())
 
-	verifyNumaflowControllerRolloutReady()
+	VerifyNumaflowControllerRolloutReady()
 
-	verifyNumaflowControllerExists(Namespace)
+	VerifyNumaflowControllerExists(Namespace)
 
 }
 
@@ -245,10 +245,10 @@ func UpdateNumaflowControllerRollout(originalVersion, newVersion, pipelineRollou
 	})
 
 	if valid {
-		verifyNumaflowControllerRolloutReady()
+		VerifyNumaflowControllerRolloutReady()
 	} else {
 		// verify NumaflowControllerRollout ChildResourcesHealthy condition == false but NumaflowControllerRollout itself is marked "Deployed"
-		verifyNumaflowControllerRollout(Namespace, func(rollout apiv1.NumaflowControllerRollout) bool {
+		VerifyNumaflowControllerRollout(Namespace, func(rollout apiv1.NumaflowControllerRollout) bool {
 			healthCondition := getRolloutCondition(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 			return rollout.Status.Phase == apiv1.PhaseDeployed && healthCondition != nil && healthCondition.Status == metav1.ConditionFalse && healthCondition.Reason == "Failed"
 		})

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -24,12 +24,12 @@ import (
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
-func getPipeline(namespace, pipelineRolloutName string) (*unstructured.Unstructured, error) {
-	return getChildResource(getGVRForPipeline(), namespace, pipelineRolloutName)
+func GetPipeline(namespace, pipelineRolloutName string) (*unstructured.Unstructured, error) {
+	return getChildResource(GetGVRForPipeline(), namespace, pipelineRolloutName)
 }
 
-func getPipelineName(namespace, pipelineRolloutName string) (string, error) {
-	pipeline, err := getPipeline(namespace, pipelineRolloutName)
+func GetPipelineName(namespace, pipelineRolloutName string) (string, error) {
+	pipeline, err := GetPipeline(namespace, pipelineRolloutName)
 	if err != nil {
 		return "", err
 	}
@@ -41,11 +41,11 @@ func VerifyPipelineSpec(namespace string, pipelineRolloutName string, f func(num
 	Document("verifying Pipeline Spec")
 	var retrievedPipelineSpec numaflowv1.PipelineSpec
 	Eventually(func() bool {
-		unstruct, err := getPipeline(namespace, pipelineRolloutName)
+		unstruct, err := GetPipeline(namespace, pipelineRolloutName)
 		if err != nil {
 			return false
 		}
-		if retrievedPipelineSpec, err = getPipelineSpec(unstruct); err != nil {
+		if retrievedPipelineSpec, err = GetPipelineSpec(unstruct); err != nil {
 			return false
 		}
 
@@ -56,7 +56,7 @@ func VerifyPipelineSpec(namespace string, pipelineRolloutName string, f func(num
 func VerifyPipelineStatusEventually(namespace string, pipelineRolloutName string, f func(numaflowv1.PipelineSpec, numaflowv1.PipelineStatus) bool) {
 
 	Eventually(func() bool {
-		_, retrievedPipelineSpec, retrievedPipelineStatus, err := getPipelineSpecAndStatus(namespace, pipelineRolloutName)
+		_, retrievedPipelineSpec, retrievedPipelineStatus, err := GetPipelineSpecAndStatus(namespace, pipelineRolloutName)
 		return err == nil && f(retrievedPipelineSpec, retrievedPipelineStatus)
 	}, testTimeout).Should(BeTrue())
 }
@@ -64,7 +64,7 @@ func VerifyPipelineStatusEventually(namespace string, pipelineRolloutName string
 func VerifyPipelineStatusConsistently(namespace string, pipelineRolloutName string, f func(numaflowv1.PipelineSpec, numaflowv1.PipelineStatus) bool) {
 
 	Consistently(func() bool {
-		_, retrievedPipelineSpec, retrievedPipelineStatus, err := getPipelineSpecAndStatus(namespace, pipelineRolloutName)
+		_, retrievedPipelineSpec, retrievedPipelineStatus, err := GetPipelineSpecAndStatus(namespace, pipelineRolloutName)
 		return err == nil && f(retrievedPipelineSpec, retrievedPipelineStatus)
 	}, 15*time.Second, testPollingInterval).Should(BeTrue())
 
@@ -106,9 +106,9 @@ func VerifyPipelineRunning(namespace string, pipelineRolloutName string, useVert
 	// Get Pipeline Pods to verify they're all up
 	Document("Verifying that the Pipeline is ready")
 	// check "vertex" Pods
-	pipeline, err := getPipeline(namespace, pipelineRolloutName)
+	pipeline, err := GetPipeline(namespace, pipelineRolloutName)
 	Expect(err).ShouldNot(HaveOccurred())
-	spec, err := getPipelineSpec(pipeline)
+	spec, err := GetPipelineSpec(pipeline)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	numPods := len(spec.Vertices)
@@ -165,14 +165,14 @@ func VerifyInProgressStrategy(pipelineRolloutName string, inProgressStrategy api
 }
 
 // Get PipelineSpec from Unstructured type
-func getPipelineSpec(u *unstructured.Unstructured) (numaflowv1.PipelineSpec, error) {
+func GetPipelineSpec(u *unstructured.Unstructured) (numaflowv1.PipelineSpec, error) {
 	specMap := u.Object["spec"]
 	var pipelineSpec numaflowv1.PipelineSpec
 	err := util.StructToStruct(&specMap, &pipelineSpec)
 	return pipelineSpec, err
 }
 
-func getGVRForPipeline() schema.GroupVersionResource {
+func GetGVRForPipeline() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    "numaflow.numaproj.io",
 		Version:  "v1alpha1",
@@ -180,7 +180,7 @@ func getGVRForPipeline() schema.GroupVersionResource {
 	}
 }
 
-func getGVRForVertex() schema.GroupVersionResource {
+func GetGVRForVertex() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    "numaflow.numaproj.io",
 		Version:  "v1alpha1",
@@ -206,21 +206,21 @@ func UpdatePipelineRolloutInK8S(namespace string, name string, f func(apiv1.Pipe
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
-func getPipelineSpecAndStatus(namespace string, pipelineRolloutName string) (*unstructured.Unstructured, numaflowv1.PipelineSpec, numaflowv1.PipelineStatus, error) {
+func GetPipelineSpecAndStatus(namespace string, pipelineRolloutName string) (*unstructured.Unstructured, numaflowv1.PipelineSpec, numaflowv1.PipelineStatus, error) {
 
 	var retrievedPipelineSpec numaflowv1.PipelineSpec
 	var retrievedPipelineStatus numaflowv1.PipelineStatus
 
-	unstruct, err := getPipeline(namespace, pipelineRolloutName)
+	unstruct, err := GetPipeline(namespace, pipelineRolloutName)
 	if err != nil {
 		return nil, retrievedPipelineSpec, retrievedPipelineStatus, err
 	}
-	retrievedPipelineSpec, err = getPipelineSpec(unstruct)
+	retrievedPipelineSpec, err = GetPipelineSpec(unstruct)
 	if err != nil {
 		return unstruct, retrievedPipelineSpec, retrievedPipelineStatus, err
 	}
 
-	retrievedPipelineStatus, err = getPipelineStatus(unstruct)
+	retrievedPipelineStatus, err = GetPipelineStatus(unstruct)
 
 	if err != nil {
 		return unstruct, retrievedPipelineSpec, retrievedPipelineStatus, err
@@ -228,7 +228,7 @@ func getPipelineSpecAndStatus(namespace string, pipelineRolloutName string) (*un
 	return unstruct, retrievedPipelineSpec, retrievedPipelineStatus, nil
 }
 
-func getPipelineStatus(u *unstructured.Unstructured) (numaflowv1.PipelineStatus, error) {
+func GetPipelineStatus(u *unstructured.Unstructured) (numaflowv1.PipelineStatus, error) {
 	statusMap := u.Object["status"]
 	var status numaflowv1.PipelineStatus
 	err := util.StructToStruct(&statusMap, &status)
@@ -238,14 +238,14 @@ func getPipelineStatus(u *unstructured.Unstructured) (numaflowv1.PipelineStatus,
 func UpdatePipelineSpecInK8S(namespace string, pipelineRolloutName string, f func(numaflowv1.PipelineSpec) (numaflowv1.PipelineSpec, error)) {
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		unstruct, err := getPipeline(namespace, pipelineRolloutName)
+		unstruct, err := GetPipeline(namespace, pipelineRolloutName)
 		Expect(err).ShouldNot(HaveOccurred())
 		retrievedPipeline := unstruct
 
 		// modify Pipeline Spec to verify it gets auto-healed
-		err = updatePipelineSpec(retrievedPipeline, f)
+		err = UpdatePipelineSpec(retrievedPipeline, f)
 		Expect(err).ShouldNot(HaveOccurred())
-		_, err = dynamicClient.Resource(getGVRForPipeline()).Namespace(namespace).Update(ctx, retrievedPipeline, metav1.UpdateOptions{})
+		_, err = dynamicClient.Resource(GetGVRForPipeline()).Namespace(namespace).Update(ctx, retrievedPipeline, metav1.UpdateOptions{})
 		return err
 	})
 
@@ -253,7 +253,7 @@ func UpdatePipelineSpecInK8S(namespace string, pipelineRolloutName string, f fun
 }
 
 // Take a Pipeline Unstructured type and update the PipelineSpec in some way
-func updatePipelineSpec(u *unstructured.Unstructured, f func(numaflowv1.PipelineSpec) (numaflowv1.PipelineSpec, error)) error {
+func UpdatePipelineSpec(u *unstructured.Unstructured, f func(numaflowv1.PipelineSpec) (numaflowv1.PipelineSpec, error)) error {
 
 	// get PipelineSpec from unstructured object
 	specMap := u.Object["spec"]
@@ -309,7 +309,7 @@ func watchPipelineRollout() {
 func watchPipeline() {
 
 	watchResourceType(func() (watch.Interface, error) {
-		watcher, err := dynamicClient.Resource(getGVRForPipeline()).Namespace(Namespace).Watch(context.Background(), metav1.ListOptions{})
+		watcher, err := dynamicClient.Resource(GetGVRForPipeline()).Namespace(Namespace).Watch(context.Background(), metav1.ListOptions{})
 		return watcher, err
 	}, func(o runtime.Object) Output {
 		if obj, ok := o.(*unstructured.Unstructured); ok {
@@ -336,7 +336,7 @@ func watchPipeline() {
 func watchVertices() {
 
 	watchResourceType(func() (watch.Interface, error) {
-		watcher, err := dynamicClient.Resource(getGVRForVertex()).Namespace(Namespace).Watch(context.Background(), metav1.ListOptions{})
+		watcher, err := dynamicClient.Resource(GetGVRForVertex()).Namespace(Namespace).Watch(context.Background(), metav1.ListOptions{})
 		return watcher, err
 	}, func(o runtime.Object) Output {
 		if obj, ok := o.(*unstructured.Unstructured); ok {
@@ -451,7 +451,7 @@ func DeletePipelineRollout(name string) {
 	Eventually(func() bool {
 		// ensures deletion of single pipeline
 		pipelineRolloutLabel := fmt.Sprintf("numaplane.numaproj.io/parent-rollout-name=%v", name)
-		list, err := dynamicClient.Resource(getGVRForPipeline()).Namespace(Namespace).List(ctx, metav1.ListOptions{LabelSelector: pipelineRolloutLabel})
+		list, err := dynamicClient.Resource(GetGVRForPipeline()).Namespace(Namespace).List(ctx, metav1.ListOptions{LabelSelector: pipelineRolloutLabel})
 		if err != nil {
 			return false
 		}
@@ -503,15 +503,15 @@ func UpdatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expecte
 	if overrideSourceVertexReplicas {
 		scaleTo := int64(math.Floor(float64(GetVerticesScaleValue()) / float64(2)))
 
-		pipeline, err := getPipeline(Namespace, name)
+		pipeline, err := GetPipeline(Namespace, name)
 		Expect(err).ShouldNot(HaveOccurred())
 		vertexName := fmt.Sprintf("%s-%s", pipeline.GetName(), PipelineSourceVertexName)
 
-		vertex, err := dynamicClient.Resource(getGVRForVertex()).Namespace(Namespace).Get(ctx, vertexName, metav1.GetOptions{})
+		vertex, err := dynamicClient.Resource(GetGVRForVertex()).Namespace(Namespace).Get(ctx, vertexName, metav1.GetOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
 		err = unstructured.SetNestedField(vertex.Object, scaleTo, "spec", "replicas")
 		Expect(err).ShouldNot(HaveOccurred())
-		_, err = dynamicClient.Resource(getGVRForVertex()).Namespace(Namespace).Update(ctx, vertex, metav1.UpdateOptions{})
+		_, err = dynamicClient.Resource(GetGVRForVertex()).Namespace(Namespace).Update(ctx, vertex, metav1.UpdateOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
 	}
 
@@ -548,7 +548,7 @@ func VerifyPipelineStaysPaused(pipelineRolloutName string) {
 	Document("verifying Pipeline stays in paused or otherwise pausing")
 	Consistently(func() bool {
 		rollout, _ := pipelineRolloutClient.Get(ctx, pipelineRolloutName, metav1.GetOptions{})
-		_, _, retrievedPipelineStatus, err := getPipelineSpecAndStatus(Namespace, pipelineRolloutName)
+		_, _, retrievedPipelineStatus, err := GetPipelineSpecAndStatus(Namespace, pipelineRolloutName)
 		if err != nil {
 			return false
 		}
@@ -558,7 +558,7 @@ func VerifyPipelineStaysPaused(pipelineRolloutName string) {
 
 	VerifyInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
 
-	pipeline, err := getPipeline(Namespace, pipelineRolloutName)
+	pipeline, err := GetPipeline(Namespace, pipelineRolloutName)
 	Expect(err).ShouldNot(HaveOccurred())
 	verifyPodsRunning(Namespace, 0, getVertexLabelSelector(pipeline.GetName()))
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #577 

### Modifications

This PR makes all functions used in the e2e test suite public to increase ease for writing new test suites and allowing use of all minor functions. 

This also makes debugging any new issues with test cases much simpler. In the future all new functions will be public as well to keep consistency.  

### Verification

Running e2e test locally and on CI.

### Backward incompatibilities

N/A
