### PR TITLE
feat: Scale down failed MonoVertex to 0 Pods 

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
@@ -13,6 +13,9 @@ spec:
     #  annotations:
     #    numaflow.numaproj.io/instance: "0"
     spec:
+      scale:
+        min: 2
+        max: 3
       source:
         udsource:
           container:

--- a/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
@@ -20,6 +20,9 @@ spec:
         udsource:
           container:
             image: quay.io/numaio/numaflow-go/source-simple-source:stable
+        transformer:
+          container:
+            image: docker.intuit.com/quay-rmt/numaio/numaflow-rs/source-transformer-now:stable
       sink:
         udsink:
           container:

--- a/internal/controller/common/numaflowtypes/monovertex.go
+++ b/internal/controller/common/numaflowtypes/monovertex.go
@@ -38,26 +38,3 @@ func ParseMonoVertexStatus(monoVertex *unstructured.Unstructured) (MonoVertexSta
 
 	return status, nil
 }
-
-/*
-func MonoVertexWithoutReplicas(monoVertex *unstructured.Unstructured) (map[string]interface{}, error) {
-	var specAsMap map[string]any
-	if err := util.StructToStruct(monoVertex.Object["spec"], &specAsMap); err != nil {
-		return nil, err
-	}
-	// remove "replicas" field
-	excludedPaths := []string{"replicas"}
-	util.RemovePaths(specAsMap, excludedPaths, ".")
-	return specAsMap, nil
-}
-func MonoVertexWithoutScaleMinAndMax(monoVertex *unstructured.Unstructured) (map[string]interface{}, error) {
-	var specAsMap map[string]any
-	if err := util.StructToStruct(monoVertex.Object["spec"], &specAsMap); err != nil {
-		return nil, err
-	}
-	// remove "replicas" field
-	excludedPaths := []string{"scale.min", "scale.max"}
-	util.RemovePaths(specAsMap, excludedPaths, ".")
-	return specAsMap, nil
-}
-*/

--- a/internal/controller/common/numaflowtypes/monovertex.go
+++ b/internal/controller/common/numaflowtypes/monovertex.go
@@ -38,13 +38,26 @@ func ParseMonoVertexStatus(monoVertex *unstructured.Unstructured) (MonoVertexSta
 
 	return status, nil
 }
+
+/*
 func MonoVertexWithoutReplicas(monoVertex *unstructured.Unstructured) (map[string]interface{}, error) {
 	var specAsMap map[string]any
 	if err := util.StructToStruct(monoVertex.Object["spec"], &specAsMap); err != nil {
 		return nil, err
 	}
 	// remove "replicas" field
-	comparisonExcludedPaths := []string{"replicas"}
-	util.RemovePaths(specAsMap, comparisonExcludedPaths, ".")
+	excludedPaths := []string{"replicas"}
+	util.RemovePaths(specAsMap, excludedPaths, ".")
 	return specAsMap, nil
 }
+func MonoVertexWithoutScaleMinAndMax(monoVertex *unstructured.Unstructured) (map[string]interface{}, error) {
+	var specAsMap map[string]any
+	if err := util.StructToStruct(monoVertex.Object["spec"], &specAsMap); err != nil {
+		return nil, err
+	}
+	// remove "replicas" field
+	excludedPaths := []string{"scale.min", "scale.max"}
+	util.RemovePaths(specAsMap, excludedPaths, ".")
+	return specAsMap, nil
+}
+*/

--- a/internal/controller/common/numaflowtypes/pipeline.go
+++ b/internal/controller/common/numaflowtypes/pipeline.go
@@ -197,3 +197,8 @@ func PipelineWithoutDesiredPhase(pipeline *unstructured.Unstructured) {
 		unstructured.RemoveNestedField(pipeline.Object, "spec", "lifecycle")
 	}
 }
+
+func PipelineWithoutScaleMinMax(pipeline *unstructured.Unstructured) {
+	unstructured.RemoveNestedField(pipeline.Object, "spec", "scale", "min")
+	unstructured.RemoveNestedField(pipeline.Object, "spec", "scale", "max")
+}

