### PR TITLE
chore: increase scale values for source vertex in E2E tests

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -91,8 +91,6 @@ const (
 	UpgradeStateLabelSelector = "numaplane.numaproj.io/upgrade-state=promoted"
 
 	LogSpacer = "================================"
-
-	SourceVertexScaleMin = 5
 )
 
 type Output struct {
@@ -106,6 +104,15 @@ type Output struct {
 type PipelineRolloutInfo struct {
 	PipelineRolloutName string `json:"pipelineRolloutName"`
 	PipelineIsFailed    bool   `json:"pipelineIsFailed,omitempty"`
+}
+
+func GetSourceVertexScaleMin() int {
+	switch getUpgradeStrategy() {
+	case config.ProgressiveStrategyID:
+		return 5
+	default:
+		return 1
+	}
 }
 
 func verifyPodsRunning(namespace string, numPods int, labelSelector string) {

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -91,6 +91,8 @@ const (
 	UpgradeStateLabelSelector = "numaplane.numaproj.io/upgrade-state=promoted"
 
 	LogSpacer = "================================"
+
+	SourceVertexScaleMin = 5
 )
 
 type Output struct {

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -66,7 +66,7 @@ var (
 						Duration: &pipelineSpecSourceDuration,
 					},
 				},
-				Scale: numaflowv1.Scale{Min: ptr.To(int32(SourceVertexScaleMin)), Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
+				Scale: numaflowv1.Scale{Min: ptr.To(int32(GetSourceVertexScaleMin())), Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
 			},
 			{
 				Name: "out",
@@ -97,7 +97,7 @@ var (
 						Duration: &pipelineSpecSourceDuration,
 					},
 				},
-				Scale: numaflowv1.Scale{Min: ptr.To(int32(SourceVertexScaleMin)), Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
+				Scale: numaflowv1.Scale{Min: ptr.To(int32(GetSourceVertexScaleMin())), Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
 			},
 			{
 				Name: "cat",
@@ -174,10 +174,11 @@ var (
 
 	currentMonoVertexSpec numaflowv1.MonoVertexSpec
 	initialMonoVertexSpec = numaflowv1.MonoVertexSpec{
-		// Replicas: ptr.To(int32(1)),
-		Scale: numaflowv1.Scale{
-			Min: ptr.To(int32(SourceVertexScaleMin)),
-		},
+		// TTODO
+		Replicas: ptr.To(int32(1)),
+		// Scale: numaflowv1.Scale{
+		// 	Min: ptr.To(int32(GetSourceVertexScaleMin())),
+		// },
 		Source: &numaflowv1.Source{
 			UDSource: &numaflowv1.UDSource{
 				Container: &numaflowv1.Container{
@@ -274,7 +275,7 @@ var _ = Describe("Functional e2e:", Serial, func() {
 
 	It("Should update the child Pipeline if the PipelineRollout is updated", func() {
 
-		numPipelineVertices := len(updatedPipelineSpec.Vertices) + SourceVertexScaleMin - 1
+		numPipelineVertices := len(updatedPipelineSpec.Vertices)
 		UpdatePipelineRollout(pipelineRolloutName, updatedPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
 			return len(retrievedPipelineSpec.Vertices) == numPipelineVertices
 		}, true)

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -174,11 +174,9 @@ var (
 
 	currentMonoVertexSpec numaflowv1.MonoVertexSpec
 	initialMonoVertexSpec = numaflowv1.MonoVertexSpec{
-		// TTODO
-		Replicas: ptr.To(int32(1)),
-		// Scale: numaflowv1.Scale{
-		// 	Min: ptr.To(int32(GetSourceVertexScaleMin())),
-		// },
+		Scale: numaflowv1.Scale{
+			Min: ptr.To(int32(GetSourceVertexScaleMin())),
+		},
 		Source: &numaflowv1.Source{
 			UDSource: &numaflowv1.UDSource{
 				Container: &numaflowv1.Container{

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -85,7 +85,7 @@ func VerifyMonoVertexReady(namespace, monoVertexRolloutName string) {
 	daemonLabelSelector := fmt.Sprintf("%s=%s,%s=%s", numaflowv1.KeyMonoVertexName, monoVertexName, numaflowv1.KeyComponent, "mono-vertex-daemon")
 
 	By("Verifying that the MonoVertex is ready")
-	verifyPodsRunning(namespace, SourceVertexScaleMin, vertexLabelSelector)
+	verifyPodsRunning(namespace, 1, vertexLabelSelector) // TTODO: replace 1 with SourceVertexScaleMin
 	verifyPodsRunning(namespace, 1, daemonLabelSelector)
 
 }

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -85,7 +85,7 @@ func VerifyMonoVertexReady(namespace, monoVertexRolloutName string) {
 	daemonLabelSelector := fmt.Sprintf("%s=%s,%s=%s", numaflowv1.KeyMonoVertexName, monoVertexName, numaflowv1.KeyComponent, "mono-vertex-daemon")
 
 	By("Verifying that the MonoVertex is ready")
-	verifyPodsRunning(namespace, 1, vertexLabelSelector) // TTODO: replace 1 with SourceVertexScaleMin
+	verifyPodsRunning(namespace, GetSourceVertexScaleMin(), vertexLabelSelector)
 	verifyPodsRunning(namespace, 1, daemonLabelSelector)
 
 }

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -85,7 +85,7 @@ func VerifyMonoVertexReady(namespace, monoVertexRolloutName string) {
 	daemonLabelSelector := fmt.Sprintf("%s=%s,%s=%s", numaflowv1.KeyMonoVertexName, monoVertexName, numaflowv1.KeyComponent, "mono-vertex-daemon")
 
 	By("Verifying that the MonoVertex is ready")
-	verifyPodsRunning(namespace, 1, vertexLabelSelector)
+	verifyPodsRunning(namespace, SourceVertexScaleMin, vertexLabelSelector)
 	verifyPodsRunning(namespace, 1, daemonLabelSelector)
 
 }

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -103,7 +103,10 @@ func VerifyPipelineRunning(namespace string, pipelineRolloutName string) {
 	spec, err := GetPipelineSpec(pipeline)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	numPods := len(spec.Vertices)
+	// The number of total pods is the scaled number of source vertex pods (SourceVertexScaleMin) + the output vertex pod.
+	// The '-1' removes 1 from the number of pods, since the source vertex pods are all included in the SourceVertexScaleMin
+	// and we should not count 1 additional from the number of total vertices.
+	numPods := len(spec.Vertices) + SourceVertexScaleMin - 1
 	verifyPodsRunning(namespace, numPods, getVertexLabelSelector(pipeline.GetName()))
 
 	verifyPodsRunning(namespace, 1, getDaemonLabelSelector(pipeline.GetName()))

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -103,10 +103,10 @@ func VerifyPipelineRunning(namespace string, pipelineRolloutName string) {
 	spec, err := GetPipelineSpec(pipeline)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	// The number of total pods is the scaled number of source vertex pods (SourceVertexScaleMin) + the output vertex pod.
-	// The '-1' removes 1 from the number of pods, since the source vertex pods are all included in the SourceVertexScaleMin
+	// The number of total pods is the scaled number of source vertex pods (GetSourceVertexScaleMin()) + the output vertex pod.
+	// The '-1' removes 1 from the number of pods, since the source vertex pods are all included in the GetSourceVertexScaleMin()
 	// and we should not count 1 additional from the number of total vertices.
-	numPods := len(spec.Vertices) + SourceVertexScaleMin - 1
+	numPods := len(spec.Vertices) + GetSourceVertexScaleMin() - 1
 	verifyPodsRunning(namespace, numPods, getVertexLabelSelector(pipeline.GetName()))
 
 	verifyPodsRunning(namespace, 1, getDaemonLabelSelector(pipeline.GetName()))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Increased the scale values for Pipeline and MonoVertex in the E2E tests to verify scaling logic.

### Verification

E2E tests execution.

### Backward incompatibilities

None.
