### PR TITLE
fix: get just the live rollout resource when reconciling to avoid issues caused by getting cached status

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -123,7 +123,7 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	ctx = logger.WithLogger(ctx, numaLogger)
 	r.customMetrics.ISBServiceROSyncs.WithLabelValues().Inc()
 
-	isbServiceRollout := &apiv1.ISBServiceRollout{}
+	/*isbServiceRollout := &apiv1.ISBServiceRollout{}
 	if err := r.client.Get(ctx, req.NamespacedName, isbServiceRollout); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
@@ -131,6 +131,10 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			r.ErrorHandler(isbServiceRollout, err, "GetISBServiceFailed", "Failed to get isb service rollout")
 			return ctrl.Result{}, err
 		}
+	}*/
+	isbServiceRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().ISBServiceRollouts(req.NamespacedName.Namespace).Get(ctx, req.NamespacedName.Name, metav1.GetOptions{})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error getting the live ISB Service rollout: %w", err)
 	}
 
 	// save off a copy of the original before we modify it
@@ -426,12 +430,12 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 
 		// Get the ISBServiceRollout live resource so we can grab the ProgressiveStatus from that for our own local isbServiceRollout
 		// (Note we don't copy the entire Status in case we've updated something locally)
-		liveISBServiceRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().ISBServiceRollouts(isbServiceRollout.Namespace).Get(ctx, isbServiceRollout.Name, metav1.GetOptions{})
+		/*liveISBServiceRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().ISBServiceRollouts(isbServiceRollout.Namespace).Get(ctx, isbServiceRollout.Name, metav1.GetOptions{})
 		if err != nil {
 			return 0, fmt.Errorf("error getting the live ISBServiceRollout for assessment processing: %w", err)
 		}
 
-		isbServiceRollout.Status.ProgressiveStatus = *liveISBServiceRollout.Status.ProgressiveStatus.DeepCopy()
+		isbServiceRollout.Status.ProgressiveStatus = *liveISBServiceRollout.Status.ProgressiveStatus.DeepCopy()*/
 
 		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, isbServiceRollout, existingISBServiceDef, isbServiceNeedsToUpdate, r, r.client)
 		if err != nil {

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -123,13 +123,17 @@ func (r *MonoVertexRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	ctx = logger.WithLogger(ctx, numaLogger)
 	r.customMetrics.MonoVertexROSyncs.WithLabelValues().Inc()
 
-	monoVertexRollout := &apiv1.MonoVertexRollout{}
+	/*monoVertexRollout := &apiv1.MonoVertexRollout{}
 	if err := r.client.Get(ctx, req.NamespacedName, monoVertexRollout); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		} else {
 			r.ErrorHandler(monoVertexRollout, err, "GetMonoVertexFailed", "Failed to get MonoVertexRollout")
 		}
+	}*/
+	monoVertexRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().MonoVertexRollouts(req.NamespacedName.Namespace).Get(ctx, req.NamespacedName.Name, metav1.GetOptions{})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error getting the live monoVertex rollout: %w", err)
 	}
 
 	// store copy of original rollout
@@ -336,12 +340,12 @@ func (r *MonoVertexRolloutReconciler) processExistingMonoVertex(ctx context.Cont
 
 		// Get the MonoVertexRollout live resource so we can grab the ProgressiveStatus from that for our own local monoVertexRollout
 		// (Note we don't copy the entire Status in case we've updated something locally)
-		liveMonoVertexRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().MonoVertexRollouts(monoVertexRollout.Namespace).Get(ctx, monoVertexRollout.Name, metav1.GetOptions{})
+		/*liveMonoVertexRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().MonoVertexRollouts(monoVertexRollout.Namespace).Get(ctx, monoVertexRollout.Name, metav1.GetOptions{})
 		if err != nil {
 			return 0, fmt.Errorf("error getting the live MonoVertexRollout for assessment processing: %w", err)
 		}
 
-		monoVertexRollout.Status.ProgressiveStatus = *liveMonoVertexRollout.Status.ProgressiveStatus.DeepCopy()
+		monoVertexRollout.Status.ProgressiveStatus = *liveMonoVertexRollout.Status.ProgressiveStatus.DeepCopy()*/
 
 		// don't risk out-of-date cache while performing Progressive strategy - get
 		// the most current version of the MonoVertex just in case

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -123,14 +123,8 @@ func (r *MonoVertexRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	ctx = logger.WithLogger(ctx, numaLogger)
 	r.customMetrics.MonoVertexROSyncs.WithLabelValues().Inc()
 
-	/*monoVertexRollout := &apiv1.MonoVertexRollout{}
-	if err := r.client.Get(ctx, req.NamespacedName, monoVertexRollout); err != nil {
-		if apierrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		} else {
-			r.ErrorHandler(monoVertexRollout, err, "GetMonoVertexFailed", "Failed to get MonoVertexRollout")
-		}
-	}*/
+	// Get the live MonoVertexRollout since we need latest Status for Progressive rollout case
+	// TODO: consider storing MonoVertexRollout Status in a local cache instead of this
 	monoVertexRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().MonoVertexRollouts(req.NamespacedName.Namespace).Get(ctx, req.NamespacedName.Name, metav1.GetOptions{})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error getting the live monoVertex rollout: %w", err)
@@ -337,15 +331,6 @@ func (r *MonoVertexRolloutReconciler) processExistingMonoVertex(ctx context.Cont
 	switch inProgressStrategy {
 	case apiv1.UpgradeStrategyProgressive:
 		numaLogger.Debug("processing MonoVertex with Progressive")
-
-		// Get the MonoVertexRollout live resource so we can grab the ProgressiveStatus from that for our own local monoVertexRollout
-		// (Note we don't copy the entire Status in case we've updated something locally)
-		/*liveMonoVertexRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().MonoVertexRollouts(monoVertexRollout.Namespace).Get(ctx, monoVertexRollout.Name, metav1.GetOptions{})
-		if err != nil {
-			return 0, fmt.Errorf("error getting the live MonoVertexRollout for assessment processing: %w", err)
-		}
-
-		monoVertexRollout.Status.ProgressiveStatus = *liveMonoVertexRollout.Status.ProgressiveStatus.DeepCopy()*/
 
 		// don't risk out-of-date cache while performing Progressive strategy - get
 		// the most current version of the MonoVertex just in case

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -167,7 +167,7 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 	r.customMetrics.PipelineROSyncs.WithLabelValues().Inc()
 
 	// Get PipelineRollout CR
-	pipelineRollout := &apiv1.PipelineRollout{}
+	/*pipelineRollout := &apiv1.PipelineRollout{}
 	if err := r.client.Get(ctx, namespacedName, pipelineRollout); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
@@ -175,6 +175,10 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 			r.ErrorHandler(pipelineRollout, err, "GetPipelineRolloutFailed", "Failed to get PipelineRollout")
 			return ctrl.Result{}, err
 		}
+	}*/
+	pipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(namespacedName.Namespace).Get(ctx, namespacedName.Name, metav1.GetOptions{})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error getting the live PipelineRollout: %w", err)
 	}
 
 	// save off a copy of the original before we modify it
@@ -348,11 +352,11 @@ func (r *PipelineRolloutReconciler) reconcile(
 				return 0, nil, err
 			}
 			// Get the PipelineRollout live resource
-			livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
+			/*livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
 			if err != nil {
 				return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
 			}
-			*pipelineRollout = *livePipelineRollout
+			*pipelineRollout = *livePipelineRollout*/
 			controllerutil.RemoveFinalizer(pipelineRollout, common.FinalizerName)
 		}
 		// generate the metrics for the Pipeline deletion.
@@ -592,12 +596,12 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 
 		// Get the PipelineRollout live resource so we can grab the ProgressiveStatus from that for our own local pipelineRollout
 		// (Note we don't copy the entire Status in case we've updated something locally)
-		livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
+		/*livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
 		if err != nil {
 			return 0, fmt.Errorf("error getting the live PipelineRollout for assessment processing: %w", err)
 		}
 
-		pipelineRollout.Status.ProgressiveStatus = *livePipelineRollout.Status.ProgressiveStatus.DeepCopy()
+		pipelineRollout.Status.ProgressiveStatus = *livePipelineRollout.Status.ProgressiveStatus.DeepCopy()*/
 
 		done, _, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, pipelineRollout, existingPipelineDef, pipelineNeedsToUpdate, r, r.client)
 		if err != nil {

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -172,8 +172,6 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error getting the live PipelineRollout: %w", err)
 	}
-	fmt.Printf("deletethis: PipelineRollout Get: resource version=%q\n", pipelineRollout.ResourceVersion)
-	fmt.Printf("deletethis: PipelineRollout Get: resource status: %+v\n", pipelineRollout.Status)
 
 	// save off a copy of the original before we modify it
 	pipelineRolloutOrig := pipelineRollout
@@ -342,7 +340,6 @@ func (r *PipelineRolloutReconciler) reconcile(
 		if controllerutil.ContainsFinalizer(pipelineRollout, common.FinalizerName) {
 			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
 			foreground := metav1.DeletePropagationForeground
-			fmt.Printf("deletethis: PipelineRollout before Delete: resource version=%q\n", pipelineRollout.ResourceVersion)
 			if err := r.client.Delete(ctx, pipelineRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return 0, nil, err
 			}
@@ -352,8 +349,6 @@ func (r *PipelineRolloutReconciler) reconcile(
 				return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
 			}
 			*pipelineRollout = *livePipelineRollout
-			fmt.Printf("deletethis: PipelineRollout Get after Delete: resource version=%q\n", pipelineRollout.ResourceVersion)
-			fmt.Printf("deletethis: PipelineRollout Get after Delete: resource status: %+v\n", pipelineRollout.Status)
 			controllerutil.RemoveFinalizer(pipelineRollout, common.FinalizerName)
 		}
 		// generate the metrics for the Pipeline deletion.
@@ -819,17 +814,7 @@ func getBasePipelineMetadata(pipelineRollout *apiv1.PipelineRollout) (apiv1.Meta
 
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatus(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) error {
 
-	fmt.Printf("deletethis: PipelineRollout pre-update: resource version=%q\n", pipelineRollout.ResourceVersion)
-	fmt.Printf("deletethis: PipelineRollout pre-update: resource status: %+v\n", pipelineRollout.Status)
-	err := r.client.Status().Update(ctx, pipelineRollout)
-	if err == nil {
-		fmt.Printf("deletethis: PipelineRollout post-update: resource version=%q\n", pipelineRollout.ResourceVersion)
-		fmt.Printf("deletethis: PipelineRollout post-update: resource status: %+v\n", pipelineRollout.Status)
-	} else {
-		fmt.Println("deletethis: PipelineRollout post-update: can't print resource version due to error")
-
-	}
-	return err
+	return r.client.Status().Update(ctx, pipelineRollout)
 }
 
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatusToFailed(ctx context.Context, pipelineRollout *apiv1.PipelineRollout, err error) error {

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -232,12 +232,12 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 	// generate the metrics for the Pipeline.
 	r.customMetrics.IncPipelineROsRunning(pipelineRollout.Name, pipelineRollout.Namespace)
 
+	r.recorder.Eventf(pipelineRollout, "Normal", "ReconcileSuccess", "Reconciliation successful")
+	numaLogger.Debug("reconciliation successful")
+
 	if requeueDelay > 0 {
 		return ctrl.Result{RequeueAfter: requeueDelay}, nil
 	}
-
-	r.recorder.Eventf(pipelineRollout, "Normal", "ReconcileSuccess", "Reconciliation successful")
-	numaLogger.Debug("reconciliation successful")
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -352,11 +352,11 @@ func (r *PipelineRolloutReconciler) reconcile(
 				return 0, nil, err
 			}
 			// Get the PipelineRollout live resource
-			/*livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
+			livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
 			if err != nil {
 				return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
 			}
-			*pipelineRollout = *livePipelineRollout*/
+			*pipelineRollout = *livePipelineRollout
 			controllerutil.RemoveFinalizer(pipelineRollout, common.FinalizerName)
 		}
 		// generate the metrics for the Pipeline deletion.

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -172,6 +172,8 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error getting the live PipelineRollout: %w", err)
 	}
+	fmt.Printf("deletethis: PipelineRollout Get: resource version=%q\n", pipelineRollout.ResourceVersion)
+	fmt.Printf("deletethis: PipelineRollout Get: resource status: %+v\n", pipelineRollout.Status)
 
 	// save off a copy of the original before we modify it
 	pipelineRolloutOrig := pipelineRollout
@@ -340,6 +342,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 		if controllerutil.ContainsFinalizer(pipelineRollout, common.FinalizerName) {
 			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
 			foreground := metav1.DeletePropagationForeground
+			fmt.Printf("deletethis: PipelineRollout before Delete: resource version=%q\n", pipelineRollout.ResourceVersion)
 			if err := r.client.Delete(ctx, pipelineRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return 0, nil, err
 			}
@@ -349,6 +352,8 @@ func (r *PipelineRolloutReconciler) reconcile(
 				return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
 			}
 			*pipelineRollout = *livePipelineRollout
+			fmt.Printf("deletethis: PipelineRollout Get after Delete: resource version=%q\n", pipelineRollout.ResourceVersion)
+			fmt.Printf("deletethis: PipelineRollout Get after Delete: resource status: %+v\n", pipelineRollout.Status)
 			controllerutil.RemoveFinalizer(pipelineRollout, common.FinalizerName)
 		}
 		// generate the metrics for the Pipeline deletion.
@@ -813,7 +818,18 @@ func getBasePipelineMetadata(pipelineRollout *apiv1.PipelineRollout) (apiv1.Meta
 }
 
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatus(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) error {
-	return r.client.Status().Update(ctx, pipelineRollout)
+
+	fmt.Printf("deletethis: PipelineRollout pre-update: resource version=%q\n", pipelineRollout.ResourceVersion)
+	fmt.Printf("deletethis: PipelineRollout pre-update: resource status: %+v\n", pipelineRollout.Status)
+	err := r.client.Status().Update(ctx, pipelineRollout)
+	if err == nil {
+		fmt.Printf("deletethis: PipelineRollout post-update: resource version=%q\n", pipelineRollout.ResourceVersion)
+		fmt.Printf("deletethis: PipelineRollout post-update: resource status: %+v\n", pipelineRollout.Status)
+	} else {
+		fmt.Println("deletethis: PipelineRollout post-update: can't print resource version due to error")
+
+	}
+	return err
 }
 
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatusToFailed(ctx context.Context, pipelineRollout *apiv1.PipelineRollout, err error) error {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Mostly Fixes #602

### Modifications

Eventually, I'd like to have a local cache to store the Rollout Status, since we are the only ones writing to it. 

For now, however, I have updated the code to get the live Rollout every time to prevent cases like that identified by #602. 

I ended up doing this for the PipelineRollout, ISBServiceRollout, and MonoVertexRollout, since they are involved in the Progressive rollout case, in which we need to make sure we have the latest and greatest `Status` since we use that information that we previously wrote to inform what we do next.

Thus, I didn't end up changing NumaflowControllerRollout and NumaflowController because I don't believe we do anything like that for those. 

### Verification

I mostly no longer see the resource version conflict errors for these Rollouts in the CI logs. (I occasionally see one, but I think it's due to the test updating the Rollout in the middle of a reconciliation. That can still occur.)

### Backward incompatibilities

N/A
