### PR TITLE
chore: update Numaflow version to v1.4.3-rc in PPND E2E tests

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -67,6 +67,9 @@ var (
 )
 
 const (
+	InitialNumaflowControllerVersion = "1.4.3-rc3"
+	UpdatedNumaflowControllerVersion = "1.4.3-rc33" // note this one is really a clone of "1.4.3-rc3"
+
 	Namespace = "numaplane-system"
 
 	ControllerOutputPath = "../output/controllers"

--- a/tests/e2e/functional-e2e/functional_test.go
+++ b/tests/e2e/functional-e2e/functional_test.go
@@ -37,8 +37,6 @@ const (
 	isbServiceRolloutName            = "test-isbservice-rollout"
 	pipelineRolloutName              = "test-pipeline-rollout"
 	monoVertexRolloutName            = "test-monovertex-rollout"
-	initialNumaflowControllerVersion = "1.4.3-rc3"
-	updatedNumaflowControllerVersion = "1.4.3-rc33" // note this one is really a clone of "1.4.3-rc3"
 	invalidNumaflowControllerVersion = "99.99.99"
 	initialJetstreamVersion          = "2.10.17"
 	updatedJetstreamVersion          = "2.10.11"
@@ -211,7 +209,7 @@ func TestFunctionalE2E(t *testing.T) {
 var _ = Describe("Functional e2e:", Serial, func() {
 
 	It("Should create the NumaflowControllerRollout if it doesn't exist", func() {
-		CreateNumaflowControllerRollout(initialNumaflowControllerVersion)
+		CreateNumaflowControllerRollout(InitialNumaflowControllerVersion)
 	})
 
 	It("Should create the ISBServiceRollout if it doesn't exist", func() {
@@ -322,15 +320,15 @@ var _ = Describe("Functional e2e:", Serial, func() {
 	})
 
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is updated", func() {
-		UpdateNumaflowControllerRollout(initialNumaflowControllerVersion, updatedNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, true)
+		UpdateNumaflowControllerRollout(InitialNumaflowControllerVersion, UpdatedNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, true)
 	})
 
 	It("Should fail if the NumaflowControllerRollout is updated with a bad version", func() {
-		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, invalidNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, false)
+		UpdateNumaflowControllerRollout(UpdatedNumaflowControllerVersion, invalidNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, false)
 	})
 
 	It("Should update the child NumaflowController if the NumaflowControllerRollout is restored back to previous version", func() {
-		UpdateNumaflowControllerRollout(invalidNumaflowControllerVersion, updatedNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, true)
+		UpdateNumaflowControllerRollout(invalidNumaflowControllerVersion, UpdatedNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: pipelineRolloutName}}, true)
 	})
 
 	It("Should update the child ISBService if the ISBServiceRollout is updated", func() {

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -84,8 +84,7 @@ func VerifyPipelineRolloutHealthy(pipelineRolloutName string) {
 	}).Should(Equal(metav1.ConditionTrue))
 }
 
-// TODO: remove tmpNumaflowBugOverride once the Numaflow bug (scale config not applied to replicas field) is fixed
-func VerifyPipelineRunning(namespace string, pipelineRolloutName string, tmpNumaflowBugOverride ...bool) {
+func VerifyPipelineRunning(namespace string, pipelineRolloutName string) {
 	By("Verifying that the Pipeline is running")
 	VerifyPipelineStatusEventually(namespace, pipelineRolloutName,
 		func(retrievedPipelineSpec numaflowv1.PipelineSpec, retrievedPipelineStatus numaflowv1.PipelineStatus) bool {
@@ -104,13 +103,7 @@ func VerifyPipelineRunning(namespace string, pipelineRolloutName string, tmpNuma
 	spec, err := GetPipelineSpec(pipeline)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	// TODO: only keep verifyVerticesPodsRunning(namespace, pipeline.GetName(), spec.Vertices, ComponentVertex) once the related Numaflow bug is fixed
-	if UpgradeStrategy == config.PPNDStrategyID && tmpNumaflowBugOverride != nil && len(tmpNumaflowBugOverride) == 1 && tmpNumaflowBugOverride[0] {
-		verifyPodsRunning(namespace, len(spec.Vertices), getVertexLabelSelector(pipeline.GetName()))
-	} else {
-		verifyVerticesPodsRunning(namespace, pipeline.GetName(), spec.Vertices, ComponentVertex)
-	}
-
+	verifyVerticesPodsRunning(namespace, pipeline.GetName(), spec.Vertices, ComponentVertex)
 	verifyPodsRunning(namespace, 1, getDaemonLabelSelector(pipeline.GetName()))
 }
 

--- a/tests/e2e/ppnd-e2e/ppnd_test.go
+++ b/tests/e2e/ppnd-e2e/ppnd_test.go
@@ -369,6 +369,6 @@ func allowDataLoss() {
 	})
 
 	By("Verifying that Pipeline has stopped trying to pause")
-	VerifyPipelineRunning(Namespace, slowPipelineRolloutName, true)
+	VerifyPipelineRunning(Namespace, slowPipelineRolloutName)
 
 }

--- a/tests/e2e/ppnd-e2e/ppnd_test.go
+++ b/tests/e2e/ppnd-e2e/ppnd_test.go
@@ -36,13 +36,11 @@ import (
 )
 
 const (
-	isbServiceRolloutName            = "test-isbservice-rollout"
-	slowPipelineRolloutName          = "slow-pipeline-rollout"
-	failedPipelineRolloutName        = "failed-pipeline-rollout"
-	initialNumaflowControllerVersion = "1.4.1"
-	updatedNumaflowControllerVersion = "1.4.2"
-	initialJetstreamVersion          = "2.10.17"
-	updatedJetstreamVersion          = "2.10.11"
+	isbServiceRolloutName     = "test-isbservice-rollout"
+	slowPipelineRolloutName   = "slow-pipeline-rollout"
+	failedPipelineRolloutName = "failed-pipeline-rollout"
+	initialJetstreamVersion   = "2.10.17"
+	updatedJetstreamVersion   = "2.10.11"
 )
 
 var (
@@ -156,7 +154,7 @@ func TestPauseAndDrainE2E(t *testing.T) {
 var _ = Describe("Pause and drain e2e", Serial, func() {
 
 	It("Should create initial rollout objects", func() {
-		CreateNumaflowControllerRollout(initialNumaflowControllerVersion)
+		CreateNumaflowControllerRollout(InitialNumaflowControllerVersion)
 		CreateISBServiceRollout(isbServiceRolloutName, isbServiceSpec)
 	})
 
@@ -223,7 +221,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 
 			By("Updating Numaflow controller to cause a PPND change")
 			updatedNumaflowControllerROSpec := apiv1.NumaflowControllerRolloutSpec{
-				Controller: apiv1.Controller{Version: updatedNumaflowControllerVersion},
+				Controller: apiv1.Controller{Version: UpdatedNumaflowControllerVersion},
 			}
 			UpdateNumaflowControllerRolloutInK8S(func(rollout apiv1.NumaflowControllerRollout) (apiv1.NumaflowControllerRollout, error) {
 				rollout.Spec = updatedNumaflowControllerROSpec
@@ -237,7 +235,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 			// confirm update
 			VerifyNumaflowControllerDeployment(Namespace, func(d appsv1.Deployment) bool {
 				colon := strings.Index(d.Spec.Template.Spec.Containers[0].Image, ":")
-				return colon != -1 && d.Spec.Template.Spec.Containers[0].Image[colon+1:] == "v"+updatedNumaflowControllerVersion
+				return colon != -1 && d.Spec.Template.Spec.Containers[0].Image[colon+1:] == "v"+UpdatedNumaflowControllerVersion
 			})
 
 		}
@@ -305,7 +303,7 @@ var _ = Describe("Pause and drain e2e", Serial, func() {
 		time.Sleep(5 * time.Second)
 
 		By("Updating Numaflow controller to cause a PPND change")
-		UpdateNumaflowControllerRollout(updatedNumaflowControllerVersion, initialNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: failedPipelineRolloutName, PipelineIsFailed: true}}, true)
+		UpdateNumaflowControllerRollout(UpdatedNumaflowControllerVersion, InitialNumaflowControllerVersion, []PipelineRolloutInfo{{PipelineRolloutName: failedPipelineRolloutName, PipelineIsFailed: true}}, true)
 
 		time.Sleep(5 * time.Second)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Updated Numaflow version to v1.4.3-rc for PPND E2E tests and made a common variable to be used for both PPND and functional tests.
