### PR TITLE
fix: scaling to zero behavior fix

### DIFF
--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -210,9 +210,7 @@ func scaleDownMonoVertex(
 	// If for the vertex we already set a Scaled scale value, we only need to update the actual pods count
 	// to later verify that the pods were actually scaled down.
 	// We want to skip scaling down again.
-	// TODO: why do we concern ourselves if vertexScaleValues.ScaleTo != 0? If we scale 1 Pod to 0, we go past here even if the scale values
-	// were found
-	if vertexScaleValues, exist := scaleValuesMap[promotedChildDef.GetName()]; exist && vertexScaleValues.ScaleTo != 0 {
+	if vertexScaleValues, exist := scaleValuesMap[promotedChildDef.GetName()]; exist {
 		vertexScaleValues.Actual = actualPodsCount
 		scaleValuesMap[promotedChildDef.GetName()] = vertexScaleValues
 

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -254,7 +254,7 @@ func scaleDownPipelineSourceVertices(
 			// If for the vertex we already set a Scaled scale value, we only need to update the actual pods count
 			// to later verify that the pods were actually scaled down.
 			// We want to skip scaling down again.
-			if vertexScaleValues, exist := scaleValuesMap[vertexName]; exist && vertexScaleValues.ScaleTo != 0 {
+			if vertexScaleValues, exist := scaleValuesMap[vertexName]; exist {
 				vertexScaleValues.Actual = actualPodsCount
 				scaleValuesMap[vertexName] = vertexScaleValues
 

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -273,7 +273,7 @@ var _ = Describe("Functional e2e:", Serial, func() {
 		numPipelineVertices := len(updatedPipelineSpec.Vertices)
 		UpdatePipelineRollout(pipelineRolloutName, updatedPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return len(retrievedPipelineSpec.Vertices) == numPipelineVertices
-		}, true, true)
+		}, true, true, false)
 
 	})
 
@@ -288,7 +288,7 @@ var _ = Describe("Functional e2e:", Serial, func() {
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhasePaused, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhasePaused
-		}, false, false)
+		}, false, false, false)
 
 		VerifyPipelineStaysPaused(pipelineRolloutName)
 	})
@@ -302,7 +302,7 @@ var _ = Describe("Functional e2e:", Serial, func() {
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhaseRunning
-		}, false, false)
+		}, false, false, true)
 	})
 
 	It("Should pause the MonoVertex if user requests it", func() {

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -260,7 +260,7 @@ func UpdateNumaflowControllerRollout(originalVersion, newVersion string, pipelin
 		if rolloutInfo.PipelineIsFailed {
 			VerifyPipelineFailed(Namespace, rolloutName)
 		} else {
-			VerifyPipelineRunning(Namespace, rolloutName, false)
+			VerifyPipelineRunning(Namespace, rolloutName, true)
 		}
 	}
 

--- a/tests/e2e/ppnd-e2e/ppnd_test.go
+++ b/tests/e2e/ppnd-e2e/ppnd_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 
 			UpdatePipelineRollout(slowPipelineRolloutName, *slowPipelineSpec, numaflowv1.PipelinePhasePausing, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 				return true
-			}, true, false)
+			}, true, false, false)
 
 			verifyPipelineIsSlowToPause()
 			allowDataLoss()
@@ -254,7 +254,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 		// update spec to have topology change
 		UpdatePipelineRollout(failedPipelineRolloutName, updatedPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return len(retrievedPipelineSpec.Vertices) == 3
-		}, true, false)
+		}, true, false, false)
 
 		time.Sleep(5 * time.Second)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #584 

### Modifications

Removed the check for which the scaleTo value should not be 0.
On the E2E tests, added a `scaleInVertex` arg on the `UpdatePipelineRollout` as a workaround to force scale up the `in` vertex back to 3 pods since after pausing a pipeline and resuming it, the scale values are ignored by Numaflow and we have to manually change the replicas on the vertex. This is similar to the scale down workaround adopted on the other E2E tests and that will be removed once the Numaflow changes/fixes are available. 

### Verification

Manually tested by creating a MonoVertex and Pipeline with no scale values set.

### Backward incompatibilities

None.
