### PR TITLE
chore: watch numaflowcontroller kind during e2e

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -392,6 +392,8 @@ func writeToFile(resource Output) error {
 		fileName = filepath.Join(ResourceChangesMonoVertexOutputPath, "monovertex.yaml")
 	case "MonoVertexRollout":
 		fileName = filepath.Join(ResourceChangesMonoVertexOutputPath, "monovertex_rollout.yaml")
+	case "NumaflowController":
+		fileName = filepath.Join(ResourceChangesNumaflowControllerOutputPath, "numaflowcontroller.yaml")
 	case "NumaflowControllerRollout":
 		fileName = filepath.Join(ResourceChangesNumaflowControllerOutputPath, "numaflowcontroller_rollout.yaml")
 	case "Pod":

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -54,6 +54,7 @@ var (
 	pipelineRolloutClient           planepkg.PipelineRolloutInterface
 	isbServiceRolloutClient         planepkg.ISBServiceRolloutInterface
 	numaflowControllerRolloutClient planepkg.NumaflowControllerRolloutInterface
+	numaflowControllerClient        planepkg.NumaflowControllerInterface
 	monoVertexRolloutClient         planepkg.MonoVertexRolloutInterface
 	kubeClient                      clientgo.Interface
 
@@ -540,6 +541,10 @@ func BeforeSuiteSetup() {
 	Expect(numaflowControllerRolloutClient).NotTo(BeNil())
 	Expect(err).NotTo(HaveOccurred())
 
+	numaflowControllerClient = planeversiond.NewForConfigOrDie(cfg).NumaplaneV1alpha1().NumaflowControllers(Namespace)
+	Expect(numaflowControllerClient).NotTo(BeNil())
+	Expect(err).NotTo(HaveOccurred())
+
 	kubeClient, err = clientgo.NewForConfig(cfg)
 	Expect(kubeClient).NotTo(BeNil())
 	Expect(err).NotTo(HaveOccurred())
@@ -553,8 +558,7 @@ func BeforeSuiteSetup() {
 		wg.Add(1)
 		go watchPods()
 
-		wg.Add(1)
-		go watchNumaflowControllerRollout()
+		startNumaflowControllerRolloutWatches()
 
 		startPipelineRolloutWatches()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

I noticed we weren't watching the "kind" `NumaflowController` so I added it.


### Verification

I now see it being printed as a file `numaflowcontroller.yaml` in the CI in the same directory as `numaflowcontroller_rollout.yaml`

### Backward incompatibilities

N/A