### PR TITLE
feat: verify replicas for child health

### DIFF
--- a/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
@@ -214,6 +214,12 @@ spec:
                                 running for the vertex
                               format: int64
                               type: integer
+                            initial:
+                              description: Initial indicates how many pods were actually
+                                running for the vertex at the beginning of the upgrade
+                                process
+                              format: int64
+                              type: integer
                             originalScaleMinMax:
                               description: OriginalScaleMinMax stores the original
                                 scale min and max values as JSON string
@@ -225,6 +231,7 @@ spec:
                               type: integer
                           required:
                           - actual
+                          - initial
                           - originalScaleMinMax
                           - scaleTo
                           type: object

--- a/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
@@ -209,13 +209,13 @@ spec:
                             max values, scaleTo value, and actual scale value of a
                             pipeline or monovertex vertex
                           properties:
-                            actual:
-                              description: Actual indicates how many pods are actually
+                            current:
+                              description: Current indicates how many pods are currently
                                 running for the vertex
                               format: int64
                               type: integer
                             initial:
-                              description: Initial indicates how many pods were actually
+                              description: Initial indicates how many pods were initially
                                 running for the vertex at the beginning of the upgrade
                                 process
                               format: int64
@@ -230,7 +230,7 @@ spec:
                               format: int64
                               type: integer
                           required:
-                          - actual
+                          - current
                           - initial
                           - originalScaleMinMax
                           - scaleTo

--- a/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
@@ -237,6 +237,12 @@ spec:
                                 running for the vertex
                               format: int64
                               type: integer
+                            initial:
+                              description: Initial indicates how many pods were actually
+                                running for the vertex at the beginning of the upgrade
+                                process
+                              format: int64
+                              type: integer
                             originalScaleMinMax:
                               description: OriginalScaleMinMax stores the original
                                 scale min and max values as JSON string
@@ -248,6 +254,7 @@ spec:
                               type: integer
                           required:
                           - actual
+                          - initial
                           - originalScaleMinMax
                           - scaleTo
                           type: object

--- a/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
@@ -232,13 +232,13 @@ spec:
                             max values, scaleTo value, and actual scale value of a
                             pipeline or monovertex vertex
                           properties:
-                            actual:
-                              description: Actual indicates how many pods are actually
+                            current:
+                              description: Current indicates how many pods are currently
                                 running for the vertex
                               format: int64
                               type: integer
                             initial:
-                              description: Initial indicates how many pods were actually
+                              description: Initial indicates how many pods were initially
                                 running for the vertex at the beginning of the upgrade
                                 process
                               format: int64
@@ -253,7 +253,7 @@ spec:
                               format: int64
                               type: integer
                           required:
-                          - actual
+                          - current
                           - initial
                           - originalScaleMinMax
                           - scaleTo

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -523,13 +523,13 @@ spec:
                             max values, scaleTo value, and actual scale value of a
                             pipeline or monovertex vertex
                           properties:
-                            actual:
-                              description: Actual indicates how many pods are actually
+                            current:
+                              description: Current indicates how many pods are currently
                                 running for the vertex
                               format: int64
                               type: integer
                             initial:
-                              description: Initial indicates how many pods were actually
+                              description: Initial indicates how many pods were initially
                                 running for the vertex at the beginning of the upgrade
                                 process
                               format: int64
@@ -544,7 +544,7 @@ spec:
                               format: int64
                               type: integer
                           required:
-                          - actual
+                          - current
                           - initial
                           - originalScaleMinMax
                           - scaleTo
@@ -1267,13 +1267,13 @@ spec:
                             max values, scaleTo value, and actual scale value of a
                             pipeline or monovertex vertex
                           properties:
-                            actual:
-                              description: Actual indicates how many pods are actually
+                            current:
+                              description: Current indicates how many pods are currently
                                 running for the vertex
                               format: int64
                               type: integer
                             initial:
-                              description: Initial indicates how many pods were actually
+                              description: Initial indicates how many pods were initially
                                 running for the vertex at the beginning of the upgrade
                                 process
                               format: int64
@@ -1288,7 +1288,7 @@ spec:
                               format: int64
                               type: integer
                           required:
-                          - actual
+                          - current
                           - initial
                           - originalScaleMinMax
                           - scaleTo

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -528,6 +528,12 @@ spec:
                                 running for the vertex
                               format: int64
                               type: integer
+                            initial:
+                              description: Initial indicates how many pods were actually
+                                running for the vertex at the beginning of the upgrade
+                                process
+                              format: int64
+                              type: integer
                             originalScaleMinMax:
                               description: OriginalScaleMinMax stores the original
                                 scale min and max values as JSON string
@@ -539,6 +545,7 @@ spec:
                               type: integer
                           required:
                           - actual
+                          - initial
                           - originalScaleMinMax
                           - scaleTo
                           type: object
@@ -1265,6 +1272,12 @@ spec:
                                 running for the vertex
                               format: int64
                               type: integer
+                            initial:
+                              description: Initial indicates how many pods were actually
+                                running for the vertex at the beginning of the upgrade
+                                process
+                              format: int64
+                              type: integer
                             originalScaleMinMax:
                               description: OriginalScaleMinMax stores the original
                                 scale min and max values as JSON string
@@ -1276,6 +1289,7 @@ spec:
                               type: integer
                           required:
                           - actual
+                          - initial
                           - originalScaleMinMax
                           - scaleTo
                           type: object

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -108,6 +108,7 @@ func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPostFailure(
 ) (bool, error) {
 	return false, nil
 }
+
 func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
