### PR TITLE
feat: e2e test improvement - update functions can check multiple pipelines behavior

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -103,6 +103,12 @@ type Output struct {
 	Status     interface{}       `json:"status,omitempty"`
 }
 
+type PipelineRolloutInfo struct {
+	PipelineRolloutName          string `json:"pipelineRolloutName"`
+	PipelineIsFailed             bool   `json:"pipelineIsFailed,omitempty"`
+	OverrideSourceVertexReplicas bool   `json:"overrideSourceVertexReplicas,omitempty"`
+}
+
 func GetVerticesScaleValue() int {
 	switch getUpgradeStrategy() {
 	case config.ProgressiveStrategyID:

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -43,7 +43,7 @@ const (
 	initialJetstreamVersion          = "2.10.17"
 	updatedJetstreamVersion          = "2.10.11"
 
-	anotherPipelineRolloutName = "another-pipeline-rollout"
+	// anotherPipelineRolloutName = "another-pipeline-rollout"
 )
 
 var (
@@ -218,9 +218,9 @@ var _ = Describe("Functional e2e", Serial, func() {
 	})
 
 	// extra PipelineRollout to verify that multiple Pipelines will behave correctly during ISBService/controller updates
-	It("Should create another PipelineRollout if it does not exist", func() {
-		CreatePipelineRollout(anotherPipelineRolloutName, Namespace, initialPipelineSpec, false)
-	})
+	// It("Should create another PipelineRollout if it does not exist", func() {
+	// 	CreatePipelineRollout(anotherPipelineRolloutName, Namespace, initialPipelineSpec, false)
+	// })
 
 	currentPipelineSpec = initialPipelineSpec
 
@@ -285,19 +285,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		Document("setting desiredPhase=Paused")
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhasePaused
-		initialPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhasePaused
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhasePaused, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhasePaused
 		}, false, false)
 
 		VerifyPipelineStaysPaused(pipelineRolloutName)
-
-		UpdatePipelineRollout(anotherPipelineRolloutName, initialPipelineSpec, numaflowv1.PipelinePhasePaused, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
-			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhasePaused
-		}, false, false)
-
-		VerifyPipelineStaysPaused(anotherPipelineRolloutName)
 	})
 
 	time.Sleep(2 * time.Second)
@@ -306,13 +299,8 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		Document("setting desiredPhase=Running")
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhaseRunning
-		initialPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhaseRunning
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
-			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhaseRunning
-		}, false, false)
-
-		UpdatePipelineRollout(anotherPipelineRolloutName, initialPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhaseRunning
 		}, false, false)
 	})
@@ -345,19 +333,22 @@ var _ = Describe("Functional e2e", Serial, func() {
 	time.Sleep(2 * time.Second)
 
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is updated", func() {
-		UpdateNumaflowControllerRollout(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, true, false)
+		UpdateNumaflowControllerRollout(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName}, true, false)
+		// UpdateNumaflowControllerRollout(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, true, false)
 	})
 
 	time.Sleep(2 * time.Second)
 
 	It("Should fail if the NumaflowControllerRollout is updated with a bad version", func() {
-		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, false, false)
+		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, []string{pipelineRolloutName}, false, false)
+		// UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, false, false)
 	})
 
 	time.Sleep(2 * time.Second)
 
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is restored back to previous version", func() {
-		UpdateNumaflowControllerRollout(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, true, false)
+		UpdateNumaflowControllerRollout(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName}, true, false)
+		// UpdateNumaflowControllerRollout(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, true, false)
 	})
 
 	time.Sleep(2 * time.Second)
@@ -368,28 +359,43 @@ var _ = Describe("Functional e2e", Serial, func() {
 		updatedISBServiceSpec := isbServiceSpec
 		updatedISBServiceSpec.JetStream.Version = updatedJetstreamVersion
 
-		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName}, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream.Version == updatedJetstreamVersion
 		}, true, false, true, false)
+
+		// UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		// 	return retrievedISBServiceSpec.JetStream.Version == updatedJetstreamVersion
+		// }, true, false, true, false)
 
 	})
 
 	It("Should update the child ISBService updating a no-data-loss field", func() {
 
-		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, ISBServiceSpecNoDataLossField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName}, ISBServiceSpecNoDataLossField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream != nil &&
 				retrievedISBServiceSpec.JetStream.ContainerTemplate != nil &&
 				retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() != nil &&
 				*retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() == updatedMemLimit
 		}, false, false, false, false)
 