--- a/internal/controller/common/numaflowtypes/pipeline.go
+++ b/internal/controller/common/numaflowtypes/pipeline.go
@@ -201,4 +201,11 @@ func PipelineWithoutDesiredPhase(pipeline *unstructured.Unstructured) {
 func PipelineWithoutScaleMinMax(pipeline *unstructured.Unstructured) {
 	unstructured.RemoveNestedField(pipeline.Object, "spec", "scale", "min")
 	unstructured.RemoveNestedField(pipeline.Object, "spec", "scale", "max")
+
+	// if "scale" is there and empty, remove it
+	spec := pipeline.Object["spec"].(map[string]interface{})
+	scaleMap, found := spec["scale"].(map[string]interface{})
+	if found && len(scaleMap) == 0 {
+		unstructured.RemoveNestedField(pipeline.Object, "spec", "scale")
+	}
 }

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -876,7 +876,7 @@ func (r *ISBServiceRolloutReconciler) merge(existingISBService, newISBService *u
 	return resultISBService
 }
 
-// ChildNeedsUpdating determines if the difference between the current child definition and the desired child definition requires an update
+// ChildNeedsUpdating() tests for essential equality, with any fields that Numaplane manipulates eliminated from the comparison
 // This implements a function of the progressiveController interface
 func (r *ISBServiceRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
 	numaLogger := logger.FromContext(ctx)

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -108,3 +108,11 @@ func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPostFailure(
 ) (bool, error) {
 	return false, nil
 }
+func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPostSuccess(
+	ctx context.Context,
+	rolloutObject progressive.ProgressiveRolloutObject,
+	upgradingChildDef *unstructured.Unstructured,
+	c client.Client,
+) error {
+	return nil
+}

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -108,7 +108,7 @@ func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPostFailure(
 ) (bool, error) {
 	return false, nil
 }
-func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPostSuccess(
+func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
 	upgradingChildDef *unstructured.Unstructured,

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -99,3 +99,12 @@ func (r *ISBServiceRolloutReconciler) ProcessPromotedChildPostFailure(
 ) (bool, error) {
 	return false, nil
 }
+
+func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPostFailure(
+	ctx context.Context,
+	rolloutObject progressive.ProgressiveRolloutObject,
+	upgradingChildDef *unstructured.Unstructured,
+	c client.Client,
+) (bool, error) {
+	return false, nil
+}

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -608,6 +608,14 @@ func (r *MonoVertexRolloutReconciler) ChildNeedsUpdating(ctx context.Context, fr
 
 		excludedPaths := []string{"replicas", "scale.min", "scale.max"}
 		util.RemovePaths(specAsMap, excludedPaths, ".")
+
+		// if "scale" is there and empty, remove it
+		// (this enables accurate comparison between one monovertex with "scale" empty and one with "scale" not present)
+		scaleMap, found := specAsMap["scale"].(map[string]interface{})
+		if found && len(scaleMap) == 0 {
+			unstructured.RemoveNestedField(specAsMap, "scale")
+		}
+
 		return specAsMap, nil
 	}
 

--- a/internal/controller/monovertexrollout/monovertexrollout_controller_test.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller_test.go
@@ -575,3 +575,61 @@ func TestChildNeedsUpdating(t *testing.T) {
 		})
 	}
 }
