### PR TITLE
fix: scale upgrading MonoVertex to desired scale values once deemed successful for promotion

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -118,15 +118,6 @@ func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPostSuccess(
 	return nil
 }
 
-func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
-	ctx context.Context,
-	rolloutObject progressive.ProgressiveRolloutObject,
-	upgradingChildDef *unstructured.Unstructured,
-	c client.Client,
-) error {
-	return nil
-}
-
 func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPreUpgrade(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -109,6 +109,15 @@ func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPostFailure(
 	return false, nil
 }
 
+func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPostSuccess(
+	ctx context.Context,
+	rolloutObject progressive.ProgressiveRolloutObject,
+	upgradingChildDef *unstructured.Unstructured,
+	c client.Client,
+) error {
+	return nil
+}
+
 func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -215,6 +215,17 @@ func (r *PipelineRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
 	return nil
 }
 
+func (r *PipelineRolloutReconciler) ProcessUpgradingChildPostSuccess(
+	ctx context.Context,
+	rolloutObject progressive.ProgressiveRolloutObject,
+	upgradingMonoVertexDef *unstructured.Unstructured,
+	c client.Client,
+) error {
+
+	// TODO
+	return nil
+}
+
 /*
 ProcessUpgradingChildPreUpgrade handles the pre-upgrade processing of an upgrading pipeline.
 It performs the following pre-upgrade operations:

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -204,17 +204,6 @@ func (r *PipelineRolloutReconciler) ProcessUpgradingChildPostFailure(
 	return false, nil
 }
 
-func (r *PipelineRolloutReconciler) ProcessUpgradingChildPreForcedPromotion(
-	ctx context.Context,
-	rolloutObject progressive.ProgressiveRolloutObject,
-	upgradingPipelineDef *unstructured.Unstructured,
-	c client.Client,
-) error {
-
-	// TODO
-	return nil
-}
-
 func (r *PipelineRolloutReconciler) ProcessUpgradingChildPostSuccess(
 	ctx context.Context,
 	rolloutObject progressive.ProgressiveRolloutObject,

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -58,7 +58,10 @@ type progressiveController interface {
 	// ProcessUpgradingChildPostFailure performs operations on the upgrading child after the upgrade fails (just the operations which are unique to this Kind)
 	ProcessUpgradingChildPostFailure(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) (bool, error)
 
-	// ProcessUpgradingChildPreForcedPromotion performs operations on the upgrading child after the upgrade succeeds (just the operations which are unique to this Kind)
+	// ProcessUpgradingChildPostSuccess performs operations on the upgrading child after the upgrade succeeds (just the operations which are unique to this Kind)
+	ProcessUpgradingChildPostSuccess(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) error
+
+	// ProcessUpgradingChildPreForcedPromotion performs operations on the upgrading child after the upgrade succeeds due to a "forced promotion" (just the operations which are unique to this Kind)
 	ProcessUpgradingChildPreForcedPromotion(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) error
 
 	// ProcessUpgradingChildPreUpgrade performs operations on the upgrading child prior to the upgrade (just the operations which are unique to this Kind)
@@ -264,7 +267,7 @@ func processUpgradingChild(
 			return false, false, 0, err
 		}
 
-		done, err := declareSuccess(ctx, rolloutObject, existingPromotedChildDef, existingUpgradingChildDef, childStatus, c)
+		done, err := declareSuccess(ctx, rolloutObject, controller, existingPromotedChildDef, existingUpgradingChildDef, childStatus, c)
 		if err != nil || done {
 			return done, false, 0, err
 		} else {
@@ -360,7 +363,7 @@ func processUpgradingChild(
 
 	case apiv1.AssessmentResultSuccess:
 		if childStatus.CanDeclareSuccess() {
-			done, err := declareSuccess(ctx, rolloutObject, existingPromotedChildDef, existingUpgradingChildDef, childStatus, c)
+			done, err := declareSuccess(ctx, rolloutObject, controller, existingPromotedChildDef, existingUpgradingChildDef, childStatus, c)
 			if err != nil || done {
 				return done, false, 0, err
 			} else {
@@ -438,6 +441,7 @@ Returns:
 func declareSuccess(
 	ctx context.Context,
 	rolloutObject ProgressiveRolloutObject,
+	controller progressiveController,
 	existingPromotedChildDef, existingUpgradingChildDef *unstructured.Unstructured,
 	childStatus *apiv1.UpgradingChildStatus,
 	c client.Client,
@@ -445,10 +449,15 @@ func declareSuccess(
 
 	numaLogger := logger.FromContext(ctx)
 
+	err := controller.ProcessUpgradingChildPostSuccess(ctx, rolloutObject, existingUpgradingChildDef, c)
+	if err != nil {
+		return false, err
+	}
+
 	// Label the new child as promoted and then remove the label from the old one
 	numaLogger.WithValues("old child", existingPromotedChildDef.GetName(), "new child", existingUpgradingChildDef.GetName()).Debug("replacing 'promoted' child")
 	reasonSuccess := common.LabelValueProgressiveSuccess
-	err := ctlrcommon.UpdateUpgradeState(ctx, c, common.LabelValueUpgradePromoted, &reasonSuccess, existingUpgradingChildDef)
+	err = ctlrcommon.UpdateUpgradeState(ctx, c, common.LabelValueUpgradePromoted, &reasonSuccess, existingUpgradingChildDef)
 	if err != nil {
 		return false, err
 	}
@@ -464,8 +473,7 @@ func declareSuccess(
 	rolloutObject.GetRolloutStatus().MarkDeployed(rolloutObject.GetRolloutObjectMeta().Generation)
 
 	// we're done
-	return true, err
-
+	return true, nil
 }
 
 // return:

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -61,9 +61,6 @@ type progressiveController interface {
 	// ProcessUpgradingChildPostSuccess performs operations on the upgrading child after the upgrade succeeds (just the operations which are unique to this Kind)
 	ProcessUpgradingChildPostSuccess(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) error
 
-	// ProcessUpgradingChildPreForcedPromotion performs operations on the upgrading child after the upgrade succeeds due to a "forced promotion" (just the operations which are unique to this Kind)
-	ProcessUpgradingChildPreForcedPromotion(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) error
-
 	// ProcessUpgradingChildPreUpgrade performs operations on the upgrading child prior to the upgrade (just the operations which are unique to this Kind)
 	ProcessUpgradingChildPreUpgrade(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) (bool, error)
 }
@@ -261,11 +258,6 @@ func processUpgradingChild(
 	// check for Force Promote set in Progressive strategy to force success logic
 	if rolloutObject.GetProgressiveStrategy().ForcePromote {
 		childStatus.ForcedSuccess = true
-
-		err = controller.ProcessUpgradingChildPreForcedPromotion(ctx, rolloutObject, existingUpgradingChildDef, c)
-		if err != nil {
-			return false, false, 0, err
-		}
 
 		done, err := declareSuccess(ctx, rolloutObject, controller, existingPromotedChildDef, existingUpgradingChildDef, childStatus, c)
 		if err != nil || done {

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -67,10 +67,6 @@ func (fpc fakeProgressiveController) ProcessUpgradingChildPostSuccess(ctx contex
 	return nil
 }
 
-func (fpc fakeProgressiveController) ProcessUpgradingChildPreForcedPromotion(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) error {
-	return nil
-}
-
 func (fpc fakeProgressiveController) ProcessUpgradingChildPreUpgrade(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
 	return false, nil
 }

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -59,11 +59,15 @@ func (fpc fakeProgressiveController) ProcessPromotedChildPostFailure(ctx context
 	return false, nil
 }
 
-func (fpc fakeProgressiveController) ProcessUpgradingChildPostFailure(ctx context.Context, rolloutObject ProgressiveRolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
+func (fpc fakeProgressiveController) ProcessUpgradingChildPostFailure(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) (bool, error) {
 	return false, nil
 }
 
-func (fpc fakeProgressiveController) ProcessUpgradingChildPreForcedPromotion(ctx context.Context, rolloutObject ProgressiveRolloutObject, promotedChildDef *unstructured.Unstructured, c client.Client) error {
+func (fpc fakeProgressiveController) ProcessUpgradingChildPostSuccess(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) error {
+	return nil
+}
+
+func (fpc fakeProgressiveController) ProcessUpgradingChildPreForcedPromotion(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) error {
 	return nil
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Scale the upgrading MonoVertex deemed successful for promotion to the Rollout scale values immediately after the assessment has been completed.

### Verification

https://drive.google.com/file/d/187BIbKxIyzDhk5Jw59Uf6quMuVErXzJy/view?usp=drive_link

### Backward incompatibilities

None
