### PR TITLE
feat: retry status update after failure for PipelineRollout, ISBServiceRollout, MonoVertexRollout

### DIFF
--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -813,8 +813,30 @@ func getBasePipelineMetadata(pipelineRollout *apiv1.PipelineRollout) (apiv1.Meta
 }
 
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatus(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) error {
+	numaLogger := logger.FromContext(ctx)
 
-	return r.client.Status().Update(ctx, pipelineRollout)
+	err := r.client.Status().Update(ctx, pipelineRollout)
+
+	if err != nil && apierrors.IsConflict(err) {
+		// there was a Resource Version conflict error (i.e. an update was made to PipelineRollout after the version we retrieved), so retry using the latest Resource Version: get the PipelineRollout live resource
+		// and attach our Status to it.
+		// The reason this is okay is because we are the only ones who write the Status, and because we retrieved the live version of this ISBServiceRollout at the beginning of the reconciliation
+		// Therefore, we know that the Status is totally current.
+		livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("error getting the live PipelineRollout after attempting to update the PipelineRollout Status: %w", err)
+		}
+		status := pipelineRollout.Status // save off the Status
+		*pipelineRollout = *livePipelineRollout
+		numaLogger.Debug("resource version conflict error after getting latest PipelineRollout Status: try again with latest resource version")
+		pipelineRollout.Status = status
+		err = r.client.Status().Update(ctx, pipelineRollout)
+		if err != nil {
+			return fmt.Errorf("consecutive errors attempting to update PipelineRolloutStatus: %w", err)
+		}
+		return nil
+	}
+	return err
 }
 
 func (r *PipelineRolloutReconciler) updatePipelineRolloutStatusToFailed(ctx context.Context, pipelineRollout *apiv1.PipelineRollout, err error) error {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #602

### Modifications

As part of PR #606, I made it so that we get the live version of the PipelineRollout, MonoVertexRollout, and ISBServiceRollout. This was to make it so we have the latest and greatest Status for these, since we need to use that Status to make decisions as part of "Progressive" logic. This makes it so that we don't have resource version conflict errors that are due to the fact that we retrieved a cached version of the Rollout which had an older resource version in it.

The one thing it did not address was the possibility that somebody may update the other parts of the Rollout (spec, etc) in between when we get the live rollout and go to update the Status. So, I am taking care of that a different way now. If there's a conflict error when writing the Status, I'm getting the live one (so as to get the latest ResourceVersion) and incorporating our latest and greatest `Status` in it, and writing that.


### Verification

I checked all Numaplane logs from all CI tests and searched for "Operation cannot be fulfilled on pipelinerollouts/isbservicerollouts/monovertexrollouts" - I didn't see any.

### Backward incompatibilities

N/A
