### PR TITLE
fix: elongate test timeout time

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -42,10 +42,13 @@ import (
 )
 
 var (
-	dynamicClient       dynamic.DynamicClient
-	testEnv             *envtest.Environment
-	ctx                 context.Context
-	TestTimeout         = 4 * time.Minute // Note: this timeout needs to be large enough to allow for delayed child resource healthiness assessment (current delay is 2 minutes with a 1 minute reassess window)
+	dynamicClient dynamic.DynamicClient
+	testEnv       *envtest.Environment
+	ctx           context.Context
+	// Note: this timeout needs to be large enough for:
+	//  - progressive child resource healthiness assessment (2 minutes until assessment start time + 1 minute until end time)
+	//  - time for isbsvc to be created plus pipeline to become healthy afterward
+	TestTimeout         = 6 * time.Minute
 	TestPollingInterval = 10 * time.Millisecond
 
 	pipelineRolloutClient           planepkg.PipelineRolloutInterface


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

I saw a ppnd-e2e [test](https://github.com/numaproj/numaplane/actions/runs/13599582687/job/38023310598) that failed due to a pipeline never reconciled as "Running" after isbsvc was recreated. It had 4 minutes. I ran this change to make it 6 minutes through the CI a few times and it passed each time, so I'm hoping this takes care of it. 

The issue seemed to be that after the isbsvc gets updated to a new version, the pipeline stays in an unhealthy state for awhile saying "isbsvc is unhealthy" - for some reason, that process is a little slow. I'm not sure if it has anything to do with the fact that our source vertex now has 5 pods when it used to have 1 or not.

### Verification

Ran through CI 3 times and it passed

### Backward incompatibilities

N/A