+		// UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, ISBServiceSpecNoDataLossField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		// 	return retrievedISBServiceSpec.JetStream != nil &&
+		// 		retrievedISBServiceSpec.JetStream.ContainerTemplate != nil &&
+		// 		retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() != nil &&
+		// 		*retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() == updatedMemLimit
+		// }, false, false, false, false)
+
 	})
 
 	It("Should update the child ISBService updating a recreate field", func() {
 
-		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, ISBServiceSpecRecreateField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName}, ISBServiceSpecRecreateField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream.Persistence.VolumeSize.Equal(revisedVolSize)
 		}, false, true, true, false)
+
+		// UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, ISBServiceSpecRecreateField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		// 	return retrievedISBServiceSpec.JetStream.Persistence.VolumeSize.Equal(revisedVolSize)
+		// }, false, true, true, false)
 
 	})
 
@@ -430,7 +436,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should delete the PipelineRollouts and child Pipelines", func() {
 		DeletePipelineRollout(pipelineRolloutName)
-		DeletePipelineRollout(anotherPipelineRolloutName)
+		// DeletePipelineRollout(anotherPipelineRolloutName)
 	})
 
 	It("Should delete the MonoVertexRollout and child MonoVertex", func() {

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -273,7 +273,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		numPipelineVertices := len(updatedPipelineSpec.Vertices)
 		UpdatePipelineRollout(pipelineRolloutName, updatedPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return len(retrievedPipelineSpec.Vertices) == numPipelineVertices
-		}, true, true)
+		}, true, false)
 
 	})
 
@@ -288,7 +288,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhasePaused, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhasePaused
-		}, false, true)
+		}, false, false)
 
 		VerifyPipelineStaysPaused(pipelineRolloutName)
 	})

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -42,6 +42,8 @@ const (
 	invalidNumaflowControllerVersion = "99.99.99"
 	initialJetstreamVersion          = "2.10.17"
 	updatedJetstreamVersion          = "2.10.11"
+
+	anotherPipelineRolloutName = "another-pipeline-rollout"
 )
 
 var (
@@ -215,6 +217,11 @@ var _ = Describe("Functional e2e", Serial, func() {
 		CreatePipelineRollout(pipelineRolloutName, Namespace, initialPipelineSpec, false)
 	})
 
+	// extra PipelineRollout to verify that multiple Pipelines will behave correctly during ISBService/controller updates
+	It("Should create another PipelineRollout if it does not exist", func() {
+		CreatePipelineRollout(anotherPipelineRolloutName, Namespace, initialPipelineSpec, false)
+	})
+
 	currentPipelineSpec = initialPipelineSpec
 
 	It("Should create the MonoVertexRollout if it does not exist", func() {
@@ -326,19 +333,19 @@ var _ = Describe("Functional e2e", Serial, func() {
 	time.Sleep(2 * time.Second)
 
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is updated", func() {
-		UpdateNumaflowControllerRollout(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, pipelineRolloutName, true, false)
+		UpdateNumaflowControllerRollout(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, true, false)
 	})
 
 	time.Sleep(2 * time.Second)
 
 	It("Should fail if the NumaflowControllerRollout is updated with a bad version", func() {
-		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, pipelineRolloutName, false, false)
+		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, false, false)
 	})
 
 	time.Sleep(2 * time.Second)
 
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is restored back to previous version", func() {
-		UpdateNumaflowControllerRollout(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, pipelineRolloutName, true, false)
+		UpdateNumaflowControllerRollout(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, true, false)
 	})
 
 	time.Sleep(2 * time.Second)
@@ -349,7 +356,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		updatedISBServiceSpec := isbServiceSpec
 		updatedISBServiceSpec.JetStream.Version = updatedJetstreamVersion
 
-		UpdateISBServiceRollout(isbServiceRolloutName, pipelineRolloutName, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream.Version == updatedJetstreamVersion
 		}, true, false, true, false)
 
