### PR TITLE
fix: remove assessmentEndTime max date

### DIFF
--- a/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/isbservicerollout_types.go
@@ -149,11 +149,10 @@ func (isbServiceRollout *ISBServiceRollout) GetPromotedChildStatus() *PromotedCh
 // ResetUpgradingChildStatus is a function of the progressiveRolloutObject
 // note this resets the entire Upgrading status struct which encapsulates the UpgradingChildStatus struct
 func (isbServiceRollout *ISBServiceRollout) ResetUpgradingChildStatus(upgradingISBService *unstructured.Unstructured) error {
-	assessUntil := metav1.NewTime(assessmentEndTimeInitValue)
 	isbServiceRollout.Status.ProgressiveStatus.UpgradingISBServiceStatus = &UpgradingISBServiceStatus{
 		UpgradingChildStatus: UpgradingChildStatus{
 			Name:              upgradingISBService.GetName(),
-			AssessmentEndTime: &assessUntil,
+			AssessmentEndTime: nil,
 			AssessmentResult:  AssessmentResultUnknown,
 		},
 	}

--- a/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
@@ -142,11 +142,10 @@ func (monoVertexRollout *MonoVertexRollout) GetUpgradingChildStatus() *Upgrading
 // ResetUpgradingChildStatus is a function of the progressiveRolloutObject
 // note this resets the entire Upgrading status struct which encapsulates the UpgradingChildStatus struct
 func (monoVertexRollout *MonoVertexRollout) ResetUpgradingChildStatus(upgradingMonoVertex *unstructured.Unstructured) error {
-	assessUntil := metav1.NewTime(assessmentEndTimeInitValue)
 	monoVertexRollout.Status.ProgressiveStatus.UpgradingMonoVertexStatus = &UpgradingMonoVertexStatus{
 		UpgradingChildStatus: UpgradingChildStatus{
 			Name:              upgradingMonoVertex.GetName(),
-			AssessmentEndTime: &assessUntil,
+			AssessmentEndTime: nil,
 			AssessmentResult:  AssessmentResultUnknown,
 		},
 	}

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -163,12 +163,11 @@ func (pipelineRollout *PipelineRollout) ResetUpgradingChildStatus(upgradingPipel
 	if !found {
 		isbsvcName = "default" // if not set, the default value is "default"
 	}
-	assessUntil := metav1.NewTime(assessmentEndTimeInitValue)
 	pipelineRollout.Status.ProgressiveStatus.UpgradingPipelineStatus = &UpgradingPipelineStatus{
 		InterStepBufferServiceName: isbsvcName,
 		UpgradingChildStatus: UpgradingChildStatus{
 			Name:              upgradingPipeline.GetName(),
-			AssessmentEndTime: &assessUntil,
+			AssessmentEndTime: nil,
 			AssessmentResult:  AssessmentResultUnknown,
 		},
 	}

--- a/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
@@ -75,12 +75,9 @@ type PromotedPipelineTypeStatus struct {
 	ScaleValuesRestoredToOriginal bool `json:"scaleValuesRestoredToOriginal,omitempty"`
 }
 
-// assessmentEndTimeInitValue is an arbitrary value in the far future to use as a maximum value for AssessmentEndTime
-var assessmentEndTimeInitValue = time.Date(2222, 2, 2, 2, 2, 2, 0, time.UTC)
-
-// IsAssessmentEndTimeSet checks if the AssessmentEndTime field is not nil nor set to a maximum arbitrary value in the far future.
+// IsAssessmentEndTimeSet checks if the AssessmentEndTime field is not nil.
 func (ucs *UpgradingChildStatus) IsAssessmentEndTimeSet() bool {
-	return ucs != nil && ucs.AssessmentEndTime != nil && !ucs.AssessmentEndTime.Time.Equal(assessmentEndTimeInitValue)
+	return ucs != nil && ucs.AssessmentEndTime != nil
 }
 
 // CanAssess determines if the UpgradingChildStatus instance is eligible for assessment.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #615 

### Modifications

Removed arbitrary max date for the assessmentEndTime field.

### Verification

Verified manually that the assessmentEndTime no longer shows in the status if unset and that progressive upgrade still works as expected.

### Backward incompatibilities

None.