+
+func TestGetScaleValuesFromMonoVertexSpec(t *testing.T) {
+	one := int64(1)
+	ten := int64(10)
+	tests := []struct {
+		name        string
+		input       map[string]interface{}
+		expectedMin *int64
+		expectedMax *int64
+		expectError bool
+	}{
+		{
+			name: "BothValuesPresent",
+			input: map[string]interface{}{
+				"scale": map[string]interface{}{
+					"min": int64(1),
+					"max": int64(10),
+				},
+			},
+			expectedMin: &one,
+			expectedMax: &ten,
+			expectError: false,
+		},
+		{
+			name: "NoValuesPresent",
+			input: map[string]interface{}{
+				"scale": map[string]interface{}{},
+			},
+			expectedMin: nil,
+			expectedMax: nil,
+			expectError: false,
+		},
+		{
+			name: "ErrorAccessingValues",
+			input: map[string]interface{}{
+				"scale": "invalid_structure",
+			},
+			expectedMin: nil,
+			expectedMax: nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			min, max, err := getScaleValuesFromMonoVertexSpec(tt.input)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Expected error: %v, got: %v", tt.expectError, err)
+			}
+			if (min == nil && tt.expectedMin != nil) || (min != nil && tt.expectedMin == nil) || (min != nil && *min != *tt.expectedMin) {
+				t.Errorf("Expected min: %v, got: %v", tt.expectedMin, min)
+			}
+			if (max == nil && tt.expectedMax != nil) || (max != nil && tt.expectedMax == nil) || (max != nil && *max != *tt.expectedMax) {
+				t.Errorf("Expected max: %v, got: %v", tt.expectedMax, max)
+			}
+		})
+	}
+}

--- a/internal/controller/monovertexrollout/monovertexrollout_controller_test.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller_test.go
@@ -590,8 +590,9 @@ func TestGetScaleValuesFromMonoVertexSpec(t *testing.T) {
 			name: "BothValuesPresent",
 			input: map[string]interface{}{
 				"scale": map[string]interface{}{
-					"min": int64(1),
-					"max": int64(10),
+					"min":        int64(1),
+					"max":        int64(10),
+					"anotherKey": "anotherValue",
 				},
 			},
 			expectedMin: &one,
@@ -604,6 +605,17 @@ func TestGetScaleValuesFromMonoVertexSpec(t *testing.T) {
 				"scale": map[string]interface{}{},
 			},
 			expectedMin: nil,
+			expectedMax: nil,
+			expectError: false,
+		},
+		{
+			name: "OneValuePresent",
+			input: map[string]interface{}{
+				"scale": map[string]interface{}{
+					"min": int64(1),
+				},
+			},
+			expectedMin: &one,
 			expectedMax: nil,
 			expectError: false,
 		},

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -109,26 +109,14 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPostFailure(
 	if !ok {
 		numaLogger.Errorf(errors.New("monovertex spec invalid"), "existing upgrading monovertex spec doesn't start with root 'spec' key (or is of invalid type)?: %+v", upgradingChildDef.Object)
 	} else {
-		fmt.Printf("deletethis: 1\n")
 		existingScaleMin, existingScaleMax, err := getScaleValuesFromMonoVertexSpec(existingSpec)
 		if err != nil {
-			fmt.Printf("deletethis: 2\n")
-
 			return true, err
 		}
-		fmt.Printf("deletethis: 3\n")
 
 		if existingScaleMin != nil && *existingScaleMin == 0 && existingScaleMax != nil && *existingScaleMax == 0 {
-			fmt.Printf("deletethis: 4\n")
-
 			numaLogger.Debug("already scaled down upgrading monovertex to 0, so no need to repeat")
 			return false, nil
-		} else {
-			if existingScaleMin == nil || existingScaleMax == nil {
-				fmt.Printf("deletethis: existing scale values nil; upgradingChildDef.Object=%+v\n", upgradingChildDef.Object)
-			} else {
-				fmt.Printf("deletethis: existing scale values not nil; *existingScaleMin=%d, *existingScaleMax=%d, upgradingChildDef.Object=%+v\n", *existingScaleMin, *existingScaleMax, upgradingChildDef.Object)
-			}
 		}
 	}
 
@@ -430,6 +418,5 @@ func scaleMonoVertex(
 		scaleValue = fmt.Sprintf(`{"max": %d}`, *max)
 	}
 	patchJson := fmt.Sprintf(`{"spec": {"scale": %s}}`, scaleValue)
-	fmt.Printf("deletethis: patchJson=%s\n", patchJson)
 	return kubernetes.PatchResource(ctx, c, monovertex, patchJson, k8stypes.MergePatchType)
 }

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -131,13 +131,26 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 		return err
 	}
 
