### PR TITLE
chore: remove the vertex scaling workaround added in the E2E tests no…

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -91,8 +91,6 @@ const (
 	UpgradeStateLabelSelector = "numaplane.numaproj.io/upgrade-state=promoted"
 
 	LogSpacer = "================================"
-
-	PipelineSourceVertexName = "in"
 )
 
 type Output struct {
@@ -104,18 +102,8 @@ type Output struct {
 }
 
 type PipelineRolloutInfo struct {
-	PipelineRolloutName          string `json:"pipelineRolloutName"`
-	PipelineIsFailed             bool   `json:"pipelineIsFailed,omitempty"`
-	OverrideSourceVertexReplicas bool   `json:"overrideSourceVertexReplicas,omitempty"`
-}
-
-func GetVerticesScaleValue() int {
-	switch getUpgradeStrategy() {
-	case config.ProgressiveStrategyID:
-		return 3
-	default:
-		return 1
-	}
+	PipelineRolloutName string `json:"pipelineRolloutName"`
+	PipelineIsFailed    bool   `json:"pipelineIsFailed,omitempty"`
 }
 
 func verifyPodsRunning(namespace string, numPods int, labelSelector string) {

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -260,7 +260,7 @@ func UpdateNumaflowControllerRollout(originalVersion, newVersion string, pipelin
 		if rolloutInfo.PipelineIsFailed {
 			VerifyPipelineFailed(Namespace, rolloutName)
 		} else {
-			VerifyPipelineRunning(Namespace, rolloutName, true)
+			VerifyPipelineRunning(Namespace, rolloutName)
 		}
 	}
 

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -85,7 +84,7 @@ func VerifyPipelineRolloutHealthy(pipelineRolloutName string) {
 	}).Should(Equal(metav1.ConditionTrue))
 }
 
