### PR TITLE
fix: (E2E) Remove Document fn call and refactor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
         id: go
 
       - name: Install MockGen
-        run:  go install github.com/golang/mock/mockgen@v1.6.0
+        run: go install github.com/golang/mock/mockgen@v1.6.0
 
       - name: Restore Go build cache
         uses: actions/cache@v3
@@ -134,6 +134,9 @@ jobs:
         uses: actions/setup-go@v4.0.0
         with:
           go-version: '1.23'
+
+      - name: Install Ginkgo
+        run: go install github.com/onsi/ginkgo/v2/ginkgo
 
       - name: Add bins to PATH
         run: |

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ test: codegen fmt vet envtest ## Run unit tests.
 test-functional-e2e:
 test-ppnd-e2e:
 test-%: envtest ## Run e2e tests. Note we may need to increase the timeout in the future.
-	GOFLAGS="-count=1" ginkgo -v ./tests/e2e/$*
+	GOFLAGS="-count=1" ginkgo run -v --timeout 35m ./tests/e2e/$*
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.61.0

--- a/Makefile
+++ b/Makefile
@@ -128,10 +128,8 @@ test: codegen fmt vet envtest ## Run unit tests.
 
 test-functional-e2e:
 test-ppnd-e2e:
-test-%: codegen fmt vet envtest ## Run e2e tests. Note we may need to increase the timeout in the future.
-	GOFLAGS="-count=1" go test -timeout 35m -v ./tests/e2e/$* 
-
-
+test-%: envtest ## Run e2e tests. Note we may need to increase the timeout in the future.
+	GOFLAGS="-count=1" ginkgo -v ./tests/e2e/$*
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.61.0

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -118,26 +118,8 @@ func GetVerticesScaleValue() int {
 	}
 }
 
