### PR TITLE
fix: update streamPodLogs func to not fail when pod isn't found

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -266,12 +266,12 @@ func streamPodLogs(ctx context.Context, client clientgo.Interface, namespace, po
 				return true, nil
 			}
 
-			fmt.Printf("Got error %v, retrying.\n", err)
 			return false, nil
 		})
 
 		if err != nil {
-			log.Fatalf("Failed to stream pod %q logs: %v", podName, err)
+			fmt.Printf("Failed to stream pod %q logs: %v", podName, err)
+			return
 		}
 		defer func() { _ = stream.Close() }()
 

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -269,6 +269,7 @@ func streamPodLogs(ctx context.Context, client clientgo.Interface, namespace, po
 		})
 
 		if err != nil {
+			// TODO: log this as an error using a logger library
 			fmt.Printf("Failed to stream pod %q logs: %v", podName, err)
 			return
 		}

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

Quick fix to make not finding a pod while streaming logs no longer a fatal error. This pod can simply be skipped over and goroutine killed when this occurs.

Was the result of a flakey test which tried to stream a pod that was quickly deleted.

### Verification

Running tests on CI.

### Backward incompatibilities

N/A