@@ -357,7 +364,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should update the child ISBService updating a no-data-loss field", func() {
 
-		UpdateISBServiceRollout(isbServiceRolloutName, pipelineRolloutName, ISBServiceSpecNoDataLossField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, ISBServiceSpecNoDataLossField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream != nil &&
 				retrievedISBServiceSpec.JetStream.ContainerTemplate != nil &&
 				retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() != nil &&
@@ -368,7 +375,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should update the child ISBService updating a recreate field", func() {
 
-		UpdateISBServiceRollout(isbServiceRolloutName, pipelineRolloutName, ISBServiceSpecRecreateField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, ISBServiceSpecRecreateField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream.Persistence.VolumeSize.Equal(revisedVolSize)
 		}, false, true, true, false)
 
@@ -409,8 +416,9 @@ var _ = Describe("Functional e2e", Serial, func() {
 		}, TestTimeout, TestPollingInterval).Should(Equal(1))
 	})
 
-	It("Should delete the PipelineRollout and child Pipeline", func() {
+	It("Should delete the PipelineRollouts and child Pipelines", func() {
 		DeletePipelineRollout(pipelineRolloutName)
+		DeletePipelineRollout(anotherPipelineRolloutName)
 	})
 
 	It("Should delete the MonoVertexRollout and child MonoVertex", func() {

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -273,7 +273,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		numPipelineVertices := len(updatedPipelineSpec.Vertices)
 		UpdatePipelineRollout(pipelineRolloutName, updatedPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return len(retrievedPipelineSpec.Vertices) == numPipelineVertices
-		}, true, false)
+		}, true, true)
 
 	})
 

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -302,7 +302,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhaseRunning
-		}, false, true)
+		}, false, false)
 	})
 
 	It("Should pause the MonoVertex if user requests it", func() {
@@ -369,7 +369,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 				retrievedISBServiceSpec.JetStream.ContainerTemplate != nil &&
 				retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() != nil &&
 				*retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() == updatedMemLimit
-		}, false, false, true, false)
+		}, false, false, false, false)
 
 	})
 

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -333,22 +333,19 @@ var _ = Describe("Functional e2e", Serial, func() {
 	time.Sleep(2 * time.Second)
 
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is updated", func() {
-		UpdateNumaflowControllerRollout(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName}, true, false)
-		// UpdateNumaflowControllerRollout(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, true, false)
+		UpdateNumaflowControllerRollout(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, true)
 	})
 
 	time.Sleep(2 * time.Second)
 
 	It("Should fail if the NumaflowControllerRollout is updated with a bad version", func() {
-		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, []string{pipelineRolloutName}, false, false)
-		// UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, false, false)
+		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, false)
 	})
 
 	time.Sleep(2 * time.Second)
 
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is restored back to previous version", func() {
-		UpdateNumaflowControllerRollout(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName}, true, false)
-		// UpdateNumaflowControllerRollout(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, []string{pipelineRolloutName, anotherPipelineRolloutName}, true, false)
+		UpdateNumaflowControllerRollout(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, true)
 	})
 
 	time.Sleep(2 * time.Second)
@@ -359,9 +356,9 @@ var _ = Describe("Functional e2e", Serial, func() {
 		updatedISBServiceSpec := isbServiceSpec
 		updatedISBServiceSpec.JetStream.Version = updatedJetstreamVersion
 
-		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName}, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		UpdateISBServiceRollout(isbServiceRolloutName, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName, OverrideSourceVertexReplicas: true}}, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream.Version == updatedJetstreamVersion
-		}, true, false, true, false)
+		}, true, false)
 
 		// UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 		// 	return retrievedISBServiceSpec.JetStream.Version == updatedJetstreamVersion
@@ -371,12 +368,12 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should update the child ISBService updating a no-data-loss field", func() {
 
-		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName}, ISBServiceSpecNoDataLossField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		UpdateISBServiceRollout(isbServiceRolloutName, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, ISBServiceSpecNoDataLossField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream != nil &&
 				retrievedISBServiceSpec.JetStream.ContainerTemplate != nil &&
 				retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() != nil &&
 				*retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() == updatedMemLimit
-		}, false, false, false, false)
+		}, false, false)
 
 		// UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, ISBServiceSpecNoDataLossField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 		// 	return retrievedISBServiceSpec.JetStream != nil &&