-func VerifyPipelineRunning(namespace string, pipelineRolloutName string, useVerticesScaleValue bool) {
+func VerifyPipelineRunning(namespace string, pipelineRolloutName string) {
 	By("Verifying that the Pipeline is running")
 	VerifyPipelineStatusEventually(namespace, pipelineRolloutName,
 		func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus numaflowv1.PipelineStatus) bool {
@@ -105,9 +104,6 @@ func VerifyPipelineRunning(namespace string, pipelineRolloutName string, useVert
 	Expect(err).ShouldNot(HaveOccurred())
 
 	numPods := len(spec.Vertices)
-	if useVerticesScaleValue {
-		numPods *= GetVerticesScaleValue()
-	}
 	verifyPodsRunning(namespace, numPods, getVertexLabelSelector(pipeline.GetName()))
 
 	verifyPodsRunning(namespace, 1, getDaemonLabelSelector(pipeline.GetName()))
@@ -382,7 +378,7 @@ func CreatePipelineRollout(name, namespace string, spec numaflowv1.PipelineSpec,
 
 	if !failed {
 		VerifyPipelineRolloutHealthy(name)
-		VerifyPipelineRunning(namespace, name, true)
+		VerifyPipelineRunning(namespace, name)
 	}
 }
 
@@ -451,7 +447,7 @@ func DeletePipelineRollout(name string) {
 // expectedFinalPhase - after updating the Rollout what phase we expect the child Pipeline to be in
 // verifySpecFunc - boolean function to verify that updated PipelineRollout has correct spec
 // dataLoss - informs us if the update to the PipelineRollout will cause data loss or not
-func UpdatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expectedFinalPhase numaflowv1.PipelinePhase, verifySpecFunc func(numaflowv1.PipelineSpec) bool, dataLoss bool, overrideSourceVertexReplicas, scaleInVertex bool) {
+func UpdatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expectedFinalPhase numaflowv1.PipelinePhase, verifySpecFunc func(numaflowv1.PipelineSpec) bool, dataLoss bool) {
 
 	By("Updating Pipeline spec in PipelineRollout")
 	rawSpec, err := json.Marshal(newSpec)
@@ -480,44 +476,6 @@ func UpdatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expecte
 
 	// wait for update to reconcile
 	time.Sleep(5 * time.Second)
-
-	// TODO: remove this logic once Numaflow is updated to scale vertices for sources other than Kafka and
-	// when scaling to 0 is also allowed.
-	if overrideSourceVertexReplicas && UpgradeStrategy == config.ProgressiveStrategyID {
-		scaleTo := int64(math.Floor(float64(GetVerticesScaleValue()) / float64(2)))
-
-		pipeline, err := GetPipeline(Namespace, name)
-		Expect(err).ShouldNot(HaveOccurred())
-		vertexName := fmt.Sprintf("%s-%s", pipeline.GetName(), PipelineSourceVertexName)
-
-		vertex, err := dynamicClient.Resource(GetGVRForVertex()).Namespace(Namespace).Get(ctx, vertexName, metav1.GetOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-		err = unstructured.SetNestedField(vertex.Object, scaleTo, "spec", "replicas")
-		Expect(err).ShouldNot(HaveOccurred())
-		_, err = dynamicClient.Resource(GetGVRForVertex()).Namespace(Namespace).Update(ctx, vertex, metav1.UpdateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-	}
-	// TODO: remove this logic once Numaflow is updated to scale vertices for sources other than Kafka and
-	// when scaling to 0 is also allowed.
-	// NOTE: this is needed because after resuming a pipeline, only 1 replica of the vertex is created.
-	// Numaflow does not respect the scale values also in this circumstance.
-	if scaleInVertex {
-		scaleTo := int64(GetVerticesScaleValue())
-
-		pipeline, err := GetPipeline(Namespace, name)
-		Expect(err).ShouldNot(HaveOccurred())
-		vertexName := fmt.Sprintf("%s-%s", pipeline.GetName(), PipelineSourceVertexName)
-
-		vertex, err := dynamicClient.Resource(GetGVRForVertex()).Namespace(Namespace).Get(ctx, vertexName, metav1.GetOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-		err = unstructured.SetNestedField(vertex.Object, scaleTo, "spec", "replicas")
-		Expect(err).ShouldNot(HaveOccurred())
-		_, err = dynamicClient.Resource(GetGVRForVertex()).Namespace(Namespace).Update(ctx, vertex, metav1.UpdateOptions{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// Give time to the vertex pods to start
-		time.Sleep(30 * time.Second)
-	}
 
 	// rollout phase will be pending if we are expecting a long pausing state and Pipeline will not be fully updated
 	if !(UpgradeStrategy == config.PPNDStrategyID && expectedFinalPhase == numaflowv1.PipelinePhasePausing) {

--- a/tests/e2e/ppnd-e2e/ppnd_test.go
+++ b/tests/e2e/ppnd-e2e/ppnd_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 
 			UpdatePipelineRollout(slowPipelineRolloutName, *slowPipelineSpec, numaflowv1.PipelinePhasePausing, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 				return true
-			}, true, false, false)
+			}, true)
 
 			verifyPipelineIsSlowToPause()
 			allowDataLoss()
@@ -254,7 +254,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 		// update spec to have topology change
 		UpdatePipelineRollout(failedPipelineRolloutName, updatedPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return len(retrievedPipelineSpec.Vertices) == 3
-		}, true, false, false)
+		}, true)
 
 		time.Sleep(5 * time.Second)
 
@@ -342,7 +342,7 @@ func createSlowPipelineRollout() {
 		return len(slowPipelineSpec.Vertices) == len(retrievedPipelineSpec.Vertices)
 	})
 
-	VerifyPipelineRunning(Namespace, slowPipelineRolloutName, false)
+	VerifyPipelineRunning(Namespace, slowPipelineRolloutName)
 	VerifyInProgressStrategy(slowPipelineRolloutName, apiv1.UpgradeStrategyNoOp)
 
 }
@@ -372,6 +372,6 @@ func allowDataLoss() {
 	})
 
 	By("Verifying that Pipeline has stopped trying to pause")
-	VerifyPipelineRunning(Namespace, slowPipelineRolloutName, false)
+	VerifyPipelineRunning(Namespace, slowPipelineRolloutName)
 
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #596 

### Modifications

Remove the vertex scaling workaround added in the E2E tests now that Numaflow changes are available.

### Verification

E2E tests successful.

### Backward incompatibilities

None.