-// document for Ginkgo framework and print to console
-func Document(testName string) {
-	snapshotCluster(testName)
-	By(testName)
-}
-
-func snapshotCluster(testName string) {
-	fmt.Printf("*** %+v: NAMESPACE POD STATE BEFORE TEST: %s\n", time.Now(), testName)
-	podList, _ := kubeClient.CoreV1().Pods(Namespace).List(ctx, metav1.ListOptions{})
-	if podList != nil {
-		for _, pod := range podList.Items {
-			fmt.Printf("Pod: %q, %q\n", pod.Name, pod.Status.Phase)
-		}
-	}
-}
-
 func verifyPodsRunning(namespace string, numPods int, labelSelector string) {
-	Document(fmt.Sprintf("verifying %d Pods running with label selector %q", numPods, labelSelector))
-
-	Eventually(func() bool {
+	CheckEventually(fmt.Sprintf("verifying %d Pods running with label selector %q", numPods, labelSelector), func() bool {
 		podsList, _ := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 		if podsList != nil && len(podsList.Items) == numPods {
 			for _, pod := range podsList.Items {
@@ -590,4 +572,14 @@ func setupOutputDir() {
 		}
 	}
 
+}
+
+func CheckEventually(testData string, actualOrCtx interface{}) AsyncAssertion {
+	By(testData)
+	return Eventually(actualOrCtx, TestTimeout, TestPollingInterval)
+}
+
+func CheckConsistently(testData string, actualOrCtx interface{}) AsyncAssertion {
+	By(testData)
+	return Consistently(actualOrCtx, TestTimeout, TestPollingInterval)
 }

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -574,11 +574,15 @@ func setupOutputDir() {
 
 }
 
+// CheckEventually is wrappers around Ginkgo's Eventually
+// You can override the default timeout and polling interval by using WithTimeout and WithPolling methods
 func CheckEventually(testData string, actualOrCtx interface{}) AsyncAssertion {
 	By(testData)
 	return Eventually(actualOrCtx, TestTimeout, TestPollingInterval)
 }
 
+// CheckConsistently is wrappers around Ginkgo's Consistently
+// You can override the default timeout and polling interval by using WithTimeout and WithPolling methods
 func CheckConsistently(testData string, actualOrCtx interface{}) AsyncAssertion {
 	By(testData)
 	return Consistently(actualOrCtx, TestTimeout, TestPollingInterval)

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -203,7 +203,7 @@ func TestFunctionalE2E(t *testing.T) {
 	RunSpecs(t, "Functional E2E Suite")
 }
 
-var _ = Describe("Functional e2e", Serial, func() {
+var _ = Describe("Functional e2e:", Serial, func() {
 
 	It("Should create the NumaflowControllerRollout if it doesn't exist", func() {
 		CreateNumaflowControllerRollout(initialNumaflowControllerVersion)
@@ -234,7 +234,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should automatically heal a Pipeline if it is updated directly", func() {
 
-		Document("Updating Pipeline directly")
+		By("Updating Pipeline directly")
 
 		// update child Pipeline
 		UpdatePipelineSpecInK8S(Namespace, pipelineRolloutName, func(pipelineSpec numaflowv1.PipelineSpec) (numaflowv1.PipelineSpec, error) {
@@ -243,7 +243,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		})
 
 		if UpgradeStrategy == config.PPNDStrategyID {
-			Document("Verify that child Pipeline is not paused when an update not requiring pause is made")
+			By("Verify that child Pipeline is not paused when an update not requiring pause is made")
 			VerifyPipelineStatusConsistently(Namespace, pipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus numaflowv1.PipelineStatus) bool {
 				return retrievedPipelineStatus.Phase != numaflowv1.PipelinePhasePaused
 			})
@@ -253,7 +253,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		time.Sleep(5 * time.Second)
 
 		// get updated Pipeline again to compare spec
-		Document("Verifying self-healing")
+		By("Verifying self-healing")
 		VerifyPipelineSpec(Namespace, pipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return !retrievedPipelineSpec.Watermark.Disabled
 		})
@@ -283,7 +283,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should pause the Pipeline if user requests it", func() {
 
-		Document("setting desiredPhase=Paused")
+		By("setting desiredPhase=Paused")
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhasePaused
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhasePaused, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
@@ -297,7 +297,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should resume the Pipeline if user requests it", func() {
 
-		Document("setting desiredPhase=Running")
+		By("setting desiredPhase=Running")
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhaseRunning
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
@@ -307,7 +307,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should pause the MonoVertex if user requests it", func() {
 
-		Document("setting desiredPhase=Paused")
+		By("setting desiredPhase=Paused")
 		currentMonoVertexSpec.Lifecycle.DesiredPhase = numaflowv1.MonoVertexPhasePaused
 
 		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhasePaused, func(spec numaflowv1.MonoVertexSpec) bool {
@@ -321,7 +321,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should resume the MonoVertex if user requests it", func() {
 
-		Document("setting desiredPhase=Running")
+		By("setting desiredPhase=Running")
 		currentMonoVertexSpec.Lifecycle.DesiredPhase = numaflowv1.MonoVertexPhaseRunning
 
 		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning, func(spec numaflowv1.MonoVertexSpec) bool {
@@ -415,20 +415,17 @@ var _ = Describe("Functional e2e", Serial, func() {
 	})
 
 	It("Should only be one child per Rollout", func() { // all prior children should be marked "Recyclable" and deleted
-		Document("verifying just 1 Pipeline")
-		Eventually(func() int {
+		CheckEventually("verifying just 1 Pipeline", func() int {
 			return GetNumberOfChildren(GetGVRForPipeline(), Namespace, pipelineRolloutName)
-		}, TestTimeout, TestPollingInterval).Should(Equal(1))
+		}).Should(Equal(1))
 
-		Document("verifying just 1 MonoVertex")
-		Eventually(func() int {
+		CheckEventually("verifying just 1 MonoVertex", func() int {
 			return GetNumberOfChildren(GetGVRForMonoVertex(), Namespace, monoVertexRolloutName)
-		}, TestTimeout, TestPollingInterval).Should(Equal(1))
+		}).Should(Equal(1))
 
-		Document("verifying just 1 InterstepBufferService")
-		Eventually(func() int {
+		CheckEventually("verifying just 1 InterstepBufferService", func() int {
 			return GetNumberOfChildren(GetGVRForISBService(), Namespace, isbServiceRolloutName)
-		}, TestTimeout, TestPollingInterval).Should(Equal(1))
+		}).Should(Equal(1))
 	})
 
 	It("Should delete the PipelineRollouts and child Pipelines", func() {
@@ -447,5 +444,4 @@ var _ = Describe("Functional e2e", Serial, func() {
 	It("Should delete the NumaflowControllerRollout and child NumaflowController", func() {
 		DeleteNumaflowControllerRollout()
 	})
-
 })

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -56,10 +56,8 @@ func GetISBServiceName(namespace, isbServiceRolloutName string) (string, error) 
 }
 
 func VerifyISBServiceSpec(namespace string, isbServiceRolloutName string, f func(numaflowv1.InterStepBufferServiceSpec) bool) {
-
-	Document("verifying ISBService Spec")
 	var retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec
-	Eventually(func() bool {
+	CheckEventually("verifying ISBService Spec", func() bool {
 		unstruct, err := GetPromotedISBService(namespace, isbServiceRolloutName)
 		if err != nil {
 			return false
@@ -69,33 +67,32 @@ func VerifyISBServiceSpec(namespace string, isbServiceRolloutName string, f func
 		}
 
 		return f(retrievedISBServiceSpec)
-	}, 8*time.Minute, TestPollingInterval).Should(BeTrue())
+	}).WithTimeout(8 * time.Minute).Should(BeTrue())
 }
 
 func VerifyISBSvcRolloutReady(isbServiceRolloutName string) {
-	Document("Verifying that the ISBServiceRollout is ready")
+	By("Verifying that the ISBServiceRollout is ready")
 
-	Eventually(func() bool {
+	CheckEventually("verify ISBServiceRollout is deployed", func() bool {
 		rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 		return rollout.Status.Phase == apiv1.PhaseDeployed
-	}, TestTimeout, TestPollingInterval).Should(BeTrue())
+	}).Should(BeTrue())
 
-	Eventually(func() metav1.ConditionStatus {
+	CheckEventually("verify ISBServiceRollout child resource is deployed", func() metav1.ConditionStatus {
 		rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 		return getRolloutConditionStatus(rollout.Status.Conditions, apiv1.ConditionChildResourceDeployed)
-	}, TestTimeout, TestPollingInterval).Should(Equal(metav1.ConditionTrue))
+	}).Should(Equal(metav1.ConditionTrue))
 
-	Eventually(func() metav1.ConditionStatus {
+	CheckEventually("verify ISBServiceRollout child resource is healthy", func() metav1.ConditionStatus {
 		rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 		return getRolloutConditionStatus(rollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
-	}, 4*time.Minute, TestPollingInterval).Should(Equal(metav1.ConditionTrue))
+	}).WithTimeout(4 * time.Minute).Should(Equal(metav1.ConditionTrue))
 
 	if UpgradeStrategy == config.PPNDStrategyID {
-		Document("Verifying that the ISBServiceRollout PausingPipelines condition is as expected")
-		Eventually(func() metav1.ConditionStatus {
+		CheckEventually("Verifying that the ISBServiceRollout PausingPipelines condition is as expected", func() metav1.ConditionStatus {
 			rollout, _ := isbServiceRolloutClient.Get(ctx, isbServiceRolloutName, metav1.GetOptions{})
 			return getRolloutConditionStatus(rollout.Status.Conditions, apiv1.ConditionPausingPipelines)
-		}, TestTimeout, TestPollingInterval).Should(Or(Equal(metav1.ConditionFalse), Equal(metav1.ConditionUnknown)))
+		}).Should(Or(Equal(metav1.ConditionFalse), Equal(metav1.ConditionUnknown)))
 	}
 
 }
@@ -103,26 +100,22 @@ func VerifyISBSvcRolloutReady(isbServiceRolloutName string) {
 func VerifyISBSvcReady(namespace string, isbServiceRolloutName string, nodeSize int) {
 
 	var isbsvcName string
-
-	Document("Verifying that the ISBService exists")
-	Eventually(func() error {
+	CheckEventually("Verifying that the ISBService exists", func() error {
 		unstruct, err := GetPromotedISBService(namespace, isbServiceRolloutName)
 		if err == nil {
 			isbsvcName = unstruct.GetName()
 		}
 		return err
-	}, TestTimeout, TestPollingInterval).Should(Succeed())
+	}).Should(Succeed())
 
 	// TODO: eventually we can use ISBServiceRollout.Status.Conditions(ChildResourcesHealthy) to get this instead
 
-	Document("Verifying that the StatefulSet exists and is ready")
-	Eventually(func() bool {
+	CheckEventually("Verifying that the StatefulSet exists and is ready", func() bool {
 		statefulSet, _ := kubeClient.AppsV1().StatefulSets(namespace).Get(ctx, fmt.Sprintf("isbsvc-%s-js", isbsvcName), metav1.GetOptions{})
 		return statefulSet != nil && statefulSet.Generation == statefulSet.Status.ObservedGeneration && statefulSet.Status.UpdatedReplicas == int32(nodeSize)
-	}, TestTimeout, TestPollingInterval).Should(BeTrue())
+	}).Should(BeTrue())
 
-	Document("Verifying that the StatefulSet Pods are in Running phase")
-	Eventually(func() bool {
+	CheckEventually("Verifying that the StatefulSet Pods are in Running phase", func() bool {
 		podList, _ := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", numaflowv1.KeyISBSvcName, isbsvcName)})
 		podsInRunning := 0
 		if podList != nil {
@@ -133,11 +126,11 @@ func VerifyISBSvcReady(namespace string, isbServiceRolloutName string, nodeSize 
 			}
 		}
 		return podsInRunning == nodeSize
-	}, TestTimeout, TestPollingInterval).Should(BeTrue())
+	}).Should(BeTrue())
 }
 
 func UpdateISBServiceRolloutInK8S(name string, f func(apiv1.ISBServiceRollout) (apiv1.ISBServiceRollout, error)) {
-	Document("updating ISBServiceRollout")
+	By("updating ISBServiceRollout")
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		rollout, err := isbServiceRolloutClient.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
@@ -155,11 +148,10 @@ func UpdateISBServiceRolloutInK8S(name string, f func(apiv1.ISBServiceRollout) (
 }
 
 func VerifyInProgressStrategyISBService(namespace string, isbsvcRolloutName string, inProgressStrategy apiv1.UpgradeStrategy) {
-	Document("Verifying InProgressStrategy for ISBService")
-	Eventually(func() bool {
+	CheckEventually("Verifying InProgressStrategy for ISBService", func() bool {
 		rollout, _ := isbServiceRolloutClient.Get(ctx, isbsvcRolloutName, metav1.GetOptions{})
 		return rollout.Status.UpgradeInProgress == inProgressStrategy
-	}, TestTimeout, TestPollingInterval).Should(BeTrue())
+	}).Should(BeTrue())
 }
 
 func watchISBServiceRollout() {
@@ -251,11 +243,10 @@ func CreateISBServiceRollout(name string, isbServiceSpec numaflowv1.InterStepBuf
 	_, err := isbServiceRolloutClient.Create(ctx, isbServiceRolloutSpec, metav1.CreateOptions{})
 	Expect(err).ShouldNot(HaveOccurred())
 
-	Document("Verifying that the ISBServiceRollout was created")
-	Eventually(func() error {
+	CheckEventually("Verifying that the ISBServiceRollout was created", func() error {
 		_, err := isbServiceRolloutClient.Get(ctx, name, metav1.GetOptions{})
 		return err
-	}, TestTimeout, TestPollingInterval).Should(Succeed())
+	}).Should(Succeed())
 
 	VerifyISBSvcRolloutReady(name)
 
@@ -292,12 +283,11 @@ func createISBServiceRolloutSpec(name, namespace string, isbServiceSpec numaflow
 
 // delete ISBServiceRollout and verify deletion
 func DeleteISBServiceRollout(name string) {
-	Document("Deleting ISBServiceRollout")
+	By("Deleting ISBServiceRollout")
 	err := isbServiceRolloutClient.Delete(ctx, name, metav1.DeleteOptions{})
 	Expect(err).ShouldNot(HaveOccurred())
 
-	Document("Verifying ISBServiceRollout deletion")
-	Eventually(func() bool {
+	CheckEventually("Verifying ISBServiceRollout deletion", func() bool {
 		_, err := isbServiceRolloutClient.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			if !errors.IsNotFound(err) {
@@ -308,8 +298,7 @@ func DeleteISBServiceRollout(name string) {
 		return true
 	}).WithTimeout(TestTimeout).Should(BeFalse(), "The ISBServiceRollout should have been deleted but it was found.")
 
-	Document("Verifying ISBService deletion")
-	Eventually(func() bool {
+	CheckEventually("Verifying ISBService deletion", func() bool {
 		list, err := dynamicClient.Resource(GetGVRForISBService()).Namespace(Namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false
@@ -386,7 +375,7 @@ func UpdateISBServiceRollout(
 
 		if dataLossRisk {
 
-			Document("Verify that in-progress-strategy gets set to PPND")
+			By("Verify that in-progress-strategy gets set to PPND")
 			VerifyInProgressStrategyISBService(Namespace, isbServiceRolloutName, apiv1.UpgradeStrategyPPND)
 			// if we expect the pipeline to be healthy after update
 			for _, rolloutInfo := range pipelineRollouts {
@@ -396,12 +385,10 @@ func UpdateISBServiceRollout(
 				}
 			}
 
-			Document("Verify that the pipelines are unpaused by checking the PPND conditions on ISBService Rollout and PipelineRollout")
-			Eventually(verifyNotPausing, TestTimeout).Should(BeTrue())
+			CheckEventually("Verify that the pipelines are unpaused by checking the PPND conditions on ISBService Rollout and PipelineRollout", verifyNotPausing).Should(BeTrue())
 
 		} else {
-			Document("Verify that dependent Pipeline is not paused when an update to ISBService not requiring pause is made")
-			Consistently(verifyNotPausing, 15*time.Second).Should(BeTrue())
+			CheckConsistently("Verify that dependent Pipeline is not paused when an update to ISBService not requiring pause is made", verifyNotPausing).WithTimeout(15 * time.Second).Should(BeTrue())
 		}
 	}
 
@@ -435,7 +422,7 @@ func UpdateISBServiceRollout(
 		}
 	}
 
-	Document("getting new isbservice name")
+	By("getting new isbservice name")
 	newISBServiceName, err := GetISBServiceName(Namespace, isbServiceRolloutName)
 	Expect(err).ShouldNot(HaveOccurred())
 
@@ -443,18 +430,18 @@ func UpdateISBServiceRollout(
 
 		rolloutName := rolloutInfo.PipelineRolloutName
 
-		Document("getting new pipeline name")
+		By("getting new pipeline name")
 		newPipelineName, err := GetPipelineName(Namespace, rolloutName)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		if recreateFieldChanged || (dataLossFieldChanged && UpgradeStrategy == config.ProgressiveStrategyID) {
 			// make sure the names of isbsvc and pipeline have changed
-			Document(fmt.Sprintf("verifying new isbservice name is different from original %s and new pipeline name is different from original %s", originalISBServiceName, originalPipelineNames[rolloutName]))
+			By(fmt.Sprintf("verifying new isbservice name is different from original %s and new pipeline name is different from original %s", originalISBServiceName, originalPipelineNames[rolloutName]))
 			Expect(originalISBServiceName != newISBServiceName).To(BeTrue())
 			Expect(originalPipelineNames[rolloutName] != newPipelineName).To(BeTrue())
 		} else {
 			// make sure the names of isbsvc and pipeline have not changed
-			Document(fmt.Sprintf("verifying new isbservice name matches original %s and new pipeline name matches original %s", originalISBServiceName, originalPipelineNames[rolloutName]))
+			By(fmt.Sprintf("verifying new isbservice name matches original %s and new pipeline name matches original %s", originalISBServiceName, originalPipelineNames[rolloutName]))
 			Expect(originalISBServiceName == newISBServiceName).To(BeTrue())
 			Expect(originalPipelineNames[rolloutName] == newPipelineName).To(BeTrue())
 		}

--- a/tests/e2e/ppnd-e2e/ppnd_test.go
+++ b/tests/e2e/ppnd-e2e/ppnd_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 
 			createSlowPipelineRollout()
 
-			Document("Updating Pipeline Topology to cause a PPND change")
+			By("Updating Pipeline Topology to cause a PPND change")
 			slowPipelineSpec.Vertices[1] = slowPipelineSpec.Vertices[2]
 			slowPipelineSpec.Vertices = slowPipelineSpec.Vertices[0:2]
 			slowPipelineSpec.Edges = []numaflowv1.Edge{
@@ -189,7 +189,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 
 			createSlowPipelineRollout()
 
-			Document("Updating ISBService to cause a PPND change")
+			By("Updating ISBService to cause a PPND change")
 			updatedISBServiceSpec := isbServiceSpec
 			updatedISBServiceSpec.JetStream.Version = updatedJetstreamVersion
 			rawSpec, err := json.Marshal(updatedISBServiceSpec)
@@ -218,7 +218,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 
 			createSlowPipelineRollout()
 
-			Document("Updating Numaflow controller to cause a PPND change")
+			By("Updating Numaflow controller to cause a PPND change")
 			updatedNumaflowControllerROSpec := apiv1.NumaflowControllerRolloutSpec{
 				Controller: apiv1.Controller{Version: updatedNumaflowControllerVersion},
 			}
@@ -276,7 +276,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 		time.Sleep(5 * time.Second)
 
 		// update ISBService to have data loss update
-		Document("Updating ISBService to cause a PPND change")
+		By("Updating ISBService to cause a PPND change")
 		updatedISBServiceSpec := isbServiceSpec
 		updatedISBServiceSpec.JetStream.Version = initialJetstreamVersion
 
@@ -305,7 +305,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 
 		time.Sleep(5 * time.Second)
 
-		Document("Updating Numaflow controller to cause a PPND change")
+		By("Updating Numaflow controller to cause a PPND change")
 		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, initialNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: failedPipelineRolloutName, PipelineIsFailed: true}}, true)
 
 		time.Sleep(5 * time.Second)
@@ -323,7 +323,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 
 func createSlowPipelineRollout() {
 
-	Document("Creating a slow pipeline")
+	By("Creating a slow pipeline")
 	slowPipelineSpec = updatedPipelineSpec.DeepCopy()
 	highRPU := int64(10000000)
 	readBatchSize := uint64(1)
@@ -337,7 +337,7 @@ func createSlowPipelineRollout() {
 
 	CreatePipelineRollout(slowPipelineRolloutName, Namespace, *slowPipelineSpec, false)
 
-	Document("Verifying that the slow pipeline was created")
+	By("Verifying that the slow pipeline was created")
 	VerifyPipelineSpec(Namespace, slowPipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 		return len(slowPipelineSpec.Vertices) == len(retrievedPipelineSpec.Vertices)
 	})
@@ -349,11 +349,11 @@ func createSlowPipelineRollout() {
 
 func verifyPipelineIsSlowToPause() {
 
-	Document("Verifying that Pipeline tries to pause")
+	By("Verifying that Pipeline tries to pause")
 	VerifyPipelineStatusEventually(Namespace, slowPipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus numaflowv1.PipelineStatus) bool {
 		return retrievedPipelineStatus.Phase == numaflowv1.PipelinePhasePausing
 	})
-	Document("Verifying that Pipeline keeps trying to pause")
+	By("Verifying that Pipeline keeps trying to pause")
 	VerifyPipelineStatusConsistently(Namespace, slowPipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus numaflowv1.PipelineStatus) bool {
 		return retrievedPipelineStatus.Phase == numaflowv1.PipelinePhasePausing
 	})
@@ -371,7 +371,7 @@ func allowDataLoss() {
 		return rollout, nil
 	})
 
-	Document("Verifying that Pipeline has stopped trying to pause")
+	By("Verifying that Pipeline has stopped trying to pause")
 	VerifyPipelineRunning(Namespace, slowPipelineRolloutName, false)
 
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #500 

### Modifications

- Removing Documentation fn call and created a wrapper method for `Eventually()` and `Consistently()` for printing the test case name as well while run.

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
