### PR TITLE
fix: remove blank spaces from configmap

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1999,11 +1999,21 @@ subjects:
 ---
 apiVersion: v1
 data:
-  config.yaml: "logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN.
-    ERROR, FATAL will be printed regardless of the log level\nincludedResources: \"group=apps,kind=Deployment;\\\ngroup=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\\\ngroup=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role\"\ndefaultUpgradeStrategy:
-    \"pause-and-drain\"\nprogressive:\n  defaultAssessmentSchedule: \n    - kind:
-    Pipeline\n      schedule: \"120,60,10\"\n    - kind: MonoVertex\n      schedule:
-    \"120,60,10\"\n    - kind: InterstepBufferService\n      schedule: \"0,0,10\"\n"
+  config.yaml: |
+    # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
+    logLevel: INFO
+    includedResources: "group=apps,kind=Deployment;\
+    group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
+    group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
+    defaultUpgradeStrategy: "pause-and-drain"
+    progressive:
+      defaultAssessmentSchedule:
+        - kind: Pipeline
+          schedule: "120,60,10"
+        - kind: MonoVertex
+          schedule: "120,60,10"
+        - kind: InterstepBufferService
+          schedule: "0,0,10"
 kind: ConfigMap
 metadata:
   name: numaplane-controller-config

--- a/config/manager/controller-config.yaml
+++ b/config/manager/controller-config.yaml
@@ -4,13 +4,14 @@ metadata:
   name: numaplane-controller-config
 data:
   config.yaml: |
-    logLevel: INFO # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
+    # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
+    logLevel: INFO
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
     defaultUpgradeStrategy: "pause-and-drain"
     progressive:
-      defaultAssessmentSchedule: 
+      defaultAssessmentSchedule:
         - kind: Pipeline
           schedule: "120,60,10"
         - kind: MonoVertex

--- a/tests/manifests/special-cases/no-strategy/controller-config.yaml
+++ b/tests/manifests/special-cases/no-strategy/controller-config.yaml
@@ -4,13 +4,14 @@ metadata:
   name: numaplane-controller-config
 data:
   config.yaml: |
-    logLevel: DEBUG # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
+    # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
+    logLevel: DEBUG
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
     defaultUpgradeStrategy: "no-strategy"
     progressive:
-      defaultAssessmentSchedule: 
+      defaultAssessmentSchedule:
         - kind: Pipeline
           schedule: "120,60,10"
         - kind: MonoVertex

--- a/tests/manifests/special-cases/progressive/controller-config.yaml
+++ b/tests/manifests/special-cases/progressive/controller-config.yaml
@@ -4,13 +4,12 @@ metadata:
   name: numaplane-controller-config
 data:
   config.yaml: |
-    logLevel: DEBUG # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
-    includedResources: "group=apps,kind=Deployment;\
-    group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
-    group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
+    # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
+    logLevel: DEBUG
+    includedResources: "group=apps,kind=Deployment;group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
     defaultUpgradeStrategy: "progressive"
     progressive:
-      defaultAssessmentSchedule: 
+      defaultAssessmentSchedule:
         - kind: Pipeline
           schedule: "120,60,10"
         - kind: MonoVertex


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Modifications

It seems that having a trailing blank space after a line in the ConfigMap causes the formatting to get messed up if you do `kubectl get configmap <name> -o yaml`, like this:
```
apiVersion: v1
data:
  config.yaml: "logLevel: DEBUG \nincludedResources: \"group=apps,kind=Deployment;group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role\"\ndefaultUpgradeStrategy:
    \"progressive\"\nprogressive:\n  defaultAssessmentSchedule: \n    \n"
kind: ConfigMap
```

Removed the two blank spaces and now it looks like this:
```
apiVersion: v1
data:
  config.yaml: |
    # Supported log levels are: VERBOSE, DEBUG, INFO, WARN. ERROR, FATAL will be printed regardless of the log level
    logLevel: DEBUG
    includedResources: "group=apps,kind=Deployment;\
    group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
    group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
    defaultUpgradeStrategy: "no-strategy"
    progressive:
      defaultAssessmentSchedule:
        - kind: Pipeline
          schedule: "120,60,10"
        - kind: MonoVertex
          schedule: "120,60,10"
        - kind: InterstepBufferService
          schedule: "0,0,10"
kind: ConfigMap
```

### Verification

I applied each of the 3 configmaps that were changed and verified them:
- default (pause and drain)
- progressive
- no-strategy

### Backward incompatibilities

N/A