@@ -389,9 +386,9 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 	It("Should update the child ISBService updating a recreate field", func() {
 
-		UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName}, ISBServiceSpecRecreateField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		UpdateISBServiceRollout(isbServiceRolloutName, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName, OverrideSourceVertexReplicas: true}}, ISBServiceSpecRecreateField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream.Persistence.VolumeSize.Equal(revisedVolSize)
-		}, false, true, true, false)
+		}, false, true)
 
 		// UpdateISBServiceRollout(isbServiceRolloutName, []string{pipelineRolloutName, anotherPipelineRolloutName}, ISBServiceSpecRecreateField, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 		// 	return retrievedISBServiceSpec.JetStream.Persistence.VolumeSize.Equal(revisedVolSize)

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -285,12 +285,19 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		Document("setting desiredPhase=Paused")
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhasePaused
+		initialPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhasePaused
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhasePaused, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhasePaused
 		}, false, false)
 
 		VerifyPipelineStaysPaused(pipelineRolloutName)
+
+		UpdatePipelineRollout(anotherPipelineRolloutName, initialPipelineSpec, numaflowv1.PipelinePhasePaused, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
+			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhasePaused
+		}, false, false)
+
+		VerifyPipelineStaysPaused(anotherPipelineRolloutName)
 	})
 
 	time.Sleep(2 * time.Second)
@@ -299,8 +306,13 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		Document("setting desiredPhase=Running")
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhaseRunning
+		initialPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhaseRunning
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
+			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhaseRunning
+		}, false, false)
+
+		UpdatePipelineRollout(anotherPipelineRolloutName, initialPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhaseRunning
 		}, false, false)
 	})

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -288,7 +288,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhasePaused, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhasePaused
-		}, false, false)
+		}, false, true)
 
 		VerifyPipelineStaysPaused(pipelineRolloutName)
 	})
@@ -302,7 +302,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return retrievedPipelineSpec.Lifecycle.DesiredPhase == numaflowv1.PipelinePhaseRunning
-		}, false, false)
+		}, false, true)
 	})
 
 	It("Should pause the MonoVertex if user requests it", func() {

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -273,7 +273,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 		numPipelineVertices := len(updatedPipelineSpec.Vertices)
 		UpdatePipelineRollout(pipelineRolloutName, updatedPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return len(retrievedPipelineSpec.Vertices) == numPipelineVertices
-		}, true, true)
+		}, true, false)
 
 	})
 

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -369,7 +369,7 @@ var _ = Describe("Functional e2e", Serial, func() {
 				retrievedISBServiceSpec.JetStream.ContainerTemplate != nil &&
 				retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() != nil &&
 				*retrievedISBServiceSpec.JetStream.ContainerTemplate.Resources.Limits.Memory() == updatedMemLimit
-		}, false, false, false, false)
+		}, false, false, true, false)
 
 	})
 

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -366,7 +366,9 @@ func UpdateISBServiceRollout(
 			isbCondStatus := getRolloutConditionStatus(isbRollout.Status.Conditions, apiv1.ConditionPausingPipelines)
 			for _, rolloutInfo := range pipelineRollouts {
 				_, _, retrievedPipelineStatus, err := GetPipelineSpecAndStatus(Namespace, rolloutInfo.PipelineRolloutName)
-				Expect(err).ShouldNot(HaveOccurred())
+				if err != nil {
+					return false
+				}
 				if retrievedPipelineStatus.Phase == numaflowv1.PipelinePhasePaused {
 					return false
 				}

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -321,7 +321,7 @@ func DeleteISBServiceRollout(name string) {
 	}).WithTimeout(TestTimeout).Should(BeTrue(), "The ISBService should have been deleted but it was found.")
 }
 
