### PR TITLE
fix: Add safe check for not found error

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -127,6 +127,10 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// TODO: consider storing ISBServiceRollout Status in a local cache instead of this
 	isbServiceRollout, err := getLiveISBServiceRollout(ctx, req.NamespacedName.Name, req.NamespacedName.Namespace)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			numaLogger.Info("ISBServiceRollout not found, %v", err)
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("error getting the live ISB Service rollout: %w", err)
 	}
 
@@ -203,6 +207,10 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 			// Get the ISBServiceRollout live resource
 			liveISBServiceRollout, err := getLiveISBServiceRollout(ctx, isbServiceRollout.Name, isbServiceRollout.Namespace)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					numaLogger.Info("ISBServiceRollout not found, %v", err)
+					return ctrl.Result{}, nil
+				}
 				return ctrl.Result{}, fmt.Errorf("error getting the live ISB Service rollout: %w", err)
 			}
 			*isbServiceRollout = *liveISBServiceRollout
@@ -786,6 +794,10 @@ func (r *ISBServiceRolloutReconciler) updateISBServiceRolloutStatus(ctx context.
 		// Therefore, we know that the Status is totally current.
 		liveISBServiceRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().ISBServiceRollouts(isbServiceRollout.Namespace).Get(ctx, isbServiceRollout.Name, metav1.GetOptions{})
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				numaLogger.Info("ISBServiceRollout not found, %v", err)
+				return nil
+			}
 			return fmt.Errorf("error getting the live ISBServiceRollout after attempting to update the ISBServiceRollout Status: %w", err)
 		}
 		status := isbServiceRollout.Status // save off the Status

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -126,6 +126,10 @@ func (r *MonoVertexRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// TODO: consider storing MonoVertexRollout Status in a local cache instead of this
 	monoVertexRollout, err := getLiveMonovertexRollout(ctx, req.NamespacedName.Name, req.NamespacedName.Namespace)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			numaLogger.Info("MonoVertxRollout not found, %v", err)
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("error getting the live monoVertex rollout: %w", err)
 	}
 
@@ -196,6 +200,10 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 			// Get the monoVertexRollout live resource
 			liveMonoVertexRollout, err := getLiveMonovertexRollout(ctx, monoVertexRollout.Name, monoVertexRollout.Namespace)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					numaLogger.Info("MonoVertxRollout not found, %v", err)
+					return ctrl.Result{}, nil
+				}
 				return ctrl.Result{}, fmt.Errorf("error getting the live monoVertex rollout: %w", err)
 			}
 			*monoVertexRollout = *liveMonoVertexRollout
@@ -504,6 +512,10 @@ func (r *MonoVertexRolloutReconciler) updateMonoVertexRolloutStatus(ctx context.
 		// Therefore, we know that the Status is totally current.
 		liveRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().MonoVertexRollouts(monoVertexRollout.Namespace).Get(ctx, monoVertexRollout.Name, metav1.GetOptions{})
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				numaLogger.Info("MonoVertxRollout not found, %v", err)
+				return nil
+			}
 			return fmt.Errorf("error getting the live MonoVertexRollout after attempting to update the MonoVertexRollout Status: %w", err)
 		}
 		status := monoVertexRollout.Status // save off the Status

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -236,6 +236,10 @@ func (r *NumaflowControllerReconciler) reconcile(
 			// Get the controller live resource
 			liveController, err := getLiveNumaflowController(ctx, controller.Name, controller.Namespace)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					numaLogger.Info("NumaflowController not found, %v", err)
+					return ctrl.Result{}, nil
+				}
 				return ctrl.Result{}, fmt.Errorf("error getting the live controller: %w", err)
 			}
 			*controller = *liveController

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -203,6 +203,10 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 			// Get the nfcRollout live resource
 			liveControllerRollout, err := getLiveNumaflowControllerRollout(ctx, nfcRollout.Name, nfcRollout.Namespace)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					numaLogger.Info("NumaflowControllerRollout not found, %v", err)
+					return ctrl.Result{}, nil
+				}
 				return ctrl.Result{}, fmt.Errorf("error getting the live numaflow controller rollout: %w", err)
 			}
 			*nfcRollout = *liveControllerRollout

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -170,6 +170,10 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 	// TODO: consider storing PipelineRollout Status in a local cache instead of this
 	pipelineRollout, err := getLivePipelineRollout(ctx, namespacedName.Name, namespacedName.Namespace)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			numaLogger.Info("PipelineRollout not found, %v", err)
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("error getting the live PipelineRollout: %w", err)
 	}
 
@@ -343,6 +347,10 @@ func (r *PipelineRolloutReconciler) reconcile(
 			// Get the PipelineRollout live resource
 			livePipelineRollout, err := getLivePipelineRollout(ctx, pipelineRollout.Name, pipelineRollout.Namespace)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					numaLogger.Info("PipelineRollout not found, %v", err)
+					return 0, nil, nil
+				}
 				return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
 			}
 			*pipelineRollout = *livePipelineRollout
@@ -821,6 +829,10 @@ func (r *PipelineRolloutReconciler) updatePipelineRolloutStatus(ctx context.Cont
 		// Therefore, we know that the Status is totally current.
 		livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				numaLogger.Info("PipelineRollout not found, %v", err)
+				return nil
+			}
 			return fmt.Errorf("error getting the live PipelineRollout after attempting to update the PipelineRollout Status: %w", err)
 		}
 		status := pipelineRollout.Status // save off the Status


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #632 

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->
- Add logger and stop reconciler for resource not found error after resource got deleted.

### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->
- Ran E2E test locally in kind cluster

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
