### PR TITLE
feat: keep child index from getting too high, for readability

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -155,7 +155,13 @@ var (
 		Version:  NumaflowAPIVersion,
 		Resource: "interstepbufferservices",
 	}
+)
 
+const (
 	// DefaultRequeueDelay indicates the default requeue time (in seconds) used by Reconcilers
 	DefaultRequeueDelay = 20 * time.Second
+
+	// MaxNameCount represents the maximum index value used as a suffix for a given child Numaflow resource
+	// (after reaching this value, we roll over back to 0)
+	MaxNameCount int32 = 9999
 )

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -163,5 +163,5 @@ const (
 
 	// MaxNameCount represents the maximum index value used as a suffix for a given child Numaflow resource
 	// (after reaching this value, we roll over back to 0)
-	MaxNameCount int32 = 9999
+	MaxNameCount int32 = 999
 )

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -931,7 +931,14 @@ func (r *ISBServiceRolloutReconciler) IncrementChildCount(ctx context.Context, r
 		}
 	}
 
-	err := r.updateCurrentChildCount(ctx, rolloutObject, currentNameCount+1)
+	// For readability of the InterstepBufferService name, keep the count from getting too high by rolling around back to 0
+	// TODO: consider handling the extremely rare case that user still has a "promoted" child of index 0 running
+	nextNameCount := currentNameCount + 1
+	if nextNameCount > common.MaxNameCount {
+		nextNameCount = 0
+	}
+
+	err := r.updateCurrentChildCount(ctx, rolloutObject, nextNameCount)
 	if err != nil {
 		return int32(0), err
 	}

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -726,8 +726,14 @@ func (r *MonoVertexRolloutReconciler) IncrementChildCount(ctx context.Context, r
 			return int32(0), err
 		}
 	}
+	// For readability of the monovertex name, keep the count from getting too high by rolling around back to 0
+	// TODO: consider handling the extremely rare case that user still has a "promoted" child of index 0 running
+	nextNameCount := currentNameCount + 1
+	if nextNameCount > common.MaxNameCount {
+		nextNameCount = 0
+	}
 
-	err := r.updateCurrentChildCount(ctx, rolloutObject, currentNameCount+1)
+	err := r.updateCurrentChildCount(ctx, rolloutObject, nextNameCount)
 	if err != nil {
 		return int32(0), err
 	}

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -1057,7 +1057,14 @@ func (r *PipelineRolloutReconciler) IncrementChildCount(ctx context.Context, rol
 		}
 	}
 
-	err := r.updateCurrentChildCount(ctx, rolloutObject, currentNameCount+1)
+	// For readability of the pipeline name, keep the count from getting too high by rolling around back to 0
+	// TODO: consider handling the extremely rare case that user still has a "promoted" child of index 0 running
+	nextNameCount := currentNameCount + 1
+	if nextNameCount > common.MaxNameCount {
+		nextNameCount = 0
+	}
+
+	err := r.updateCurrentChildCount(ctx, rolloutObject, nextNameCount)
 	if err != nil {
 		return int32(0), err
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

Derek requested that we not allow the index suffix on the child name to get too high, for the purpose of readability. Therefore, I am rolling over to 0 after 999. 

I decided not to take any extra precaution that the user isn't already running a child name of "-0" at that time. That would only happen in the very strange case that they did a Progressive update 999 times, each one failing, which would cause the "-0" one to still be there. 

### Verification

Tested isbservicerollout, pipelinerollout, and monovertexrollout by temporarily setting the value as 3 and observing that after multiple progressive updates, after it hit "-3", the next one was "-0".

### Backward incompatibilities

N/A