-// pipelineRolloutName is pipelinerollout and child pipeline that may be checked to see if it is pausing or not after update
+// pipelineRolloutNames is an array of pipelinerollout names that are checked to see if it is pausing or not after update
 // newSpec is the updated spec of the ISBService defined in the rollout
 // verifySpecFunc is passed to the verifyISBServiceSpec func which verifies the ISBService spec defined in the updated rollout
 // matches what we expect

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -195,7 +195,7 @@ func DeleteNumaflowControllerRollout() {
 
 // originalVersion is the original version of the current NumaflowController defined in the rollout
 // newVersion is the new version the updated NumaflowController should have if it is a valid version
-// pipelineRolloutName is the pipeline we check to be sure that it is pausing during the update
+// pipelineRolloutNames is an array of PipelineRollout names we check to be sure that they are pausing during an update
 // valid boolean indicates if newVersion is a valid version or not (which will change the check we make)
 // pipelineIsFailed informs us if any dependent pipelines are currently failed and to not check if they are running
 func UpdateNumaflowControllerRollout(originalVersion, newVersion string, pipelineRolloutNames []string, valid bool, pipelineIsFailed bool) {

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -263,7 +263,7 @@ func UpdateNumaflowControllerRollout(originalVersion, newVersion string, pipelin
 		if pipelineIsFailed {
 			VerifyPipelineFailed(Namespace, name)
 		} else {
-			VerifyPipelineRunning(Namespace, name, true)
+			VerifyPipelineRunning(Namespace, name, false)
 		}
 	}
 

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -263,7 +263,7 @@ func UpdateNumaflowControllerRollout(originalVersion, newVersion string, pipelin
 		if pipelineIsFailed {
 			VerifyPipelineFailed(Namespace, name)
 		} else {
-			VerifyPipelineRunning(Namespace, name, false)
+			VerifyPipelineRunning(Namespace, name, true)
 		}
 	}
 

--- a/tests/e2e/ppnd-e2e/ppnd_test.go
+++ b/tests/e2e/ppnd-e2e/ppnd_test.go
@@ -282,9 +282,9 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 
 		// need to update function
 		// update would normally cause data loss
-		UpdateISBServiceRollout(isbServiceRolloutName, []string{failedPipelineRolloutName}, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		UpdateISBServiceRollout(isbServiceRolloutName, []PipelineRolloutInfo{{PipelineRolloutName: failedPipelineRolloutName, PipelineIsFailed: true}}, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream.Version == initialJetstreamVersion
-		}, true, false, false, true)
+		}, true, false)
 
 		time.Sleep(5 * time.Second)
 
@@ -306,7 +306,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 		time.Sleep(5 * time.Second)
 
 		Document("Updating Numaflow controller to cause a PPND change")
-		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, initialNumaflowControllerVersion, []string{failedPipelineRolloutName}, true, true)
+		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, initialNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: failedPipelineRolloutName, PipelineIsFailed: true}}, true)
 
 		time.Sleep(5 * time.Second)
 

--- a/tests/e2e/ppnd-e2e/ppnd_test.go
+++ b/tests/e2e/ppnd-e2e/ppnd_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 
 		// need to update function
 		// update would normally cause data loss
-		UpdateISBServiceRollout(isbServiceRolloutName, failedPipelineRolloutName, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
+		UpdateISBServiceRollout(isbServiceRolloutName, []string{failedPipelineRolloutName}, updatedISBServiceSpec, func(retrievedISBServiceSpec numaflowv1.InterStepBufferServiceSpec) bool {
 			return retrievedISBServiceSpec.JetStream.Version == initialJetstreamVersion
 		}, true, false, false, true)
 
@@ -306,7 +306,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 		time.Sleep(5 * time.Second)
 
 		Document("Updating Numaflow controller to cause a PPND change")
-		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, initialNumaflowControllerVersion, failedPipelineRolloutName, true, true)
+		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, initialNumaflowControllerVersion, []string{failedPipelineRolloutName}, true, true)
 
 		time.Sleep(5 * time.Second)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #588 

### Modifications

Improves e2e testing by updating the `UpdateISBServiceRollout` and `UpdateNumaflowControllerRollout` functions to take an array of PipelineRollout names instead of a singular one. This allows us to check multiple Pipelines behavior as we proceed through an update of an ISBService or NumaflowController.

To ensure this, I have added a PipelineRollout `another-pipeline-rollout` to our functional test run which we check alongside the initial PipelineRollout which we update.


### Verification

Running e2e tests locally and checking that CI run is successful.

### Backward incompatibilities

N/A