-	min, foundMin, err := unstructured.NestedInt64(monovertexSpec, "scale", "min")
+	minPtr, maxPtr, err := getScaleValuesFromMonoVertexSpec(monovertexSpec)
 	if err != nil {
 		return err
 	}
-	max, foundMax, err := unstructured.NestedInt64(monovertexSpec, "scale", "max")
+
+	err = scaleMonoVertex(ctx, upgradingChildDef, minPtr, maxPtr, c)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func getScaleValuesFromMonoVertexSpec(monovertexSpec map[string]interface{}) (*int64, *int64, error) {
+	min, foundMin, err := unstructured.NestedInt64(monovertexSpec, "scale", "min")
+	if err != nil {
+		return nil, nil, err
+	}
+	max, foundMax, err := unstructured.NestedInt64(monovertexSpec, "scale", "max")
+	if err != nil {
+		return nil, nil, err
 	}
 	var minPtr, maxPtr *int64
 	if foundMin {
@@ -146,14 +159,7 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 	if foundMax {
 		maxPtr = &max
 	}
-
-	// TODO: compare these values to upgradingChildDef values to see if we really need to patch or not
-
-	err = scaleMonoVertex(ctx, upgradingChildDef, minPtr, maxPtr, c)
-	if err != nil {
-		return err
-	}
-	return nil
+	return minPtr, maxPtr, nil
 }
 
 /*

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -115,7 +115,7 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPostFailure(
 	return false, nil
 }
 
-func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPostSuccess(
+func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
 	upgradingChildDef *unstructured.Unstructured,

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -107,7 +107,7 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPostFailure(
 		return true, err
 	}
 
-	numaLogger.Debug("completed post-upgrade processing of promoted monovertex")
+	numaLogger.Debug("completed post-failure processing of upgrading monovertex")
 
 	return false, nil
 }

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -439,13 +439,15 @@ func scaleMonoVertex(
 	max *int64,
 	c client.Client) error {
 
-	scaleValue := "null"
+	var scaleValue string
 	if min != nil && max != nil {
 		scaleValue = fmt.Sprintf(`{"min": %d, "max": %d}`, *min, *max)
 	} else if min != nil {
 		scaleValue = fmt.Sprintf(`{"min": %d, "max": null}`, *min)
 	} else if max != nil {
 		scaleValue = fmt.Sprintf(`{"min": null, "max": %d}`, *max)
+	} else {
+		scaleValue = `{"min": null, "max": null}`
 	}
 	patchJson := fmt.Sprintf(`{"spec": {"scale": %s}}`, scaleValue)
 	return kubernetes.PatchResource(ctx, c, monovertex, patchJson, k8stypes.MergePatchType)

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -120,25 +120,22 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPostFailure(
 
 	// scale down monovertex to 0 Pods
 	// need to check to see if it's already scaled down before we do this
-	existingSpec, ok := upgradingChildDef.Object["spec"].(map[string]interface{})
-	if !ok {
-		numaLogger.Errorf(errors.New("monovertex spec invalid"), "existing upgrading monovertex spec doesn't start with root 'spec' key (or is of invalid type)?: %+v", upgradingChildDef.Object)
-	} else {
-		existingScaleMin, existingScaleMax, err := getScaleValuesFromMonoVertexSpec(existingSpec)
-		if err != nil {
-			return true, err
-		}
+	existingSpec := upgradingChildDef.Object["spec"].(map[string]interface{})
 
-		if existingScaleMin != nil && *existingScaleMin == 0 && existingScaleMax != nil && *existingScaleMax == 0 {
-			numaLogger.Debug("already scaled down upgrading monovertex to 0, so no need to repeat")
-			return false, nil
-		}
+	existingScaleMin, existingScaleMax, err := getScaleValuesFromMonoVertexSpec(existingSpec)
+	if err != nil {
+		return true, err
+	}
+
+	if existingScaleMin != nil && *existingScaleMin == 0 && existingScaleMax != nil && *existingScaleMax == 0 {
+		numaLogger.Debug("already scaled down upgrading monovertex to 0, so no need to repeat")
+		return false, nil
 	}
 
 	// scale the Pods down to 0
 	min := int64(0)
 	max := int64(0)
-	err := scaleMonoVertex(ctx, upgradingChildDef, &min, &max, c)
+	err = scaleMonoVertex(ctx, upgradingChildDef, &min, &max, c)
 	if err != nil {
 		return true, err
 	}

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -120,24 +120,24 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPostSuccess(
 	rolloutObject progressive.ProgressiveRolloutObject,
 	upgradingChildDef *unstructured.Unstructured,
 	c client.Client,
-) (bool, error) {
+) error {
 
 	monoVertexRollout, ok := rolloutObject.(*apiv1.MonoVertexRollout)
 	if !ok {
-		return true, fmt.Errorf("unexpected type for ProgressiveRolloutObject: %+v; can't process upgrading monovertex post-success", rolloutObject)
+		return fmt.Errorf("unexpected type for ProgressiveRolloutObject: %+v; can't process upgrading monovertex post-success", rolloutObject)
 	}
 	var monovertexSpec map[string]interface{}
 	if err := util.StructToStruct(monoVertexRollout.Spec.MonoVertex.Spec, &monovertexSpec); err != nil {
-		return true, err
+		return err
 	}
 
 	min, foundMin, err := unstructured.NestedInt64(monovertexSpec, "scale", "min")
 	if err != nil {
-		return true, err
+		return err
 	}
 	max, foundMax, err := unstructured.NestedInt64(monovertexSpec, "scale", "max")
 	if err != nil {
-		return true, err
+		return err
 	}
 	var minPtr, maxPtr *int64
 	if foundMin {
@@ -146,11 +146,14 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPostSuccess(
 	if foundMax {
 		maxPtr = &max
 	}
+
+	// TODO: compare these values to upgradingChildDef values to see if we really need to patch or not
+
 	err = scaleMonoVertex(ctx, upgradingChildDef, minPtr, maxPtr, c)
 	if err != nil {
-		return true, err
+		return err
 	}
-	return false, nil
+	return nil
 }
 
 /*

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -935,7 +935,7 @@ func (r *PipelineRolloutReconciler) drain(ctx context.Context, pipeline *unstruc
 	return kubernetes.PatchResource(ctx, r.client, pipeline, patchJson, k8stypes.MergePatchType)
 }
 
-// ChildNeedsUpdating() tests for essential equality, with any irrelevant fields eliminated from the comparison
+// ChildNeedsUpdating() tests for essential equality, with any fields that Numaplane manipulates eliminated from the comparison
 // This implements a function of the progressiveController interface
 func (r *PipelineRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from, to *unstructured.Unstructured) (bool, error) {
 	numaLogger := logger.FromContext(ctx)
@@ -943,7 +943,9 @@ func (r *PipelineRolloutReconciler) ChildNeedsUpdating(ctx context.Context, from
 	toCopy := to.DeepCopy()
 	// remove lifecycle.desiredPhase field from comparison to test for equality
 	numaflowtypes.PipelineWithoutDesiredPhase(fromCopy)
+	numaflowtypes.PipelineWithoutScaleMinMax(fromCopy)
 	numaflowtypes.PipelineWithoutDesiredPhase(toCopy)
+	numaflowtypes.PipelineWithoutScaleMinMax(toCopy)
 
 	specsEqual := util.CompareStructNumTypeAgnostic(fromCopy.Object["spec"], toCopy.Object["spec"])
 	numaLogger.Debugf("specsEqual: %t, from=%v, to=%v\n",

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -172,7 +172,7 @@ func (r *PipelineRolloutReconciler) ProcessUpgradingChildPostFailure(
 	return false, nil
 }
 
-func (r *PipelineRolloutReconciler) ProcessUpgradingChildPostSuccess(
+func (r *PipelineRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
 	upgradingChildDef *unstructured.Unstructured,

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -133,7 +133,7 @@ func (r *PipelineRolloutReconciler) ProcessPromotedChildPostFailure(
 
 	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPostUpgrade").WithName("PipelineRollout")
 
-	numaLogger.Debug("started post-upgrade processing of promoted pipeline")
+	numaLogger.Debug("started post-failure processing of promoted pipeline")
 
 	pipelineRO, ok := pipelineRollout.(*apiv1.PipelineRollout)
 	if !ok {
@@ -149,9 +149,27 @@ func (r *PipelineRolloutReconciler) ProcessPromotedChildPostFailure(
 		return true, err
 	}
 
-	numaLogger.Debug("completed post-upgrade processing of promoted pipeline")
+	numaLogger.Debug("completed post-failure processing of promoted pipeline")
 
 	return requeue, nil
+}
+
+func (r *PipelineRolloutReconciler) ProcessUpgradingChildPostFailure(
+	ctx context.Context,
+	rolloutObject progressive.ProgressiveRolloutObject,
+	upgradingChildDef *unstructured.Unstructured,
+	c client.Client,
+) (bool, error) {
+
+	numaLogger := logger.FromContext(ctx).WithName("ProcessUpgradingChildPostFailure").WithName("PipelineRollout")
+
+	numaLogger.Debug("started post-failure processing of upgrading pipeline")
+
+	// TODO
+
+	numaLogger.Debug("completed post-failure processing of upgrading pipeline")
+
+	return false, nil
 }
 
 /*

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -172,6 +172,17 @@ func (r *PipelineRolloutReconciler) ProcessUpgradingChildPostFailure(
 	return false, nil
 }
 
+func (r *PipelineRolloutReconciler) ProcessUpgradingChildPostSuccess(
+	ctx context.Context,
+	rolloutObject progressive.ProgressiveRolloutObject,
+	upgradingChildDef *unstructured.Unstructured,
+	c client.Client,
+) error {
+
+	// TODO
+	return nil
+}
+
 /*
 scaleDownPipelineSourceVertices scales down the source vertices pods of a pipeline to half of the current count if not already scaled down.
 It checks if all source vertices are already scaled down and skips the operation if true.

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -340,7 +340,7 @@ func processUpgradingChild(
 			if err != nil {
 				return false, false, 0, err
 			}
-			requeue, err = controller.ProcessUpgradingChildPostFailure(ctx, rolloutObject, newUpgradingChildDef, c)
+			requeue, err = controller.ProcessUpgradingChildPostFailure(ctx, rolloutObject, existingUpgradingChildDef, c)
 			if requeue {
 				return false, false, common.DefaultRequeueDelay, nil
 			}

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -57,8 +57,8 @@ type progressiveController interface {
 	// ProcessUpgradingChildPostFailure performs operations on the upgrading child after the upgrade fails (just the operations which are unique to this Kind)
 	ProcessUpgradingChildPostFailure(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) (bool, error)
 
-	// ProcessUpgradingChildPostSuccess performs operations on the upgrading child after the upgrade succeeds (just the operations which are unique to this Kind)
-	ProcessUpgradingChildPostSuccess(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) error
+	// ProcessUpgradingChildPreForcedPromotion performs operations on the upgrading child after the upgrade succeeds (just the operations which are unique to this Kind)
+	ProcessUpgradingChildPreForcedPromotion(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) error
 }
 
 // ProgressiveRolloutObject describes a Rollout instance that supports progressive upgrade
@@ -255,6 +255,11 @@ func processUpgradingChild(
 	if rolloutObject.GetProgressiveStrategy().ForcePromote {
 		childStatus.ForcedSuccess = true
 
+		err = controller.ProcessUpgradingChildPreForcedPromotion(ctx, rolloutObject, existingUpgradingChildDef, c)
+		if err != nil {
+			return false, false, 0, err
+		}
+
 		done, err := declareSuccess(ctx, rolloutObject, controller, existingPromotedChildDef, existingUpgradingChildDef, childStatus, c)
 		if err != nil || done {
 			return done, false, 0, err
@@ -420,15 +425,10 @@ func declareSuccess(ctx context.Context,
 
 	numaLogger := logger.FromContext(ctx)
 
-	err := controller.ProcessUpgradingChildPostSuccess(ctx, rolloutObject, existingUpgradingChildDef, c)
-	if err != nil {
-		return false, err
-	}
-
 	// Label the new child as promoted and then remove the label from the old one
 	numaLogger.WithValues("old child", existingPromotedChildDef.GetName(), "new child", existingUpgradingChildDef.GetName()).Debug("replacing 'promoted' child")
 	reasonSuccess := common.LabelValueProgressiveSuccess
-	err = ctlrcommon.UpdateUpgradeState(ctx, c, common.LabelValueUpgradePromoted, &reasonSuccess, existingUpgradingChildDef)
+	err := ctlrcommon.UpdateUpgradeState(ctx, c, common.LabelValueUpgradePromoted, &reasonSuccess, existingUpgradingChildDef)
 	if err != nil {
 		return false, err
 	}

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -53,6 +53,9 @@ type progressiveController interface {
 
 	// ProcessPromotedChildPostFailure performs operations on the promoted child after the upgrade fails
 	ProcessPromotedChildPostFailure(ctx context.Context, rolloutObject ProgressiveRolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error)
+
+	// ProcessPromotedChildPostFailure performs operations on the upgrading child after the upgrade fails
+	ProcessUpgradingChildPostFailure(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) (bool, error)
 }
 
 // ProgressiveRolloutObject describes a Rollout instance that supports progressive upgrade
@@ -328,6 +331,7 @@ func processUpgradingChild(
 			if err != nil {
 				return false, false, 0, err
 			}
+			requeue, err = controller.ProcessUpgradingChildPostFailure(ctx, rolloutObject, newUpgradingChildDef, c)
 			if requeue {
 				return false, false, common.DefaultRequeueDelay, nil
 			}

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -340,7 +340,13 @@ func processUpgradingChild(
 			if err != nil {
 				return false, false, 0, err
 			}
+			if requeue {
+				return false, false, common.DefaultRequeueDelay, nil
+			}
 			requeue, err = controller.ProcessUpgradingChildPostFailure(ctx, rolloutObject, existingUpgradingChildDef, c)
+			if err != nil {
+				return false, false, 0, err
+			}
 			if requeue {
 				return false, false, common.DefaultRequeueDelay, nil
 			}

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -59,6 +59,14 @@ func (fpc fakeProgressiveController) ProcessPromotedChildPostFailure(ctx context
 	return false, nil
 }
 
+func (fpc fakeProgressiveController) ProcessUpgradingChildPostFailure(ctx context.Context, rolloutObject ProgressiveRolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
+	return false, nil
+}
+
+func (fpc fakeProgressiveController) ProcessUpgradingChildPreForcedPromotion(ctx context.Context, rolloutObject ProgressiveRolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) error {
+	return nil
+}
+
 func Test_processUpgradingChild(t *testing.T) {
 	restConfig, numaflowClientSet, client, _, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

This PR takes care of MonoVertex only - Pipeline can be done later. 

It does the following:

- Upon failure, scales the MonoVertex down to 0 Pods
- If "force promote" is done, scale it back up to the value specified in the MonoVertexRollout

(Note that for the latter, we may ultimately want to not get it from the MonoVertexRollout but instead save the `scaleDefinition` in the UpgradingChildStatus just like we do right now for Promoted child. Just thinking of very rare edge cases in which someone just changed the scale in the MonoVertexRollout and we use that instead of the one we were using. Normally, it would be fine to just use that scale value, but thinking of some rare case in which it's important that the scale value gets set atomically with some other change....) 


### Verification

Ran various sequences of failure and success and observed scale set correctly.
Tested the following with a monovertex whose scale.min and scale.max were set and one for which `scale` was not set at all:

- Updated good spec to bad spec - observed good one scaled down to half, bad one came up as normal at full scale, after failure bad one scaled down to 0 and good one scaled back up
- Updated bad spec to use "forcePromote": "true" - observed bad one got promoted, and it scaled back up (spec specified full scale but I think Numaflow wouldn't bring up all the pods because they were unhealthy (not sure if a Numaflow bug or not))
- Updated good spec to good spec - observed original scaled down to half, good one came up as normal at full scale

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
