### PR TITLE
fix: increased number of pods for the source vertex for all strategies and other e2e tests fixes

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -135,8 +135,7 @@ func verifyVerticesPodsRunning(namespace, pipelineName string, specVertices []nu
 		)
 
 		for _, vtx := range specVertices {
-			// TTODO
-			// vtxLabelSelector := fmt.Sprintf("%s=%s", numaflowv1.KeyVertexName, vtx.Name) // this only works for pipeline
+			// vtxLabelSelector := fmt.Sprintf("%s=%s", numaflowv1.KeyVertexName, vtx.Name) // this only works for pipeline (not monovertex)
 			vtxLabelSelector := fmt.Sprintf("app.kubernetes.io/name=%s-%s", pipelineName, vtx.Name) // this should work also for monovertex
 			labelSelector := fmt.Sprintf("%s,%s", baseLabelSelector, vtxLabelSelector)
 
@@ -152,7 +151,7 @@ func verifyVerticesPodsRunning(namespace, pipelineName string, specVertices []nu
 
 			podsList, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 			if err != nil {
-				panic(err) // TTODO: panic or something else?
+				return false
 			}
 
 			if podsList == nil {

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -91,6 +91,8 @@ const (
 	UpgradeStateLabelSelector = "numaplane.numaproj.io/upgrade-state=promoted"
 
 	LogSpacer = "================================"
+
+	SourceVertexScaleMin = 5
 )
 
 type Output struct {
@@ -104,15 +106,6 @@ type Output struct {
 type PipelineRolloutInfo struct {
 	PipelineRolloutName string `json:"pipelineRolloutName"`
 	PipelineIsFailed    bool   `json:"pipelineIsFailed,omitempty"`
-}
-
-func GetSourceVertexScaleMin() int {
-	switch getUpgradeStrategy() {
-	case config.ProgressiveStrategyID:
-		return 5
-	default:
-		return 1
-	}
 }
 
 func verifyPodsRunning(namespace string, numPods int, labelSelector string) {

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -210,6 +210,9 @@ func TestFunctionalE2E(t *testing.T) {
 }
 
 var _ = Describe("Functional e2e:", Serial, func() {
+	// TODO: try to elimiate these assignments
+	currentMonoVertexSpec = initialMonoVertexSpec
+	currentPipelineSpec = updatedPipelineSpec
 
 	It("Should create the NumaflowControllerRollout if it doesn't exist", func() {
 		CreateNumaflowControllerRollout(initialNumaflowControllerVersion)
@@ -228,15 +231,9 @@ var _ = Describe("Functional e2e:", Serial, func() {
 	// 	CreatePipelineRollout(anotherPipelineRolloutName, Namespace, initialPipelineSpec, false)
 	// })
 
-	currentPipelineSpec = initialPipelineSpec
-
 	It("Should create the MonoVertexRollout if it does not exist", func() {
 		CreateMonoVertexRollout(monoVertexRolloutName, Namespace, initialMonoVertexSpec)
 	})
-
-	currentMonoVertexSpec = initialMonoVertexSpec
-
-	time.Sleep(2 * time.Second)
 
 	It("Should automatically heal a Pipeline if it is updated directly", func() {
 
@@ -272,8 +269,6 @@ var _ = Describe("Functional e2e:", Serial, func() {
 		VerifyPipelineRunning(Namespace, pipelineRolloutName)
 	})
 
-	time.Sleep(2 * time.Second)
-
 	It("Should update the child Pipeline if the PipelineRollout is updated", func() {
 
 		numPipelineVertices := len(updatedPipelineSpec.Vertices)
@@ -281,10 +276,6 @@ var _ = Describe("Functional e2e:", Serial, func() {
 			return len(retrievedPipelineSpec.Vertices) == numPipelineVertices
 		}, true)
 	})
-
-	currentPipelineSpec = updatedPipelineSpec
-
-	time.Sleep(2 * time.Second)
 
 	It("Should pause the Pipeline if user requests it", func() {
 
@@ -298,8 +289,6 @@ var _ = Describe("Functional e2e:", Serial, func() {
 		VerifyPipelineStaysPaused(pipelineRolloutName)
 	})
 
-	time.Sleep(2 * time.Second)
-
 	It("Should resume the Pipeline if user requests it", func() {
 
 		By("setting desiredPhase=Running")
@@ -311,7 +300,6 @@ var _ = Describe("Functional e2e:", Serial, func() {
 	})
 
 	It("Should pause the MonoVertex if user requests it", func() {
-		// time.Sleep(30 * time.Second) // TTODO
 
 		By("setting desiredPhase=Paused")
 		currentMonoVertexSpec.Lifecycle.DesiredPhase = numaflowv1.MonoVertexPhasePaused
@@ -323,8 +311,6 @@ var _ = Describe("Functional e2e:", Serial, func() {
 		VerifyMonoVertexStaysPaused(monoVertexRolloutName)
 	})
 
-	time.Sleep(2 * time.Second)
-
 	It("Should resume the MonoVertex if user requests it", func() {
 
 		By("setting desiredPhase=Running")
@@ -335,25 +321,17 @@ var _ = Describe("Functional e2e:", Serial, func() {
 		})
 	})
 
-	time.Sleep(2 * time.Second)
-
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is updated", func() {
 		UpdateNumaflowControllerRollout(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, true)
 	})
-
-	time.Sleep(2 * time.Second)
 
 	It("Should fail if the NumaflowControllerRollout is updated with a bad version", func() {
 		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, false)
 	})
 
-	time.Sleep(2 * time.Second)
-
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is restored back to previous version", func() {
 		UpdateNumaflowControllerRollout(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, true)
 	})
-
-	time.Sleep(2 * time.Second)
 
 	It("Should update the child ISBService if the ISBServiceRollout is updated", func() {
 

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -55,7 +55,6 @@ var (
 	sourceVertexScaleMax = int32(9)
 	numVertices          = int32(1)
 	zeroReplicaSleepSec  = uint32(15) // if for some reason the Vertex has 0 replicas, this will cause Numaflow to scale it back up
-	currentPipelineSpec  numaflowv1.PipelineSpec
 	initialPipelineSpec  = numaflowv1.PipelineSpec{
 		InterStepBufferServiceName: isbServiceRolloutName,
 		Vertices: []numaflowv1.AbstractVertex{
@@ -176,7 +175,6 @@ var (
 		},
 	}
 
-	currentMonoVertexSpec numaflowv1.MonoVertexSpec
 	initialMonoVertexSpec = numaflowv1.MonoVertexSpec{
 		Scale: numaflowv1.Scale{
 			Min: &sourceVertexScaleMin,
@@ -211,9 +209,6 @@ func TestFunctionalE2E(t *testing.T) {
 }
 
 var _ = Describe("Functional e2e:", Serial, func() {
-	// TODO: try to eliminate these assignments
-	currentMonoVertexSpec = initialMonoVertexSpec
-	currentPipelineSpec = updatedPipelineSpec
 
 	It("Should create the NumaflowControllerRollout if it doesn't exist", func() {
 		CreateNumaflowControllerRollout(initialNumaflowControllerVersion)
@@ -281,6 +276,7 @@ var _ = Describe("Functional e2e:", Serial, func() {
 	It("Should pause the Pipeline if user requests it", func() {
 
 		By("setting desiredPhase=Paused")
+		currentPipelineSpec := updatedPipelineSpec
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhasePaused
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhasePaused, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
@@ -293,6 +289,7 @@ var _ = Describe("Functional e2e:", Serial, func() {
 	It("Should resume the Pipeline if user requests it", func() {
 
 		By("setting desiredPhase=Running")
+		currentPipelineSpec := updatedPipelineSpec
 		currentPipelineSpec.Lifecycle.DesiredPhase = numaflowv1.PipelinePhaseRunning
 
 		UpdatePipelineRollout(pipelineRolloutName, currentPipelineSpec, numaflowv1.PipelinePhaseRunning, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
@@ -303,6 +300,7 @@ var _ = Describe("Functional e2e:", Serial, func() {
 	It("Should pause the MonoVertex if user requests it", func() {
 
 		By("setting desiredPhase=Paused")
+		currentMonoVertexSpec := initialMonoVertexSpec
 		currentMonoVertexSpec.Lifecycle.DesiredPhase = numaflowv1.MonoVertexPhasePaused
 
 		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhasePaused, func(spec numaflowv1.MonoVertexSpec) bool {
@@ -315,6 +313,7 @@ var _ = Describe("Functional e2e:", Serial, func() {
 	It("Should resume the MonoVertex if user requests it", func() {
 
 		By("setting desiredPhase=Running")
+		currentMonoVertexSpec := initialMonoVertexSpec
 		currentMonoVertexSpec.Lifecycle.DesiredPhase = numaflowv1.MonoVertexPhaseRunning
 
 		UpdateMonoVertexRollout(monoVertexRolloutName, currentMonoVertexSpec, numaflowv1.MonoVertexPhaseRunning, func(spec numaflowv1.MonoVertexSpec) bool {

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -51,6 +51,7 @@ var (
 	pipelineSpecSourceDuration = metav1.Duration{
 		Duration: time.Second,
 	}
+	sourceVertexScaleMin = int32(5)
 	sourceVertexScaleMax = int32(9)
 	numVertices          = int32(1)
 	zeroReplicaSleepSec  = uint32(15) // if for some reason the Vertex has 0 replicas, this will cause Numaflow to scale it back up
@@ -66,7 +67,7 @@ var (
 						Duration: &pipelineSpecSourceDuration,
 					},
 				},
-				Scale: numaflowv1.Scale{Min: ptr.To(int32(SourceVertexScaleMin)), Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
+				Scale: numaflowv1.Scale{Min: &sourceVertexScaleMin, Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
 			},
 			{
 				Name: "out",
@@ -100,7 +101,7 @@ var (
 						Duration: &pipelineSpecSourceDuration,
 					},
 				},
-				Scale: numaflowv1.Scale{Min: ptr.To(int32(SourceVertexScaleMin)), Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
+				Scale: numaflowv1.Scale{Min: &sourceVertexScaleMin, Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
 			},
 			{
 				Name: "cat",
@@ -178,7 +179,7 @@ var (
 	currentMonoVertexSpec numaflowv1.MonoVertexSpec
 	initialMonoVertexSpec = numaflowv1.MonoVertexSpec{
 		Scale: numaflowv1.Scale{
-			Min: ptr.To(int32(SourceVertexScaleMin)),
+			Min: &sourceVertexScaleMin,
 		},
 		Source: &numaflowv1.Source{
 			UDSource: &numaflowv1.UDSource{
@@ -210,7 +211,7 @@ func TestFunctionalE2E(t *testing.T) {
 }
 
 var _ = Describe("Functional e2e:", Serial, func() {
-	// TODO: try to elimiate these assignments
+	// TODO: try to eliminate these assignments
 	currentMonoVertexSpec = initialMonoVertexSpec
 	currentPipelineSpec = updatedPipelineSpec
 

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -73,7 +73,7 @@ func VerifyMonoVertexRolloutReady(monoVertexRolloutName string) {
 	}).Should(Equal(metav1.ConditionTrue))
 }
 
-func VerifyMonoVertexReady(namespace, monoVertexRolloutName string) {
+func VerifyMonoVertexReady(namespace, monoVertexRolloutName string) error {
 
 	By("Verifying that the MonoVertex is running")
 	monoVertexName := VerifyMonoVertexStatus(namespace, monoVertexRolloutName,
@@ -81,13 +81,23 @@ func VerifyMonoVertexReady(namespace, monoVertexRolloutName string) {
 			return retrievedMonoVertexStatus.Phase == string(numaflowv1.MonoVertexPhaseRunning)
 		})
 
-	vertexLabelSelector := fmt.Sprintf("%s=%s,%s=%s", numaflowv1.KeyMonoVertexName, monoVertexName, numaflowv1.KeyComponent, "mono-vertex")
-	daemonLabelSelector := fmt.Sprintf("%s=%s,%s=%s", numaflowv1.KeyMonoVertexName, monoVertexName, numaflowv1.KeyComponent, "mono-vertex-daemon")
+	unstructMonoVertex, err := GetMonoVertex(namespace, monoVertexRolloutName)
+	if err != nil {
+		return fmt.Errorf("unable to get the MonoVertex for the MonoVertexRollout %s/%s: %w", namespace, monoVertexRolloutName, err)
+	}
+
+	monoVertexSpec, err := getMonoVertexSpec(unstructMonoVertex)
+	if err != nil {
+		return fmt.Errorf("error getting the MonoVertex spec: %w", err)
+	}
 
 	By("Verifying that the MonoVertex is ready")
-	verifyPodsRunning(namespace, SourceVertexScaleMin, vertexLabelSelector)
+	verifyVerticesPodsRunning(namespace, monoVertexName, []numaflowv1.AbstractVertex{{Scale: monoVertexSpec.Scale}}, ComponentMonoVertex)
+
+	daemonLabelSelector := fmt.Sprintf("%s=%s,%s=%s", numaflowv1.KeyMonoVertexName, monoVertexName, numaflowv1.KeyComponent, "mono-vertex-daemon")
 	verifyPodsRunning(namespace, 1, daemonLabelSelector)
 
+	return nil
 }
 
 func VerifyMonoVertexStatus(namespace, monoVertexRolloutName string, f func(numaflowv1.MonoVertexSpec, kubernetes.GenericStatus) bool) string {
@@ -276,7 +286,8 @@ func CreateMonoVertexRollout(name, namespace string, spec numaflowv1.MonoVertexS
 
 	VerifyMonoVertexRolloutReady(name)
 
-	VerifyMonoVertexReady(namespace, name)
+	err = VerifyMonoVertexReady(namespace, name)
+	Expect(err).ShouldNot(HaveOccurred())
 
 }
 
@@ -360,7 +371,8 @@ func UpdateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, exp
 	if expectedFinalPhase == numaflowv1.MonoVertexPhasePaused {
 		VerifyMonoVertexPaused(Namespace, name)
 	} else {
-		VerifyMonoVertexReady(Namespace, name)
+		err = VerifyMonoVertexReady(Namespace, name)
+		Expect(err).ShouldNot(HaveOccurred())
 	}
 
 }

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -85,7 +85,7 @@ func VerifyMonoVertexReady(namespace, monoVertexRolloutName string) {
 	daemonLabelSelector := fmt.Sprintf("%s=%s,%s=%s", numaflowv1.KeyMonoVertexName, monoVertexName, numaflowv1.KeyComponent, "mono-vertex-daemon")
 
 	By("Verifying that the MonoVertex is ready")
-	verifyPodsRunning(namespace, GetSourceVertexScaleMin(), vertexLabelSelector)
+	verifyPodsRunning(namespace, SourceVertexScaleMin, vertexLabelSelector)
 	verifyPodsRunning(namespace, 1, daemonLabelSelector)
 
 }

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -104,11 +104,11 @@ func VerifyPipelineRunning(namespace string, pipelineRolloutName string, tmpNuma
 	spec, err := GetPipelineSpec(pipeline)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	// TODO: only keep verifyVerticesPodsRunning(namespace, pipeline.GetName(), spec.Vertices) once the related Numaflow bug is fixed
+	// TODO: only keep verifyVerticesPodsRunning(namespace, pipeline.GetName(), spec.Vertices, ComponentVertex) once the related Numaflow bug is fixed
 	if UpgradeStrategy == config.PPNDStrategyID && tmpNumaflowBugOverride != nil && len(tmpNumaflowBugOverride) == 1 && tmpNumaflowBugOverride[0] {
 		verifyPodsRunning(namespace, len(spec.Vertices), getVertexLabelSelector(pipeline.GetName()))
 	} else {
-		verifyVerticesPodsRunning(namespace, pipeline.GetName(), spec.Vertices)
+		verifyVerticesPodsRunning(namespace, pipeline.GetName(), spec.Vertices, ComponentVertex)
 	}
 
 	verifyPodsRunning(namespace, 1, getDaemonLabelSelector(pipeline.GetName()))
@@ -506,6 +506,8 @@ func UpdatePipelineRollout(name string, newSpec numaflowv1.PipelineSpec, expecte
 		VerifyPipelinePaused(Namespace, name)
 	case numaflowv1.PipelinePhaseFailed:
 		VerifyPipelineFailed(Namespace, name)
+	case numaflowv1.PipelinePhaseRunning:
+		VerifyPipelineRunning(Namespace, name)
 	}
 
 }

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -84,7 +84,8 @@ func VerifyPipelineRolloutHealthy(pipelineRolloutName string) {
 	}).Should(Equal(metav1.ConditionTrue))
 }
 
-func VerifyPipelineRunning(namespace string, pipelineRolloutName string) {
+// TODO: remove tmpNumaflowBugOverride once the Numaflow bug (scale config not applied to replicas field) is fixed
+func VerifyPipelineRunning(namespace string, pipelineRolloutName string, tmpNumaflowBugOverride ...bool) {
 	By("Verifying that the Pipeline is running")
 	VerifyPipelineStatusEventually(namespace, pipelineRolloutName,
 		func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus numaflowv1.PipelineStatus) bool {
@@ -103,11 +104,16 @@ func VerifyPipelineRunning(namespace string, pipelineRolloutName string) {
 	spec, err := GetPipelineSpec(pipeline)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	// The number of total pods is the scaled number of source vertex pods (SourceVertexScaleMin) + the output vertex pod.
-	// The '-1' removes 1 from the number of pods, since the source vertex pods are all included in the SourceVertexScaleMin
-	// and we should not count 1 additional from the number of total vertices.
-	numPods := len(spec.Vertices) + SourceVertexScaleMin - 1
-	verifyPodsRunning(namespace, numPods, getVertexLabelSelector(pipeline.GetName()))
+	// // TTODO
+	// // The number of total pods is the scaled number of source vertex pods (SourceVertexScaleMin) + the output vertex pod.
+	// // The '-1' removes 1 from the number of pods, since the source vertex pods are all included in the SourceVertexScaleMin
+	// // and we should not count 1 additional from the number of total vertices.
+	// numPods := len(spec.Vertices) + SourceVertexScaleMin - 1
+	if UpgradeStrategy == config.PPNDStrategyID && tmpNumaflowBugOverride != nil && len(tmpNumaflowBugOverride) == 1 && tmpNumaflowBugOverride[0] {
+		verifyPodsRunning(namespace, len(spec.Vertices), getVertexLabelSelector(pipeline.GetName()))
+	} else {
+		verifyVerticesPodsRunning(namespace, pipeline.GetName(), spec.Vertices)
+	}
 
 	verifyPodsRunning(namespace, 1, getDaemonLabelSelector(pipeline.GetName()))
 }

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -104,11 +104,7 @@ func VerifyPipelineRunning(namespace string, pipelineRolloutName string, tmpNuma
 	spec, err := GetPipelineSpec(pipeline)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	// // TTODO
-	// // The number of total pods is the scaled number of source vertex pods (SourceVertexScaleMin) + the output vertex pod.
-	// // The '-1' removes 1 from the number of pods, since the source vertex pods are all included in the SourceVertexScaleMin
-	// // and we should not count 1 additional from the number of total vertices.
-	// numPods := len(spec.Vertices) + SourceVertexScaleMin - 1
+	// TODO: only keep verifyVerticesPodsRunning(namespace, pipeline.GetName(), spec.Vertices) once the related Numaflow bug is fixed
 	if UpgradeStrategy == config.PPNDStrategyID && tmpNumaflowBugOverride != nil && len(tmpNumaflowBugOverride) == 1 && tmpNumaflowBugOverride[0] {
 		verifyPodsRunning(namespace, len(spec.Vertices), getVertexLabelSelector(pipeline.GetName()))
 	} else {

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -103,10 +103,10 @@ func VerifyPipelineRunning(namespace string, pipelineRolloutName string) {
 	spec, err := GetPipelineSpec(pipeline)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	// The number of total pods is the scaled number of source vertex pods (GetSourceVertexScaleMin()) + the output vertex pod.
-	// The '-1' removes 1 from the number of pods, since the source vertex pods are all included in the GetSourceVertexScaleMin()
+	// The number of total pods is the scaled number of source vertex pods (SourceVertexScaleMin) + the output vertex pod.
+	// The '-1' removes 1 from the number of pods, since the source vertex pods are all included in the SourceVertexScaleMin
 	// and we should not count 1 additional from the number of total vertices.
-	numPods := len(spec.Vertices) + GetSourceVertexScaleMin() - 1
+	numPods := len(spec.Vertices) + SourceVertexScaleMin - 1
 	verifyPodsRunning(namespace, numPods, getVertexLabelSelector(pipeline.GetName()))
 
 	verifyPodsRunning(namespace, 1, getDaemonLabelSelector(pipeline.GetName()))
@@ -122,7 +122,6 @@ func VerifyPipelinePaused(namespace string, pipelineRolloutName string) {
 	VerifyPipelineStatusEventually(namespace, pipelineRolloutName,
 		func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus numaflowv1.PipelineStatus) bool {
 			return retrievedPipelineStatus.Phase == numaflowv1.PipelinePhasePaused && retrievedPipelineStatus.DrainedOnPause
-
 		})
 	// this happens too fast to verify it:
 	//verifyPodsRunning(namespace, 0, getVertexLabelSelector(pipelineName))

--- a/tests/e2e/ppnd-e2e/ppnd_test.go
+++ b/tests/e2e/ppnd-e2e/ppnd_test.go
@@ -166,6 +166,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 			createSlowPipelineRollout()
 
 			By("Updating Pipeline Topology to cause a PPND change")
+			// This modifies the vertices resulting in having only in and out vertices (basically removes cat vertex)
 			slowPipelineSpec.Vertices[1] = slowPipelineSpec.Vertices[2]
 			slowPipelineSpec.Vertices = slowPipelineSpec.Vertices[0:2]
 			slowPipelineSpec.Edges = []numaflowv1.Edge{
@@ -370,6 +371,6 @@ func allowDataLoss() {
 	})
 
 	By("Verifying that Pipeline has stopped trying to pause")
-	VerifyPipelineRunning(Namespace, slowPipelineRolloutName)
+	VerifyPipelineRunning(Namespace, slowPipelineRolloutName, true)
 
 }

--- a/tests/e2e/ppnd-e2e/ppnd_test.go
+++ b/tests/e2e/ppnd-e2e/ppnd_test.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/utils/ptr"
 
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaplane/internal/common"
@@ -51,6 +50,7 @@ var (
 	pipelineSpecSourceDuration = metav1.Duration{
 		Duration: time.Second,
 	}
+	sourceVertexScaleMin = int32(5)
 	sourceVertexScaleMax = int32(9)
 	numVertices          = int32(1)
 	zeroReplicaSleepSec  = uint32(15) // if for some reason the Vertex has 0 replicas, this will cause Numaflow to scale it back up
@@ -65,7 +65,7 @@ var (
 						Duration: &pipelineSpecSourceDuration,
 					},
 				},
-				Scale: numaflowv1.Scale{Min: ptr.To(int32(SourceVertexScaleMin)), Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
+				Scale: numaflowv1.Scale{Min: &sourceVertexScaleMin, Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
 			},
 			{
 				Name: "out",
@@ -96,7 +96,7 @@ var (
 						Duration: &pipelineSpecSourceDuration,
 					},
 				},
-				Scale: numaflowv1.Scale{Min: ptr.To(int32(SourceVertexScaleMin)), Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
+				Scale: numaflowv1.Scale{Min: &sourceVertexScaleMin, Max: &sourceVertexScaleMax, ZeroReplicaSleepSeconds: &zeroReplicaSleepSec},
 			},
 			{
 				Name: "cat",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Fixed E2E tests by:
- removing time.sleep lines that are executed at the beginning of the test suite instead of after each `It` node
- adding more source vertex pods
- increasing `PauseGracePeriodSeconds` since pausing the pipeline was not draining it before the timeout would occur

### Verification

E2E tests successful execution.

### Backward incompatibilities

None.
