### PR TITLE
fix: retry if there's a status update error (to avoid resource version conflict errors)

### DIFF
--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -826,16 +826,11 @@ func getBasePipelineMetadata(pipelineRollout *apiv1.PipelineRollout) (apiv1.Meta
 }
 
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatus(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) error {
+	numaLogger := logger.FromContext(ctx)
+
 	err := r.client.Status().Update(ctx, pipelineRollout)
 
-	// temporary for debugging:
-	if err != nil && !apierrors.IsConflict(err) {
-		fmt.Printf("deletethis: error updating status is not of conflict type: %v\n", err)
-	}
-
 	if err != nil && apierrors.IsConflict(err) {
-		fmt.Printf("deletethis: error updating status is of conflict type: %v\n", err)
-
 		// there was a Resource Version conflict error (i.e. an update was made to PipelineRollout after the version we retrieved), so retry using the latest Resource Version: get the PipelineRollout live resource
 		// and attach our Status to it
 		livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
@@ -843,14 +838,12 @@ func (r *PipelineRolloutReconciler) updatePipelineRolloutStatus(ctx context.Cont
 			return fmt.Errorf("error getting the live PipelineRollout after attempting to update the PipelineRollout Status: %w", err)
 		}
 		status := pipelineRollout.Status // save off the Status
-		originalResourceVersion := pipelineRollout.ResourceVersion
 		*pipelineRollout = *livePipelineRollout
-		newResourceVersion := pipelineRollout.ResourceVersion
-		fmt.Printf("deletethis: original resource version=%q, new resource version=%q\n", originalResourceVersion, newResourceVersion)
+		numaLogger.Debug("resource version conflict error after getting latest PipelineRollout Status: try again with latest resource version")
 		pipelineRollout.Status = status
 		err = r.client.Status().Update(ctx, pipelineRollout)
 		if err != nil {
-			return fmt.Errorf("consecutive errors attemptingt to update PipelineRolloutStatus: %w", err)
+			return fmt.Errorf("consecutive errors attempting to update PipelineRolloutStatus: %w", err)
 		}
 		return nil
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
