### PR TITLE
fix: Update deleting cycle for rollouts

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -200,7 +200,7 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 			if err := r.client.Delete(ctx, isbServiceRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
 				return ctrl.Result{}, err
 			}
-			// Get the nfcRollout live resource
+			// Get the ISBServiceRollout live resource
 			liveISBServiceRollout, err := getLiveISBServiceRollout(ctx, isbServiceRollout.Name, isbServiceRollout.Namespace)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("error getting the live ISB Service rollout: %w", err)

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -149,18 +149,14 @@ func (r *MonoVertexRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// update spec if needed
 	if r.needsUpdate(monoVertexRolloutOrig, monoVertexRollout) {
-		monoVertexRolloutStatus := monoVertexRollout.Status
-		if err := r.client.Update(ctx, monoVertexRollout); err != nil {
-			r.ErrorHandler(monoVertexRollout, err, "UpdateFailed", "Failed to update MonoVertexRollout")
-			statusUpdateErr := r.updateMonoVertexRolloutStatusToFailed(ctx, monoVertexRollout, err)
-			if statusUpdateErr != nil {
+		if err := r.client.Patch(ctx, monoVertexRollout, client.MergeFrom(monoVertexRolloutOrig)); err != nil {
+			r.ErrorHandler(monoVertexRollout, err, "UpdateFailed", "Failed to patch MonoVertexRollout")
+			if statusUpdateErr := r.updateMonoVertexRolloutStatusToFailed(ctx, monoVertexRollout, err); statusUpdateErr != nil {
 				r.ErrorHandler(monoVertexRollout, statusUpdateErr, "UpdateStatusFailed", "Failed to update MonoVertexRollout status")
 				return ctrl.Result{}, statusUpdateErr
 			}
 			return ctrl.Result{}, err
 		}
-		// restore original status which is lost during last call to Update()
-		monoVertexRollout.Status = monoVertexRolloutStatus
 	}
 
 	if monoVertexRollout.DeletionTimestamp.IsZero() {

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -172,18 +172,14 @@ func (r *NumaflowControllerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Update the Spec if needed
 	if r.needsUpdate(numaflowControllerOrig, numaflowController) {
-		numaflowControllerStatus := numaflowController.Status
-		if err := r.client.Update(ctx, numaflowController); err != nil {
+		if err := r.client.Patch(ctx, numaflowController, client.MergeFrom(numaflowControllerOrig)); err != nil {
 			r.ErrorHandler(numaflowController, err, "UpdateFailed", "Failed to update NumaflowController")
-			statusUpdateErr := r.updateNumaflowControllerStatusToFailed(ctx, numaflowController, err)
-			if statusUpdateErr != nil {
+			if statusUpdateErr := r.updateNumaflowControllerStatusToFailed(ctx, numaflowController, err); statusUpdateErr != nil {
 				r.ErrorHandler(numaflowController, statusUpdateErr, "UpdateStatusFailed", "Failed to update status of NumaflowController")
 				return ctrl.Result{}, statusUpdateErr
 			}
 			return ctrl.Result{}, err
 		}
-		// restore the original status, which would've been wiped in the previous call to Update()
-		numaflowController.Status = numaflowControllerStatus
 	}
 
 	// Update the Status subresource

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -146,18 +146,14 @@ func (r *NumaflowControllerRolloutReconciler) Reconcile(ctx context.Context, req
 
 	// Update the Spec if needed
 	if r.needsUpdate(numaflowControllerRolloutOrig, numaflowControllerRollout) {
-		numaflowControllerRolloutStatus := numaflowControllerRollout.Status
-		if err := r.client.Update(ctx, numaflowControllerRollout); err != nil {
+		if err := r.client.Patch(ctx, numaflowControllerRollout, client.MergeFrom(numaflowControllerRolloutOrig)); err != nil {
 			r.ErrorHandler(numaflowControllerRollout, err, "UpdateFailed", "Failed to update NumaflowControllerRollout")
-			statusUpdateErr := r.updateNumaflowControllerRolloutStatusToFailed(ctx, numaflowControllerRollout, err)
-			if statusUpdateErr != nil {
+			if statusUpdateErr := r.updateNumaflowControllerRolloutStatusToFailed(ctx, numaflowControllerRollout, err); statusUpdateErr != nil {
 				r.ErrorHandler(numaflowControllerRollout, statusUpdateErr, "UpdateStatusFailed", "Failed to update status of NumaflowControllerRollout")
 				return ctrl.Result{}, statusUpdateErr
 			}
 			return ctrl.Result{}, err
 		}
-		// restore the original status, which would've been wiped in the previous call to Update()
-		numaflowControllerRollout.Status = numaflowControllerRolloutStatus
 	}
 
 	// Update the Status subresource

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -334,18 +334,18 @@ func (r *PipelineRolloutReconciler) reconcile(
 	// (OwnerReference will delete the underlying Pipeline through Cascading deletion)
 	if !pipelineRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting PipelineRollout")
-		// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
-		foreground := metav1.DeletePropagationForeground
-		if err := r.client.Delete(ctx, pipelineRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
-			return 0, nil, err
-		}
-		// Get the PipelineRollout live resource
-		livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
-		if err != nil {
-			return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
-		}
-		*pipelineRollout = *livePipelineRollout
 		if controllerutil.ContainsFinalizer(pipelineRollout, common.FinalizerName) {
+			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
+			foreground := metav1.DeletePropagationForeground
+			if err := r.client.Delete(ctx, pipelineRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
+				return 0, nil, err
+			}
+			// Get the PipelineRollout live resource
+			livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
+			if err != nil {
+				return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
+			}
+			*pipelineRollout = *livePipelineRollout
 			controllerutil.RemoveFinalizer(pipelineRollout, common.FinalizerName)
 		}
 		// generate the metrics for the Pipeline deletion.

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -168,7 +168,7 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 
 	// Get the live PipelineRollout since we need latest Status for Progressive rollout case
 	// TODO: consider storing PipelineRollout Status in a local cache instead of this
-	pipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(namespacedName.Namespace).Get(ctx, namespacedName.Name, metav1.GetOptions{})
+	pipelineRollout, err := getLivePipelineRollout(ctx, namespacedName.Name, namespacedName.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error getting the live PipelineRollout: %w", err)
 	}
@@ -204,7 +204,7 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 		return ctrl.Result{}, err
 	}
 
-	// Update the Spec if needed
+	// Update the resource definition (everything except the Status subresource)
 	if r.needsUpdate(pipelineRolloutOrig, pipelineRollout) {
 		if err := r.client.Patch(ctx, pipelineRollout, client.MergeFrom(pipelineRolloutOrig)); err != nil {
 			r.ErrorHandler(pipelineRollout, err, "PatchFailed", "Failed to patch PipelineRollout")
@@ -341,7 +341,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 				return 0, nil, err
 			}
 			// Get the PipelineRollout live resource
-			livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
+			livePipelineRollout, err := getLivePipelineRollout(ctx, pipelineRollout.Name, pipelineRollout.Namespace)
 			if err != nil {
 				return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
 			}
@@ -1119,4 +1119,14 @@ func (r *PipelineRolloutReconciler) garbageCollectChildren(
 	}
 
 	return ctlrcommon.GarbageCollectChildren(ctx, pipelineRollout, r, r.client)
+}
+
+func getLivePipelineRollout(ctx context.Context, name, namespace string) (*apiv1.PipelineRollout, error) {
+	PipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	PipelineRollout.SetGroupVersionKind(apiv1.PipelineRolloutGroupVersionKind)
+
+	return PipelineRollout, err
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/607

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

- Fixed deletion cycle for rollout
   - Updated method `Update()` with `Patch()` for updating the resources
   - Fix Get Live rollouts resouce


### Verification
- Ran E2E Tests locally in kind cluster

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
