### PR TITLE
fix: enable certain fields related to "strategy" to be optional in the Rollouts

### DIFF
--- a/config/crd/bases/numaplane.numaproj.io_isbservicerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_isbservicerollouts.yaml
@@ -77,15 +77,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
-                    required:
-                    - assessmentSchedule
                     type: object
-                required:
-                - progressive
                 type: object
             required:
             - interStepBufferService
-            - strategy
             type: object
           status:
             description: ISBServiceRolloutStatus defines the observed state of ISBServiceRollout

--- a/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
@@ -78,15 +78,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
-                    required:
-                    - assessmentSchedule
                     type: object
-                required:
-                - progressive
                 type: object
             required:
             - monoVertex
-            - strategy
             type: object
           status:
             description: MonoVertexRolloutStatus defines the observed state of MonoVertexRollout

--- a/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
@@ -83,15 +83,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
-                    required:
-                    - assessmentSchedule
                     type: object
-                required:
-                - progressive
                 type: object
             required:
             - pipeline
-            - strategy
             type: object
           status:
             description: PipelineRolloutStatus defines the observed state of PipelineRollout

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -128,15 +128,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
-                    required:
-                    - assessmentSchedule
                     type: object
-                required:
-                - progressive
                 type: object
             required:
             - interStepBufferService
-            - strategy
             type: object
           status:
             description: ISBServiceRolloutStatus defines the observed state of ISBServiceRollout
@@ -389,15 +384,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
-                    required:
-                    - assessmentSchedule
                     type: object
-                required:
-                - progressive
                 type: object
             required:
             - monoVertex
-            - strategy
             type: object
           status:
             description: MonoVertexRolloutStatus defines the observed state of MonoVertexRollout
@@ -1104,15 +1094,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
-                    required:
-                    - assessmentSchedule
                     type: object
-                required:
-                - progressive
                 type: object
             required:
             - pipeline
-            - strategy
             type: object
           status:
             description: PipelineRolloutStatus defines the observed state of PipelineRollout

--- a/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
@@ -30,7 +30,7 @@ import (
 // ISBServiceRolloutSpec defines the desired state of ISBServiceRollout
 type ISBServiceRolloutSpec struct {
 	InterStepBufferService InterStepBufferService `json:"interStepBufferService"`
-	Strategy               RolloutStrategy        `json:"strategy"`
+	Strategy               RolloutStrategy        `json:"strategy,omitempty"`
 }
 
 // InterStepBufferService includes the spec of InterStepBufferService in Numaflow

--- a/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
@@ -32,7 +32,7 @@ const (
 // MonoVertexRolloutSpec defines the desired state of MonoVertexRollout
 type MonoVertexRolloutSpec struct {
 	MonoVertex MonoVertex                  `json:"monoVertex"`
-	Strategy   PipelineTypeRolloutStrategy `json:"strategy"`
+	Strategy   PipelineTypeRolloutStrategy `json:"strategy,omitempty"`
 }
 
 // MonoVertex includes the spec of MonoVertex in Numaflow

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -34,7 +34,7 @@ const (
 // PipelineRolloutSpec defines the desired state of PipelineRollout
 type PipelineRolloutSpec struct {
 	Pipeline Pipeline                    `json:"pipeline"`
-	Strategy PipelineTypeRolloutStrategy `json:"strategy"`
+	Strategy PipelineTypeRolloutStrategy `json:"strategy,omitempty"`
 }
 
 // Pipeline includes the spec of Pipeline in Numaflow

--- a/pkg/apis/numaplane/v1alpha1/shared_types.go
+++ b/pkg/apis/numaplane/v1alpha1/shared_types.go
@@ -41,7 +41,7 @@ const (
 )
 
 type RolloutStrategy struct {
-	Progressive ProgressiveStrategy `json:"progressive"`
+	Progressive ProgressiveStrategy `json:"progressive,omitempty"`
 }
 
 // PipelineTypeRolloutStrategy specifies the RolloutStrategy for fields shared by Pipeline and MonoVertex
@@ -52,5 +52,5 @@ type PipelineTypeRolloutStrategy struct {
 type ProgressiveStrategy struct {
 	// optional string: comma-separated list consisting of:
 	// assessmentDelay, assessmentPeriod, assessmentInterval
-	AssessmentSchedule string `json:"assessmentSchedule"`
+	AssessmentSchedule string `json:"assessmentSchedule,omitempty"`
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

The `strategy` field for PipelineRollout, ISBServiceRollout, and MonoVertexRollout was not configured as `omitempty`. This was causing it to be configured as a "required" field in the CRDs. Trying to apply our sample Rollouts was failing since the field wasn't in there. 

Also, I updated the child fields to be `omitempty` as well. 


### Verification

```
jvogelman@macos-VF3V14X2QJ numaplane % k apply -f config/samples/numaplane.numaproj.io_v1alpha1_isbservicerollout.yaml                   
isbservicerollout.numaplane.numaproj.io/my-isbsvc created
jvogelman@macos-VF3V14X2QJ numaplane % k apply -f config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml  
pipelinerollout.numaplane.numaproj.io/my-pipeline created
jvogelman@macos-VF3V14X2QJ numaplane % k apply -f config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml 
monovertexrollout.numaplane.numaproj.io/my-monovertex created

```

### Backward incompatibilities

N/A