@@ -115,4 +116,13 @@ func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 	c client.Client,
 ) error {
 	return nil
+}
+
+func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPreUpgrade(
+	ctx context.Context,
+	rolloutObject progressive.ProgressiveRolloutObject,
+	upgradingChildDef *unstructured.Unstructured,
+	c client.Client,
+) (bool, error) {
+	return false, nil
 }

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -255,9 +255,9 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPreUpgrade(
 		// Set the upgrading MonoVertex scale.min and scale.max to the number of Pods that were removed
 		// from the promoted MonoVertex.
 		// This ensures:
-		// 1. that the total number of running pods does not change during the upgrade process, which is
-		// necessary when performing the health check for "ready replicas >= desired replicas"
-		// 2. that the number of Pods before and during upgrade remains the same
+		// 1. that the total number of running pods on the "upgrading" monovertex does not change during the upgrade process,
+		// which is necessary when performing the health check for "ready replicas >= desired replicas"
+		// 2. that the total number of Pods (between the 2 monovertices) before and during upgrade remains the same
 		upgradingChildScaleTo := scaleValue.Initial - scaleValue.ScaleTo
 
 		err := unstructured.SetNestedField(upgradingMonoVertexDef.Object, upgradingChildScaleTo, "spec", "scale", "min")

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -252,10 +252,12 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPreUpgrade(
 
 	// There is only one key-value on this map, so we can just iterate over it instead of having to pass the promotedChild name to this func
 	for _, scaleValue := range monoVertexRollout.Status.ProgressiveStatus.PromotedMonoVertexStatus.ScaleValues {
-		// Calculate the upgrading MonoVertex scale value by subtracting the promoted MonoVertex target
-		// scale value from the promoted MonoVertex number of running pods before the upgrade started.
-		// Then, set both min and max to this value. All this ensures that the total number of running
-		// pods does not change during the upgrade process.
+		// Set the upgrading MonoVertex scale.min and scale.max to the number of Pods that were removed
+		// from the promoted MonoVertex.
+		// This ensures:
+		// 1. that the total number of running pods does not change during the upgrade process, which is
+		// necessary when performing the health check for "ready replicas >= desired replicas"
+		// 2. that the number of Pods before and during upgrade remains the same
 		upgradingChildScaleTo := scaleValue.Initial - scaleValue.ScaleTo
 
 		err := unstructured.SetNestedField(upgradingMonoVertexDef.Object, upgradingChildScaleTo, "spec", "scale", "min")

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -40,17 +40,15 @@ func (r *MonoVertexRolloutReconciler) CreateUpgradingChildDefinition(ctx context
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
 // This implements a function of the progressiveController interface
 func (r *MonoVertexRolloutReconciler) AssessUpgradingChild(ctx context.Context, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error) {
-	verifyReplicasFunc := func(existingUpgradingChildDef *unstructured.Unstructured) bool {
+	verifyReplicasFunc := func(existingUpgradingChildDef *unstructured.Unstructured) (bool, error) {
 		desiredReplicas, _, err := unstructured.NestedInt64(existingUpgradingChildDef.Object, "status", "desiredReplicas")
 		if err != nil {
-			// TTODO: log or return error msg
-			return false
+			return false, err
 		}
 
 		readyReplicas, _, err := unstructured.NestedInt64(existingUpgradingChildDef.Object, "status", "readyReplicas")
 		if err != nil {
-			// TTODO: log or return error msg
-			return false
+			return false, err
 		}
 
 		/*
@@ -63,7 +61,7 @@ func (r *MonoVertexRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 			>0(3)			>0(2)		F
 			>0(3)			>0(3)		T
 		*/
-		return readyReplicas >= desiredReplicas
+		return readyReplicas >= desiredReplicas, nil
 	}
 
 	return progressive.AssessUpgradingPipelineType(ctx, existingUpgradingChildDef, verifyReplicasFunc)

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -252,6 +252,10 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPreUpgrade(
 
 	// There is only one key-value on this map, so we can just iterate over it instead of having to pass the promotedChild name to this func
 	for _, scaleValue := range monoVertexRollout.Status.ProgressiveStatus.PromotedMonoVertexStatus.ScaleValues {
+		// Calculate the upgrading MonoVertex scale value by subtracting the promoted MonoVertex target
+		// scale value from the promoted MonoVertex number of running pods before the upgrade started.
+		// Then, set both min and max to this value. All this ensures that the total number of running
+		// pods does not change during the upgrade process.
 		upgradingChildScaleTo := scaleValue.Initial - scaleValue.ScaleTo
 
 		err := unstructured.SetNestedField(upgradingMonoVertexDef.Object, upgradingChildScaleTo, "spec", "scale", "min")

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -86,7 +86,7 @@ It performs the following pre-upgrade operations:
 Parameters:
   - ctx: the context for managing request-scoped values.
   - rolloutObject: the MonoVertexRollout instance
-  - promotedChildDef: the definition of the promoted child as an unstructured object.
+  - promotedMonoVertexDef: the definition of the promoted monovertex as an unstructured object.
   - c: the client used for interacting with the Kubernetes API.
 
 Returns:
@@ -96,11 +96,12 @@ Returns:
 func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPreUpgrade(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
-	promotedChildDef *unstructured.Unstructured,
+	promotedMonoVertexDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPreUpgrade").WithName("MonoVertexRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPreUpgrade").WithName("MonoVertexRollout").
+		WithValues("promotedMonoVertexNamespace", promotedMonoVertexDef.GetNamespace(), "promotedMonoVertexName", promotedMonoVertexDef.GetName())
 
 	numaLogger.Debug("started pre-upgrade processing of promoted monovertex")
 	monoVertexRollout, ok := rolloutObject.(*apiv1.MonoVertexRollout)
@@ -116,7 +117,7 @@ func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPreUpgrade(
 	// retrieves the currently running pods to update the PromotedMonoVertexStatus scaleValues.
 	// This serves to make sure that the pods have been really scaled down before proceeding
 	// with the progressive upgrade.
-	requeue, err := scaleDownPromotedMonoVertex(ctx, monoVertexRollout.Status.ProgressiveStatus.PromotedMonoVertexStatus, promotedChildDef, c)
+	requeue, err := scaleDownPromotedMonoVertex(ctx, monoVertexRollout.Status.ProgressiveStatus.PromotedMonoVertexStatus, promotedMonoVertexDef, c)
 	if err != nil {
 		return true, err
 	}
@@ -129,12 +130,12 @@ func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPreUpgrade(
 /*
 ProcessUpgradingChildPostFailure handles the failure of an upgrading monovertex (anything specific to MonoVertex)
 It performs the following post-failure operations:
-- it scales down the upgrading child to 0 pods if it's not already
+- it scales down the upgrading monovertex to 0 pods if it's not already
 
 Parameters:
   - ctx: the context for managing request-scoped values.
   - rolloutObject: the MonoVertexRollout instance
-  - upgradingChildDef: the definition of the existing upgrading child from the beginning of reconciliation
+  - upgradingMonoVertexDef: the definition of the existing upgrading monovertex from the beginning of reconciliation
   - c: the client used for interacting with the Kubernetes API.
 
 Returns:
@@ -144,17 +145,18 @@ Returns:
 func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPostFailure(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
-	upgradingChildDef *unstructured.Unstructured,
+	upgradingMonoVertexDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("ProcessUpgradingChildPostFailure").WithName("MonoVertexRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessUpgradingChildPostFailure").WithName("MonoVertexRollout").
+		WithValues("upgradingMonoVertexNamespace", upgradingMonoVertexDef.GetNamespace(), "upgradingMonoVertexName", upgradingMonoVertexDef.GetName())
 
 	numaLogger.Debug("started post-failure processing of upgrading monovertex")
 
 	// scale down monovertex to 0 Pods
 	// need to check to see if it's already scaled down before we do this
-	existingSpec := upgradingChildDef.Object["spec"].(map[string]interface{})
+	existingSpec := upgradingMonoVertexDef.Object["spec"].(map[string]interface{})
 
 	existingScaleMin, existingScaleMax, err := getScaleValuesFromMonoVertexSpec(existingSpec)
 	if err != nil {
@@ -169,7 +171,7 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPostFailure(
 	// scale the Pods down to 0
 	min := int64(0)
 	max := int64(0)
-	err = scaleMonoVertex(ctx, upgradingChildDef, &min, &max, c)
+	err = scaleMonoVertex(ctx, upgradingMonoVertexDef, &min, &max, c)
 	if err != nil {
 		return true, err
 	}
@@ -186,7 +188,7 @@ It performs the following post-failure operations:
 func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
-	upgradingChildDef *unstructured.Unstructured,
+	upgradingMonoVertexDef *unstructured.Unstructured,
 	c client.Client,
 ) error {
 
@@ -206,7 +208,7 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 		return err
 	}
 
-	err = scaleMonoVertex(ctx, upgradingChildDef, minPtr, maxPtr, c)
+	err = scaleMonoVertex(ctx, upgradingMonoVertexDef, minPtr, maxPtr, c)
 	if err != nil {
 		return err
 	}
@@ -221,7 +223,7 @@ It performs the following pre-upgrade operations:
 Parameters:
   - ctx: the context for managing request-scoped values.
   - rolloutObject: the MonoVertexRollout instance
-  - upgradingChildDef: the definition of the upgrading child as an unstructured object.
+  - upgradingMonoVertexDef: the definition of the upgrading monovertex as an unstructured object.
   - c: the client used for interacting with the Kubernetes API.
 
 Returns:
@@ -231,11 +233,12 @@ Returns:
 func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPreUpgrade(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
-	upgradingChildDef *unstructured.Unstructured,
+	upgradingMonoVertexDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("ProcessUpgradingChildPreUpgrade").WithName("MonoVertexRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessUpgradingChildPreUpgrade").WithName("MonoVertexRollout").
+		WithValues("upgradingMonoVertexNamespace", upgradingMonoVertexDef.GetNamespace(), "upgradingMonoVertexName", upgradingMonoVertexDef.GetName())
 
 	numaLogger.Debug("started pre-upgrade processing of upgrading monovertex")
 	monoVertexRollout, ok := rolloutObject.(*apiv1.MonoVertexRollout)
@@ -251,7 +254,12 @@ func (r *MonoVertexRolloutReconciler) ProcessUpgradingChildPreUpgrade(
 	for _, scaleValue := range monoVertexRollout.Status.ProgressiveStatus.PromotedMonoVertexStatus.ScaleValues {
 		upgradingChildScaleTo := scaleValue.Initial - scaleValue.ScaleTo
 
-		err := scaleMonoVertex(ctx, upgradingChildDef, &upgradingChildScaleTo, &upgradingChildScaleTo, c)
+		err := unstructured.SetNestedField(upgradingMonoVertexDef.Object, upgradingChildScaleTo, "spec", "scale", "min")
+		if err != nil {
+			return true, err
+		}
+
+		err = unstructured.SetNestedField(upgradingMonoVertexDef.Object, upgradingChildScaleTo, "spec", "scale", "max")
 		if err != nil {
 			return true, err
 		}
@@ -301,7 +309,7 @@ It performs the following post-upgrade operations:
 Parameters:
   - ctx: the context for managing request-scoped values.
   - rolloutObject: the MonoVertexRollout instance
-  - promotedChildDef: the definition of the promoted child as an unstructured object.
+  - promotedMonoVertexDef: the definition of the promoted monovertex as an unstructured object.
   - c: the client used for interacting with the Kubernetes API.
 
 Returns:
@@ -311,11 +319,12 @@ Returns:
 func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPostFailure(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
-	promotedChildDef *unstructured.Unstructured,
+	promotedMonoVertexDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPostUpgrade").WithName("MonoVertexRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPostFailure").WithName("MonoVertexRollout").
+		WithValues("promotedMonoVertexNamespace", promotedMonoVertexDef.GetNamespace(), "promotedMonoVertexName", promotedMonoVertexDef.GetName())
 
 	numaLogger.Debug("started post-failure processing of promoted monovertex")
 
@@ -328,7 +337,7 @@ func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPostFailure(
 		return true, errors.New("unable to perform post-upgrade operations because the rollout does not have promotedChildStatus set")
 	}
 
-	requeue, err := scalePromotedMonoVertexToOriginalValues(ctx, monoVertexRollout.Status.ProgressiveStatus.PromotedMonoVertexStatus, promotedChildDef, c)
+	requeue, err := scalePromotedMonoVertexToOriginalValues(ctx, monoVertexRollout.Status.ProgressiveStatus.PromotedMonoVertexStatus, promotedMonoVertexDef, c)
 	if err != nil {
 		return true, err
 	}
@@ -342,13 +351,13 @@ func (r *MonoVertexRolloutReconciler) ProcessPromotedChildPostFailure(
 scaleDownPromotedMonoVertex scales down the pods of a monovertex to half of the current count if not already scaled down.
 It checks if the monovertex was already scaled down and skips the operation if true.
 The function updates the scale values in the rollout status and adjusts the scale configuration
-of the promoted child definition. It ensures that the scale.min does not exceed the new scale.max.
+of the promoted monovertex definition. It ensures that the scale.min does not exceed the new scale.max.
 Returns a boolean indicating if scaling was performed and an error if any operation fails.
 
 Parameters:
 - ctx: the context for managing request-scoped values.
-- promotedMVStatus: the status of the promoted child in the rollout.
-- promotedChildDef: the unstructured object representing the promoted child definition.
+- promotedMVStatus: the status of the promoted monovertex in the rollout.
+- promotedMonoVertexDef: the unstructured object representing the promoted monovertex definition.
 - c: the Kubernetes client for resource operations.
 
 Returns:
@@ -358,14 +367,15 @@ Returns:
 func scaleDownPromotedMonoVertex(
 	ctx context.Context,
 	promotedMVStatus *apiv1.PromotedMonoVertexStatus,
-	promotedChildDef *unstructured.Unstructured,
+	promotedMonoVertexDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("scaleDownMonoVertex")
+	numaLogger := logger.FromContext(ctx).WithName("scaleDownPromotedMonoVertex").
+		WithValues("promotedMonoVertexNamespace", promotedMonoVertexDef.GetNamespace(), "promotedMonoVertexName", promotedMonoVertexDef.GetName())
 
 	// If the monovertex has been scaled down already, do not perform scaling down operations
-	if promotedMVStatus.AreAllSourceVerticesScaledDown(promotedChildDef.GetName()) {
+	if promotedMVStatus.AreAllSourceVerticesScaledDown(promotedMonoVertexDef.GetName()) {
 		return false, nil
 	}
 
@@ -374,11 +384,11 @@ func scaleDownPromotedMonoVertex(
 		scaleValuesMap = promotedMVStatus.ScaleValues
 	}
 
-	podsList, err := kubernetes.ListPodsMetadataOnly(ctx, c, promotedChildDef.GetNamespace(), fmt.Sprintf(
+	podsList, err := kubernetes.ListPodsMetadataOnly(ctx, c, promotedMonoVertexDef.GetNamespace(), fmt.Sprintf(
 		"%s=%s, %s=%s",
-		common.LabelKeyNumaflowPodMonoVertexName, promotedChildDef.GetName(),
+		common.LabelKeyNumaflowPodMonoVertexName, promotedMonoVertexDef.GetName(),
 		// the vertex name for a monovertex is the same as the monovertex name
-		common.LabelKeyNumaflowPodMonoVertexVertexName, promotedChildDef.GetName(),
+		common.LabelKeyNumaflowPodMonoVertexVertexName, promotedMonoVertexDef.GetName(),
 	))
 	if err != nil {
 		return true, err
@@ -389,9 +399,9 @@ func scaleDownPromotedMonoVertex(
 	// If for the vertex we already set a ScaleTo value, we only need to update the current pods count
 	// to later verify that the pods were actually scaled down.
 	// We want to skip scaling down again.
-	if vertexScaleValues, exist := scaleValuesMap[promotedChildDef.GetName()]; exist {
+	if vertexScaleValues, exist := scaleValuesMap[promotedMonoVertexDef.GetName()]; exist {
 		vertexScaleValues.Current = currentPodsCount
-		scaleValuesMap[promotedChildDef.GetName()] = vertexScaleValues
+		scaleValuesMap[promotedMonoVertexDef.GetName()] = vertexScaleValues
 
 		promotedMVStatus.ScaleValues = scaleValuesMap
 		promotedMVStatus.MarkAllSourceVerticesScaledDown()
@@ -400,36 +410,36 @@ func scaleDownPromotedMonoVertex(
 		return true, nil
 	}
 
-	originalScaleMinMax, err := progressive.ExtractOriginalScaleMinMaxAsJSONString(promotedChildDef.Object, []string{"spec", "scale"})
+	originalScaleMinMax, err := progressive.ExtractOriginalScaleMinMaxAsJSONString(promotedMonoVertexDef.Object, []string{"spec", "scale"})
 	if err != nil {
 		return true, fmt.Errorf("cannot extract the scale min and max values from the promoted monovertex: %w", err)
 	}
 
-	newMin, newMax, err := progressive.CalculateScaleMinMaxValues(promotedChildDef.Object, int(currentPodsCount), []string{"spec", "scale", "min"})
+	newMin, newMax, err := progressive.CalculateScaleMinMaxValues(promotedMonoVertexDef.Object, int(currentPodsCount), []string{"spec", "scale", "min"})
 	if err != nil {
 		return true, fmt.Errorf("cannot calculate the scale min and max values: %+w", err)
 	}
 
 	numaLogger.WithValues(
-		"promotedChildName", promotedChildDef.GetName(),
+		"promotedChildName", promotedMonoVertexDef.GetName(),
 		"currentPodsCount", currentPodsCount,
 		"newMin", newMin,
 		"newMax", newMax,
 		"originalScaleMinMax", originalScaleMinMax,
 	).Debugf("found %d pod(s) for the monovertex, scaling down to %d", currentPodsCount, newMax)
 
-	scaleValuesMap[promotedChildDef.GetName()] = apiv1.ScaleValues{
+	scaleValuesMap[promotedMonoVertexDef.GetName()] = apiv1.ScaleValues{
 		OriginalScaleMinMax: originalScaleMinMax,
 		ScaleTo:             newMax,
 		Current:             currentPodsCount,
 		Initial:             currentPodsCount,
 	}
 
-	if err := scaleMonoVertex(ctx, promotedChildDef, &newMin, &newMax, c); err != nil {
+	if err := scaleMonoVertex(ctx, promotedMonoVertexDef, &newMin, &newMax, c); err != nil {
 		return true, fmt.Errorf("error scaling the existing promoted monovertex to the original scale values: %w", err)
 	}
 
-	numaLogger.WithValues("promotedChildDef", promotedChildDef, "scaleValuesMap", scaleValuesMap).Debug("patched the promoted monovertex with the new scale configuration")
+	numaLogger.WithValues("promotedMonoVertexDef", promotedMonoVertexDef, "scaleValuesMap", scaleValuesMap).Debug("patched the promoted monovertex with the new scale configuration")
 
 	promotedMVStatus.ScaleValues = scaleValuesMap
 	promotedMVStatus.MarkAllSourceVerticesScaledDown()
@@ -437,18 +447,18 @@ func scaleDownPromotedMonoVertex(
 	// Set ScaleValuesRestoredToOriginal to false in case previously set to true and now scaling back down to recover from a previous failure
 	promotedMVStatus.ScaleValuesRestoredToOriginal = false
 
-	return !promotedMVStatus.AreAllSourceVerticesScaledDown(promotedChildDef.GetName()), nil
+	return !promotedMVStatus.AreAllSourceVerticesScaledDown(promotedMonoVertexDef.GetName()), nil
 }
 
 /*
 scalePromotedMonoVertexToOriginalValues scales a monovertex to its original values based on the rollout status.
 This function checks if the monovertex has already been scaled to the original values. If not, it restores the scale values
-from the rollout's promoted child status and updates the Kubernetes resource accordingly.
+from the rollout's promoted monovertex status and updates the Kubernetes resource accordingly.
 
 Parameters:
 - ctx: the context for managing request-scoped values.
-- promotedMVStatus: the status of the promoted child in the rollout, containing scale values.
-- promotedChildDef: the unstructured definition of the promoted child resource.
+- promotedMVStatus: the status of the promoted monovertex in the rollout, containing scale values.
+- promotedMonoVertexDef: the unstructured definition of the promoted monovertex resource.
 - c: the Kubernetes client for resource operations.
 
 Returns:
@@ -458,14 +468,15 @@ Returns:
 func scalePromotedMonoVertexToOriginalValues(
 	ctx context.Context,
 	promotedMVStatus *apiv1.PromotedMonoVertexStatus,
-	promotedChildDef *unstructured.Unstructured,
+	promotedMonoVertexDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("scaleMonoVertexToOriginalValues")
+	numaLogger := logger.FromContext(ctx).WithName("scalePromotedMonoVertexToOriginalValues").
+		WithValues("promotedMonoVertexNamespace", promotedMonoVertexDef.GetNamespace(), "promotedMonoVertexName", promotedMonoVertexDef.GetName())
 
 	// If the monovertex has been scaled back to the original values already, do not restore scaling values again
-	if promotedMVStatus.AreScaleValuesRestoredToOriginal(promotedChildDef.GetName()) {
+	if promotedMVStatus.AreScaleValuesRestoredToOriginal(promotedMonoVertexDef.GetName()) {
 		return false, nil
 	}
 
@@ -473,13 +484,13 @@ func scalePromotedMonoVertexToOriginalValues(
 		return true, errors.New("unable to restore scale values for the promoted monovertex because the rollout does not have promotedChildStatus scaleValues set")
 	}
 
-	patchJson := fmt.Sprintf(`{"spec": {"scale": %s}}`, promotedMVStatus.ScaleValues[promotedChildDef.GetName()].OriginalScaleMinMax)
+	patchJson := fmt.Sprintf(`{"spec": {"scale": %s}}`, promotedMVStatus.ScaleValues[promotedMonoVertexDef.GetName()].OriginalScaleMinMax)
 
-	if err := kubernetes.PatchResource(ctx, c, promotedChildDef, patchJson, k8stypes.MergePatchType); err != nil {
+	if err := kubernetes.PatchResource(ctx, c, promotedMonoVertexDef, patchJson, k8stypes.MergePatchType); err != nil {
 		return true, fmt.Errorf("error scaling the existing promoted monovertex to original values: %w", err)
 	}
 
-	numaLogger.WithValues("promotedChildDef", promotedChildDef).Debug("patched the promoted monovertex with the original scale configuration")
+	numaLogger.WithValues("promotedMonoVertexDef", promotedMonoVertexDef).Debug("patched the promoted monovertex with the original scale configuration")
 
 	promotedMVStatus.ScaleValuesRestoredToOriginal = true
 	promotedMVStatus.AllSourceVerticesScaledDown = false

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -40,6 +40,41 @@ func (r *MonoVertexRolloutReconciler) CreateUpgradingChildDefinition(ctx context
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
 // This implements a function of the progressiveController interface
 func (r *MonoVertexRolloutReconciler) AssessUpgradingChild(ctx context.Context, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error) {
+	// TODO: Create AnalysisRun for assessing the upgrading child if user creates an AnalysisTemplate and references it in their MonoVertexRollout
+	// The following code can serve as a template for what should work:
+	/*analysisRun := &argorolloutsv1.AnalysisRun{}
+	if err := r.client.Get(ctx, client.ObjectKey{Name: existingUpgradingChildDef.GetName(), Namespace: existingUpgradingChildDef.GetNamespace()}, analysisRun); err != nil {
+		if apierrors.IsNotFound(err) {
+			analysisRun := &argorolloutsv1.AnalysisRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      existingUpgradingChildDef.GetName(),
+					Namespace: existingUpgradingChildDef.GetNamespace(),
+					OwnerReferences: []metav1.OwnerReference{
+						*metav1.NewControllerRef(existingUpgradingChildDef, numaflowv1.MonoVertexGroupVersionKind),
+					},
+				},
+				Spec: argorolloutsv1.AnalysisRunSpec{
+					Metrics: []argorolloutsv1.Metric{
+						{
+							Name: "my-metric",
+							Provider: argorolloutsv1.MetricProvider{
+								Prometheus: &argorolloutsv1.PrometheusMetric{
+									Address: "http://prometheus.addon-metricset-ns.svc.cluster.local:9090",
+									Query:   "vector(1) == vector(2)",
+								},
+							},
+						},
+					},
+				},
+			}
+			if err = r.client.Create(ctx, analysisRun); err != nil {
+				return apiv1.AssessmentResultUnknown, err
+			}
+		} else {
+			return apiv1.AssessmentResultUnknown, err
+		}
+	}*/
+
 	return progressive.AssessUpgradingPipelineType(ctx, existingUpgradingChildDef, progressive.AreVertexReplicasReady)
 }
 

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -40,31 +40,7 @@ func (r *MonoVertexRolloutReconciler) CreateUpgradingChildDefinition(ctx context
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
 // This implements a function of the progressiveController interface
 func (r *MonoVertexRolloutReconciler) AssessUpgradingChild(ctx context.Context, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error) {
-	verifyReplicasFunc := func(existingUpgradingChildDef *unstructured.Unstructured) (bool, error) {
-		desiredReplicas, _, err := unstructured.NestedInt64(existingUpgradingChildDef.Object, "status", "desiredReplicas")
-		if err != nil {
-			return false, err
-		}
-
-		readyReplicas, _, err := unstructured.NestedInt64(existingUpgradingChildDef.Object, "status", "readyReplicas")
-		if err != nil {
-			return false, err
-		}
-
-		/*
-			// TTODO: remove after testing
-			desired		ready		outcome
-			0					0				T
-			>0				0				F
-			0					>0			T
-			>0(2)			>0(3)		T
-			>0(3)			>0(2)		F
-			>0(3)			>0(3)		T
-		*/
-		return readyReplicas >= desiredReplicas, nil
-	}
-
-	return progressive.AssessUpgradingPipelineType(ctx, existingUpgradingChildDef, verifyReplicasFunc)
+	return progressive.AssessUpgradingPipelineType(ctx, existingUpgradingChildDef, progressive.AreVertexReplicasReady)
 }
 
 /*

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -98,7 +98,7 @@ It performs the following pre-upgrade operations:
 Parameters:
   - ctx: the context for managing request-scoped values.
   - pipelineRollout: the pipelineRollout
-  - promotedPipelineDef: the definition of the promoted child as an unstructured object.
+  - promotedPipelineDef: the definition of the promoted pipeline as an unstructured object.
   - c: the client used for interacting with the Kubernetes API.
 
 Returns:
@@ -112,7 +112,8 @@ func (r *PipelineRolloutReconciler) ProcessPromotedChildPreUpgrade(
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPreUpgrade").WithName("PipelineRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPreUpgrade").WithName("PipelineRollout").
+		WithValues("promotedPipelineNamespace", promotedPipelineDef.GetNamespace(), "promotedPipelineName", promotedPipelineDef.GetName())
 
 	numaLogger.Debug("started pre-upgrade processing of promoted pipeline")
 	pipelineRO, ok := pipelineRollout.(*apiv1.PipelineRollout)
@@ -139,14 +140,14 @@ func (r *PipelineRolloutReconciler) ProcessPromotedChildPreUpgrade(
 }
 
 /*
-ProcessPromotedChildPostFailure handles the post-upgrade processing of the promoted pipeline after the "upgrading" child has failed.
+ProcessPromotedChildPostFailure handles the post-upgrade processing of the promoted pipeline after the "upgrading" pipeline has failed.
 It performs the following post-upgrade operations:
 - it restores the promoted pipeline source vertices scale values to the original values retrieved from the rollout status.
 
 Parameters:
   - ctx: the context for managing request-scoped values.
   - pipelineRollout: the PipelineRollout instance
-  - promotedPipelineDef: the definition of the promoted child as an unstructured object.
+  - promotedPipelineDef: the definition of the promoted pipeline as an unstructured object.
   - c: the client used for interacting with the Kubernetes API.
 
 Returns:
@@ -160,7 +161,8 @@ func (r *PipelineRolloutReconciler) ProcessPromotedChildPostFailure(
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPostUpgrade").WithName("PipelineRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessPromotedChildPostFailure").WithName("PipelineRollout").
+		WithValues("promotedPipelineNamespace", promotedPipelineDef.GetNamespace(), "promotedPipelineName", promotedPipelineDef.GetName())
 
 	numaLogger.Debug("started post-failure processing of promoted pipeline")
 
@@ -186,11 +188,12 @@ func (r *PipelineRolloutReconciler) ProcessPromotedChildPostFailure(
 func (r *PipelineRolloutReconciler) ProcessUpgradingChildPostFailure(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
-	upgradingChildDef *unstructured.Unstructured,
+	upgradingPipelineDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("ProcessUpgradingChildPostFailure").WithName("PipelineRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessUpgradingChildPostFailure").WithName("PipelineRollout").
+		WithValues("upgradingPipelineNamespace", upgradingPipelineDef.GetNamespace(), "upgradingPipelineName", upgradingPipelineDef.GetName())
 
 	numaLogger.Debug("started post-failure processing of upgrading pipeline")
 
@@ -204,7 +207,7 @@ func (r *PipelineRolloutReconciler) ProcessUpgradingChildPostFailure(
 func (r *PipelineRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
-	upgradingChildDef *unstructured.Unstructured,
+	upgradingPipelineDef *unstructured.Unstructured,
 	c client.Client,
 ) error {
 
@@ -220,7 +223,7 @@ It performs the following pre-upgrade operations:
 Parameters:
   - ctx: the context for managing request-scoped values.
   - rolloutObject: the PipelineRollout instance
-  - upgradingChildDef: the definition of the upgrading child as an unstructured object.
+  - upgradingPipelineDef: the definition of the upgrading pipeline as an unstructured object.
   - c: the client used for interacting with the Kubernetes API.
 
 Returns:
@@ -230,11 +233,12 @@ Returns:
 func (r *PipelineRolloutReconciler) ProcessUpgradingChildPreUpgrade(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,
-	upgradingChildDef *unstructured.Unstructured,
+	upgradingPipelineDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("ProcessUpgradingChildPreUpgrade").WithName("PipelineRollout")
+	numaLogger := logger.FromContext(ctx).WithName("ProcessUpgradingChildPreUpgrade").WithName("PipelineRollout").
+		WithValues("upgradingPipelineNamespace", upgradingPipelineDef.GetNamespace(), "upgradingPipelineName", upgradingPipelineDef.GetName())
 
 	numaLogger.Debug("started pre-upgrade processing of upgrading pipeline")
 	pipelineRollout, ok := rolloutObject.(*apiv1.PipelineRollout)
@@ -246,14 +250,14 @@ func (r *PipelineRolloutReconciler) ProcessUpgradingChildPreUpgrade(
 		return true, errors.New("unable to perform pre-upgrade operations because the rollout does not have promotedChildStatus set")
 	}
 
-	// TODO: create and implement scalePipelineVertex func
+	// TODO: create and implement updatePipelineVertexDefScale func
 	// CONSIDERATIONS:
 	// - how to scale vertices based on their type (source, sink, UDF)?
 	// - decide if min and max should be set to the same value or different values
 	// for vertexName, scaleValue := range pipelineRollout.Status.ProgressiveStatus.PromotedPipelineStatus.ScaleValues {
-	// 	upgradingChildVertexScaleTo := scaleValue.Initial - scaleValue.ScaleTo
+	// 	upgradingPipelineVertexScaleTo := scaleValue.Initial - scaleValue.ScaleTo
 
-	// 	err := scalePipelineVertex(ctx, upgradingChildDef, vertexName, &upgradingChildVertexScaleTo, &upgradingChildVertexScaleTo, c)
+	// 	err := updatePipelineVertexDefScale(ctx, upgradingPipelineDef, vertexName, &upgradingPipelineVertexScaleTo, &upgradingPipelineVertexScaleTo)
 	// 	if err != nil {
 	// 		return true, err
 	// 	}
@@ -268,12 +272,12 @@ func (r *PipelineRolloutReconciler) ProcessUpgradingChildPreUpgrade(
 scaleDownPipelineSourceVertices scales down the source vertices pods of a pipeline to half of the current count if not already scaled down.
 It checks if all source vertices are already scaled down and skips the operation if true.
 The function updates the scale values in the rollout status and adjusts the scale configuration
-of the promoted child definition. It ensures that the scale.min does not exceed the new scale.max.
+of the promoted pipeline definition. It ensures that the scale.min does not exceed the new scale.max.
 
 Parameters:
 - ctx: the context for managing request-scoped values.
-- promotedPipelineStatus: the status of the promoted child in the rollout.
-- promotedPipelineDef: the unstructured object representing the promoted child definition.
+- promotedPipelineStatus: the status of the promoted pipeline in the rollout.
+- promotedPipelineDef: the unstructured object representing the promoted pipeline definition.
 - c: the Kubernetes client for resource operations.
 
 Returns:
@@ -287,7 +291,8 @@ func scaleDownPipelineSourceVertices(
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("scaleDownPipelineSourceVertices")
+	numaLogger := logger.FromContext(ctx).WithName("scaleDownPipelineSourceVertices").
+		WithValues("promotedPipelineNamespace", promotedPipelineDef.GetNamespace(), "promotedPipelineName", promotedPipelineDef.GetName())
 
 	// If the pipeline source vertices have been scaled down already, do not perform scaling down operations
 	if promotedPipelineStatus.AreAllSourceVerticesScaledDown(promotedPipelineDef.GetName()) {
@@ -407,12 +412,12 @@ func scaleDownPipelineSourceVertices(
 /*
 scalePipelineSourceVerticesToOriginalValues scales the source vertices of a pipeline to their original values based on the rollout status.
 This function checks if the pipeline source vertices have already been scaled to the original values. If not, it restores the scale values
-from the rollout's promoted child status and updates the Kubernetes resource accordingly.
+from the rollout's promoted pipeline status and updates the Kubernetes resource accordingly.
 
 Parameters:
 - ctx: the context for managing request-scoped values.
-- promotedPipelineStatus: the status of the promoted child in the rollout, containing scale values.
-- promotedPipelineDef: the unstructured definition of the promoted child resource.
+- promotedPipelineStatus: the status of the promoted pipeline in the rollout, containing scale values.
+- promotedPipelineDef: the unstructured definition of the promoted pipeline resource.
 - c: the Kubernetes client for resource operations.
 
 Returns:
@@ -426,7 +431,8 @@ func scalePipelineSourceVerticesToOriginalValues(
 	c client.Client,
 ) (bool, error) {
 
-	numaLogger := logger.FromContext(ctx).WithName("scalePipelineSourceVerticesToOriginalValues")
+	numaLogger := logger.FromContext(ctx).WithName("scalePipelineSourceVerticesToOriginalValues").
+		WithValues("promotedPipelineNamespace", promotedPipelineDef.GetNamespace(), "promotedPipelineName", promotedPipelineDef.GetName())
 
 	// If all the pipeline source vertices have been scaled back to the original values already, do not restore scaling values again
 	if promotedPipelineStatus.AreScaleValuesRestoredToOriginal(promotedPipelineDef.GetName()) {

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -58,7 +58,12 @@ func (r *PipelineRolloutReconciler) CreateUpgradingChildDefinition(ctx context.C
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
 // This implements a function of the progressiveController interface
 func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error) {
-	return progressive.AssessUpgradingPipelineType(ctx, existingUpgradingChildDef)
+	verifyReplicasFunc := func(existingUpgradingChildDef *unstructured.Unstructured) bool {
+		// TTODO: need to verify that readyReplicas >= desiredReplicas for every pipeline vertex
+		return true
+	}
+
+	return progressive.AssessUpgradingPipelineType(ctx, existingUpgradingChildDef, verifyReplicasFunc)
 }
 
 /*

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -247,6 +247,9 @@ func (r *PipelineRolloutReconciler) ProcessUpgradingChildPreUpgrade(
 	}
 
 	// TODO: create and implement scalePipelineVertex func
+	// CONSIDERATIONS:
+	// - how to scale vertices based on their type (source, sink, UDF)?
+	// - decide if min and max should be set to the same value or different values
 	// for vertexName, scaleValue := range pipelineRollout.Status.ProgressiveStatus.PromotedPipelineStatus.ScaleValues {
 	// 	upgradingChildVertexScaleTo := scaleValue.Initial - scaleValue.ScaleTo
 

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -67,11 +67,8 @@ func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, ex
 			return false, err
 		}
 
-		if verticesList == nil || len(verticesList.Items) == 0 {
-			// TTODO: decide what to return
-			return false, errors.New("there should be at least 1 vertex in a pipeline")
-			// OR
-			// return true, nil
+		if verticesList == nil {
+			return false, errors.New("the pipeline vertices list is nil, this should not occur")
 		}
 
 		areAllVerticesReplicasReady := true

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -58,9 +58,9 @@ func (r *PipelineRolloutReconciler) CreateUpgradingChildDefinition(ctx context.C
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
 // This implements a function of the progressiveController interface
 func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error) {
-	verifyReplicasFunc := func(existingUpgradingChildDef *unstructured.Unstructured) bool {
+	verifyReplicasFunc := func(existingUpgradingChildDef *unstructured.Unstructured) (bool, error) {
 		// TTODO: need to verify that readyReplicas >= desiredReplicas for every pipeline vertex
-		return true
+		return true, nil
 	}
 
 	return progressive.AssessUpgradingPipelineType(ctx, existingUpgradingChildDef, verifyReplicasFunc)

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -213,6 +213,55 @@ func (r *PipelineRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 }
 
 /*
+ProcessUpgradingChildPreUpgrade handles the pre-upgrade processing of an upgrading pipeline.
+It performs the following pre-upgrade operations:
+- it uses the promoted rollout status scale values to calculate the upgrading pipeline scale min and max for each vertex.
+
+Parameters:
+  - ctx: the context for managing request-scoped values.
+  - rolloutObject: the PipelineRollout instance
+  - upgradingChildDef: the definition of the upgrading child as an unstructured object.
+  - c: the client used for interacting with the Kubernetes API.
+
+Returns:
+  - A boolean indicating whether we should requeue.
+  - An error if any issues occur during processing.
+*/
+func (r *PipelineRolloutReconciler) ProcessUpgradingChildPreUpgrade(
+	ctx context.Context,
+	rolloutObject progressive.ProgressiveRolloutObject,
+	upgradingChildDef *unstructured.Unstructured,
+	c client.Client,
+) (bool, error) {
+
+	numaLogger := logger.FromContext(ctx).WithName("ProcessUpgradingChildPreUpgrade").WithName("PipelineRollout")
+
+	numaLogger.Debug("started pre-upgrade processing of upgrading pipeline")
+	pipelineRollout, ok := rolloutObject.(*apiv1.PipelineRollout)
+	if !ok {
+		return true, fmt.Errorf("unexpected type for ProgressiveRolloutObject: %+v; can't process upgrading pipeline pre-upgrade", rolloutObject)
+	}
+
+	if pipelineRollout.Status.ProgressiveStatus.PromotedPipelineStatus == nil {
+		return true, errors.New("unable to perform pre-upgrade operations because the rollout does not have promotedChildStatus set")
+	}
+
+	// TODO: create and implement scalePipelineVertex func
+	// for vertexName, scaleValue := range pipelineRollout.Status.ProgressiveStatus.PromotedPipelineStatus.ScaleValues {
+	// 	upgradingChildVertexScaleTo := scaleValue.Initial - scaleValue.ScaleTo
+
+	// 	err := scalePipelineVertex(ctx, upgradingChildDef, vertexName, &upgradingChildVertexScaleTo, &upgradingChildVertexScaleTo, c)
+	// 	if err != nil {
+	// 		return true, err
+	// 	}
+	// }
+
+	numaLogger.Debug("completed pre-upgrade processing of upgrading pipeline")
+
+	return false, nil
+}
+
+/*
 scaleDownPipelineSourceVertices scales down the source vertices pods of a pipeline to half of the current count if not already scaled down.
 It checks if all source vertices are already scaled down and skips the operation if true.
 The function updates the scale values in the rollout status and adjusts the scale configuration
@@ -290,6 +339,15 @@ func scaleDownPipelineSourceVertices(
 			// to later verify that the pods were actually scaled down.
 			// We want to skip scaling down again.
 			if vertexScaleValues, exist := scaleValuesMap[vertexName]; exist {
+
+				// If OriginalScaleMinMax is empty, it means this is the first time the upgrading process
+				// has been executed and we can initialize status values.
+				// In this case, we set the Initial value to the original running pods count.
+				// We only want to set this value one time at the beginning of the upgrade process.
+				if vertexScaleValues.OriginalScaleMinMax == "" {
+					vertexScaleValues.Initial = actualPodsCount
+				}
+
 				vertexScaleValues.Actual = actualPodsCount
 				scaleValuesMap[vertexName] = vertexScaleValues
 

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -593,16 +593,5 @@ func AreVertexReplicasReady(existingUpgradingChildDef *unstructured.Unstructured
 		return false, err
 	}
 
-	/*
-		TTODO: remove after testing
-
-		desired		ready		outcome
-		0					0				T
-		>0				0				F
-		0					>0			T
-		>0(2)			>0(3)		T
-		>0(3)			>0(2)		F
-		>0(3)			>0(3)		T
-	*/
 	return readyReplicas >= desiredReplicas, nil
 }

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -406,7 +406,7 @@ func AssessUpgradingPipelineType(
 
 	numaLogger.
 		WithValues("namespace", existingUpgradingChildDef.GetNamespace(), "name", existingUpgradingChildDef.GetName()).
-		Debugf("Upgrading child is in phase %s, conditions healthy=%t", upgradingObjectStatus.Phase, healthyConditions)
+		Debugf("Upgrading child is in phase %s, conditions healthy=%t, ready replicas match desired replicas=%t", upgradingObjectStatus.Phase, healthyConditions, healthyReplicas)
 
 	if upgradingObjectStatus.Phase == "Running" && healthyConditions && healthyReplicas {
 		return apiv1.AssessmentResultSuccess, nil

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -384,7 +384,7 @@ func processUpgradingChild(
 func AssessUpgradingPipelineType(
 	ctx context.Context,
 	existingUpgradingChildDef *unstructured.Unstructured,
-	verifyReplicasFunc func(existingUpgradingChildDef *unstructured.Unstructured) bool,
+	verifyReplicasFunc func(existingUpgradingChildDef *unstructured.Unstructured) (bool, error),
 ) (apiv1.AssessmentResult, error) {
 
 	numaLogger := logger.FromContext(ctx)
@@ -396,7 +396,10 @@ func AssessUpgradingPipelineType(
 
 	healthyConditions := checkChildConditions(&upgradingObjectStatus)
 
-	healthyReplicas := verifyReplicasFunc(existingUpgradingChildDef)
+	healthyReplicas, err := verifyReplicasFunc(existingUpgradingChildDef)
+	if err != nil {
+		return apiv1.AssessmentResultUnknown, err
+	}
 
 	numaLogger.
 		WithValues("namespace", existingUpgradingChildDef.GetNamespace(), "name", existingUpgradingChildDef.GetName()).

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -571,3 +571,38 @@ func ExtractOriginalScaleMinMaxAsJSONString(object map[string]any, pathToScale [
 
 	return string(jsonBytes), nil
 }
+
+/*
+AreVertexReplicasReady checks if the number of ready replicas of a vertex matches or exceeds the desired replicas.
+
+Parameters:
+  - existingUpgradingChildDef: An unstructured object representing the vertex whose replica status is being checked.
+
+Returns:
+  - A boolean indicating whether the ready replicas are sufficient.
+  - An error if there is an issue retrieving the replica counts.
+*/
+func AreVertexReplicasReady(existingUpgradingChildDef *unstructured.Unstructured) (bool, error) {
+	desiredReplicas, _, err := unstructured.NestedInt64(existingUpgradingChildDef.Object, "status", "desiredReplicas")
+	if err != nil {
+		return false, err
+	}
+
+	readyReplicas, _, err := unstructured.NestedInt64(existingUpgradingChildDef.Object, "status", "readyReplicas")
+	if err != nil {
+		return false, err
+	}
+
+	/*
+		TTODO: remove after testing
+
+		desired		ready		outcome
+		0					0				T
+		>0				0				F
+		0					>0			T
+		>0(2)			>0(3)		T
+		>0(3)			>0(2)		F
+		>0(3)			>0(3)		T
+	*/
+	return readyReplicas >= desiredReplicas, nil
+}

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -530,3 +530,102 @@ func Test_ExtractOriginalScaleMinMaxAsJSONString(t *testing.T) {
 		})
 	}
 }
+
+func Test_AreVertexReplicasReady(t *testing.T) {
+	testCases := []struct {
+		name            string
+		desiredReplicas *int64
+		readyReplicas   *int64
+		expectedResult  bool
+	}{
+		{
+			name:            "desired = 0, ready = 0",
+			desiredReplicas: ptr.To(int64(0)),
+			readyReplicas:   ptr.To(int64(0)),
+			expectedResult:  true,
+		},
+		{
+			name:            "desired > 0, ready = 0",
+			desiredReplicas: ptr.To(int64(3)),
+			readyReplicas:   ptr.To(int64(0)),
+			expectedResult:  false,
+		},
+		{
+			name:            "desired = 0, ready > 0",
+			desiredReplicas: ptr.To(int64(0)),
+			readyReplicas:   ptr.To(int64(3)),
+			expectedResult:  true,
+		},
+		{
+			name:            "desired > 0, ready > 0, desired < ready",
+			desiredReplicas: ptr.To(int64(2)),
+			readyReplicas:   ptr.To(int64(3)),
+			expectedResult:  true,
+		},
+		{
+			name:            "desired > 0, ready > 0, desired > ready",
+			desiredReplicas: ptr.To(int64(3)),
+			readyReplicas:   ptr.To(int64(2)),
+			expectedResult:  false,
+		},
+		{
+			name:            "desired > 0, ready > 0, desired = ready",
+			desiredReplicas: ptr.To(int64(3)),
+			readyReplicas:   ptr.To(int64(3)),
+			expectedResult:  true,
+		},
+		{
+			name:            "desired = nil, ready = nil",
+			desiredReplicas: nil,
+			readyReplicas:   nil,
+			expectedResult:  true,
+		},
+		{
+			name:            "desired = nil, ready = 0",
+			desiredReplicas: nil,
+			readyReplicas:   ptr.To(int64(0)),
+			expectedResult:  true,
+		},
+		{
+			name:            "desired = 0, ready = nil",
+			desiredReplicas: ptr.To(int64(0)),
+			readyReplicas:   nil,
+			expectedResult:  true,
+		},
+		{
+			name:            "desired = nil, ready > 0",
+			desiredReplicas: nil,
+			readyReplicas:   ptr.To(int64(3)),
+			expectedResult:  true,
+		},
+		{
+			name:            "desired > 0, ready = nil",
+			desiredReplicas: ptr.To(int64(3)),
+			readyReplicas:   nil,
+			expectedResult:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			unstr := &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{},
+				},
+			}
+
+			if tc.desiredReplicas != nil {
+				_ = unstructured.SetNestedField(unstr.Object, *tc.desiredReplicas, "status", "desiredReplicas")
+			}
+
+			if tc.readyReplicas != nil {
+				_ = unstructured.SetNestedField(unstr.Object, *tc.readyReplicas, "status", "readyReplicas")
+			}
+
+			actualResult, actualErr := AreVertexReplicasReady(unstr)
+
+			assert.Nil(t, actualErr)
+			assert.Equal(t, tc.expectedResult, actualResult)
+		})
+	}
+}

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -67,6 +67,10 @@ func (fpc fakeProgressiveController) ProcessUpgradingChildPreForcedPromotion(ctx
 	return nil
 }
 
+func (fpc fakeProgressiveController) ProcessUpgradingChildPreUpgrade(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
+	return false, nil
+}
+
 func Test_processUpgradingChild(t *testing.T) {
 	restConfig, numaflowClientSet, client, _, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)

--- a/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
@@ -52,6 +52,8 @@ type ScaleValues struct {
 	ScaleTo int64 `json:"scaleTo"`
 	// Actual indicates how many pods are actually running for the vertex
 	Actual int64 `json:"actual"`
+	// Initial indicates how many pods were actually running for the vertex at the beginning of the upgrade process
+	Initial int64 `json:"initial"`
 }
 
 // PromotedChildStatus describes the status of the promoted child

--- a/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
@@ -50,9 +50,9 @@ type ScaleValues struct {
 	OriginalScaleMinMax string `json:"originalScaleMinMax"`
 	// ScaleTo indicates how many pods to scale down to
 	ScaleTo int64 `json:"scaleTo"`
-	// Actual indicates how many pods are actually running for the vertex
-	Actual int64 `json:"actual"`
-	// Initial indicates how many pods were actually running for the vertex at the beginning of the upgrade process
+	// Current indicates how many pods are currently running for the vertex
+	Current int64 `json:"current"`
+	// Initial indicates how many pods were initially running for the vertex at the beginning of the upgrade process
 	Initial int64 `json:"initial"`
 }
 
@@ -126,7 +126,7 @@ func (pcs *PromotedPipelineTypeStatus) MarkAllSourceVerticesScaledDown() {
 
 	allScaledDown := true
 	for _, sv := range pcs.ScaleValues {
-		if sv.Actual > sv.ScaleTo {
+		if sv.Current > sv.ScaleTo {
 			allScaledDown = false
 			break
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #639 

### Modifications

- Added a function to check if the ready replicas are at least equal to the desired replicas for a MonoVertex and Pipeline vertices. This function is used to perform the child health assessment during progressive upgrades.
- Implemented the upgrading child scaling (for MonoVertex only) to result in having a total number of running pods during upgrade that is equal to the number of running pods prior to the start of the progressive upgrade. This is performed by reducing the promoted MonoVertex running pods by half and applying the remaining pods (initially running pods - desired scale value on promoted MonoVertex) to the upgrading MonoVertex.

### Verification

- Video MonoVertex Tests (no upgrading child scaling): https://drive.google.com/file/d/17rwrbrezUxSYu5Wp-rO1m4tjJVEpOd74/view?usp=drive_link
- Video Pipeline Tests (no upgrading child scaling): https://drive.google.com/file/d/17qVAdcpr9eSLaennBRCsYEq80gcZySYg/view?usp=drive_link
- Video MonoVertex Tests (with upgrading child scaling): https://drive.google.com/file/d/183w2PPyhg0lF2LbgQyAtOe-3TLzbMQBz/view?usp=drive_link
- Created new unit tests for the main function that checks replicas.

### Backward incompatibilities

None.