### PR TITLE
feat: move ForcePromote label to Rollout spec

### DIFF
--- a/config/crd/bases/numaplane.numaproj.io_isbservicerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_isbservicerollouts.yaml
@@ -77,6 +77,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
+                      forcePromote:
+                        description: if ForcePromote is set, assessment will be skipped
+                          and Progressive upgrade will succeed
+                        type: boolean
                     type: object
                 type: object
             required:

--- a/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
@@ -78,6 +78,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
+                      forcePromote:
+                        description: if ForcePromote is set, assessment will be skipped
+                          and Progressive upgrade will succeed
+                        type: boolean
                     type: object
                 type: object
             required:

--- a/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
@@ -83,6 +83,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
+                      forcePromote:
+                        description: if ForcePromote is set, assessment will be skipped
+                          and Progressive upgrade will succeed
+                        type: boolean
                     type: object
                 type: object
             required:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -128,6 +128,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
+                      forcePromote:
+                        description: if ForcePromote is set, assessment will be skipped
+                          and Progressive upgrade will succeed
+                        type: boolean
                     type: object
                 type: object
             required:
@@ -388,6 +392,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
+                      forcePromote:
+                        description: if ForcePromote is set, assessment will be skipped
+                          and Progressive upgrade will succeed
+                        type: boolean
                     type: object
                 type: object
             required:
@@ -1102,6 +1110,10 @@ spec:
                           optional string: comma-separated list consisting of:
                           assessmentDelay, assessmentPeriod, assessmentInterval
                         type: string
+                      forcePromote:
+                        description: if ForcePromote is set, assessment will be skipped
+                          and Progressive upgrade will succeed
+                        type: boolean
                     type: object
                 type: object
             required:

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -91,9 +91,6 @@ const (
 	// LabelKeyUpgradeStateReason is an optional label to provide more information on top of the LabelKeyUpgradeState
 	LabelKeyUpgradeStateReason = "numaplane.numaproj.io/upgrade-state-reason"
 
-	// LabelKeyNumaplanePromote is the label value indicating that the resource managed by a NumaRollout should be force promoted
-	LabelKeyNumaplanePromote = "numaplane.numaproj.io/promote"
-
 	// LabelValueUpgradePromoted is the label value indicating that the resource managed by a NumaRollout is promoted
 	// after an upgrade.
 	LabelValueUpgradePromoted UpgradeState = "promoted"

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -245,8 +245,8 @@ func processUpgradingChild(
 	}
 	childStatus = rolloutObject.GetUpgradingChildStatus()
 
-	// check for Promote label here to force success logic
-	if rolloutObject.GetRolloutObjectMeta().Labels[common.LabelKeyNumaplanePromote] == "true" {
+	// check for Force Promote set in Progressive strategy to force success logic
+	if rolloutObject.GetProgressiveStrategy().ForcePromote {
 		childStatus.ForcedSuccess = true
 		done, err := declareSuccess(ctx, rolloutObject, existingPromotedChildDef, existingUpgradingChildDef, childStatus, c)
 		if err != nil || done {

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -159,12 +159,12 @@ func Test_processUpgradingChild(t *testing.T) {
 			expectedError:             nil,
 		},
 		{
-			name: "force promote a failure",
+			name: "force promote a failed progressive upgrade",
 			rolloutObject: setMonoVertexProgressiveStatus(
 				forcePromoteMonoVertexRollout.DeepCopy(),
 				&apiv1.UpgradingMonoVertexStatus{
 					UpgradingChildStatus: apiv1.UpgradingChildStatus{
-						Name:                "test-full-promote",
+						Name:                "test-force-promote",
 						AssessmentResult:    apiv1.AssessmentResultFailure,
 						AssessmentStartTime: &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
 					},
@@ -178,7 +178,7 @@ func Test_processUpgradingChild(t *testing.T) {
 					},
 				},
 			),
-			existingUpgradingChildDef: createMonoVertex("test-full-promote"),
+			existingUpgradingChildDef: createMonoVertex("test-force-promote"),
 			expectedDone:              true,
 			expectedNewChildCreated:   false,
 			expectedRequeueDelay:      0,
@@ -299,13 +299,21 @@ var defaultMonoVertexRollout = &apiv1.MonoVertexRollout{
 
 var forcePromoteMonoVertexRollout = &apiv1.MonoVertexRollout{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:   "test",
-		Labels: map[string]string{common.LabelKeyNumaplanePromote: "true"},
+		Name: "test",
 	},
 	Status: apiv1.MonoVertexRolloutStatus{
 		ProgressiveStatus: apiv1.MonoVertexProgressiveStatus{
 			UpgradingMonoVertexStatus: nil,
 			PromotedMonoVertexStatus:  nil,
+		},
+	},
+	Spec: apiv1.MonoVertexRolloutSpec{
+		Strategy: apiv1.PipelineTypeRolloutStrategy{
+			RolloutStrategy: apiv1.RolloutStrategy{
+				Progressive: apiv1.ProgressiveStrategy{
+					ForcePromote: true,
+				},
+			},
 		},
 	},
 }

--- a/pkg/apis/numaplane/v1alpha1/shared_types.go
+++ b/pkg/apis/numaplane/v1alpha1/shared_types.go
@@ -53,4 +53,7 @@ type ProgressiveStrategy struct {
 	// optional string: comma-separated list consisting of:
 	// assessmentDelay, assessmentPeriod, assessmentInterval
 	AssessmentSchedule string `json:"assessmentSchedule,omitempty"`
+
+	// if ForcePromote is set, assessment will be skipped and Progressive upgrade will succeed
+	ForcePromote bool `json:"forcePromote,omitempty"`
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #631 

### Modifications

This PR changes how we set a Rollout to use the `Force Promote` logic during a Progressive upgrade. 

Previously, we were setting and checking a label on the Rollout to see if we should immediately declare the upgrade a success. After some discussion, it makes more sense to have this logic which indicates how the Numaplane controller will behave should part of the Rollout spec. Thus, this PR removes the label and instead adds a boolean to the `ProgressiveStrategy` struct of the Rollout.

```
type ProgressiveStrategy struct {
	// optional string: comma-separated list consisting of:
	// assessmentDelay, assessmentPeriod, assessmentInterval
	AssessmentSchedule string `json:"assessmentSchedule,omitempty"`

	// if ForcePromote is set, assessment will be skipped and Progressive upgrade will succeed
	ForcePromote bool `json:"forcePromote,omitempty"`
}
```


### Verification

Running the controller locally and testing a Progressive upgrade that fails and passes after setting the boolean.

Updating unit tests.

### Backward incompatibilities

Older versions of Numaplane won't be able to use this feature since we have updated the CRDs.