### PR TITLE
fix: update when pausing metrics are set to avoid edge case for quick pause showing as a longer pause

### DIFF
--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -706,7 +706,8 @@ func (r *PipelineRolloutReconciler) setChildResourcesPauseCondition(pipelineRoll
 		}
 		reason := fmt.Sprintf("Pipeline%s", string(pipelinePhase))
 		msg := fmt.Sprintf("Pipeline %s", strings.ToLower(string(pipelinePhase)))
-		// if TransitionTime is still before or equal to BeginTime, keep updating Pausing metric
+		// if TransitionTime is before or equal to BeginTime, update Pausing metric
+		// if it's not, then something is wrong and we don't want to make a bad calculation
 		if !pipelineRollout.Status.PauseStatus.LastPauseTransitionTime.After(pipelineRollout.Status.PauseStatus.LastPauseBeginTime.Time) {
 			r.updatePauseMetric(pipelineRollout, pipelinePhase)
 		}
@@ -718,7 +719,8 @@ func (r *PipelineRolloutReconciler) setChildResourcesPauseCondition(pipelineRoll
 		}
 		reason := fmt.Sprintf("Pipeline%s", string(pipelinePhase))
 		msg := fmt.Sprintf("Pipeline %s", strings.ToLower(string(pipelinePhase)))
-		// if EndTime is still before or equal to Begintime, keep updating Paused metric
+		// if EndTime is before or equal to BeginTime, update Paused metric
+		// if it's not, then something is wrong, and we don't want to make a bad calculation
 		if !pipelineRollout.Status.PauseStatus.LastPauseEndTime.After(pipelineRollout.Status.PauseStatus.LastPauseBeginTime.Time) {
 			r.updatePauseMetric(pipelineRollout, pipelinePhase)
 		}

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -703,27 +703,27 @@ func (r *PipelineRolloutReconciler) setChildResourcesPauseCondition(pipelineRoll
 		// if BeginTime hasn't been set yet, we must have just started pausing - set it
 		if pipelineRollout.Status.PauseStatus.LastPauseBeginTime == metav1.NewTime(initTime) || !pipelineRollout.Status.PauseStatus.LastPauseBeginTime.After(pipelineRollout.Status.PauseStatus.LastPauseEndTime.Time) {
 			pipelineRollout.Status.PauseStatus.LastPauseBeginTime = metav1.NewTime(time.Now())
+			r.updatePauseMetric(pipelineRollout, pipelinePhase)
 		}
 		reason := fmt.Sprintf("Pipeline%s", string(pipelinePhase))
 		msg := fmt.Sprintf("Pipeline %s", strings.ToLower(string(pipelinePhase)))
-		r.updatePauseMetric(pipelineRollout, pipelinePhase)
 		pipelineRollout.Status.MarkPipelinePausingOrPaused(reason, msg, pipelineRollout.Generation)
 	} else if pipelinePhase == numaflowv1.PipelinePhasePaused {
 		// if LastPauseTransitionTime hasn't been set yet, we are just starting to enter paused phase - set it to denote end of pausing
 		if pipelineRollout.Status.PauseStatus.LastPauseTransitionTime == metav1.NewTime(initTime) || !pipelineRollout.Status.PauseStatus.LastPauseTransitionTime.After(pipelineRollout.Status.PauseStatus.LastPauseBeginTime.Time) {
 			pipelineRollout.Status.PauseStatus.LastPauseTransitionTime = metav1.NewTime(time.Now())
+			r.updatePauseMetric(pipelineRollout, pipelinePhase)
 		}
 		reason := fmt.Sprintf("Pipeline%s", string(pipelinePhase))
 		msg := fmt.Sprintf("Pipeline %s", strings.ToLower(string(pipelinePhase)))
-		r.updatePauseMetric(pipelineRollout, pipelinePhase)
 		pipelineRollout.Status.MarkPipelinePausingOrPaused(reason, msg, pipelineRollout.Generation)
 	} else {
 		// only set EndTime if BeginTime has been previously set AND EndTime is before/equal to BeginTime
 		// EndTime is either just initialized or the end of a previous pause which is why it will be before the new BeginTime
 		if (pipelineRollout.Status.PauseStatus.LastPauseBeginTime != metav1.NewTime(initTime)) && !pipelineRollout.Status.PauseStatus.LastPauseEndTime.After(pipelineRollout.Status.PauseStatus.LastPauseBeginTime.Time) {
 			pipelineRollout.Status.PauseStatus.LastPauseEndTime = metav1.NewTime(time.Now())
-			r.updatePauseMetric(pipelineRollout, pipelinePhase)
 		}
+		r.updatePauseMetric(pipelineRollout, pipelinePhase)
 		pipelineRollout.Status.MarkPipelineUnpaused(pipelineRollout.Generation)
 	}
 
@@ -736,21 +736,21 @@ func (r *PipelineRolloutReconciler) updatePauseMetric(pipelineRollout *apiv1.Pip
 
 	// if pause is manual, set metrics back to 0
 	if r.isSpecBasedPause(pipelineSpec) {
-		r.setMetric(pipelineRollout.Namespace, pipelineRollout.Name, float64(0), float64(0))
+		r.setPauseMetrics(pipelineRollout.Namespace, pipelineRollout.Name, float64(0), float64(0))
 	} else if pipelinePhase == numaflowv1.PipelinePhasePaused {
 		// if pipeline is Paused, set Paused metric to time duration since last transition time
-		r.setMetric(pipelineRollout.Namespace, pipelineRollout.Name, time.Since(pipelineRollout.Status.PauseStatus.LastPauseTransitionTime.Time).Seconds(), float64(0))
+		r.setPauseMetrics(pipelineRollout.Namespace, pipelineRollout.Name, time.Since(pipelineRollout.Status.PauseStatus.LastPauseTransitionTime.Time).Seconds(), float64(0))
 	} else if pipelinePhase == numaflowv1.PipelinePhasePausing {
 		// if pipeline is Pausing, set Pausing metric to time duration since last pause begin time
-		r.setMetric(pipelineRollout.Namespace, pipelineRollout.Name, float64(0), time.Since(pipelineRollout.Status.PauseStatus.LastPauseBeginTime.Time).Seconds())
+		r.setPauseMetrics(pipelineRollout.Namespace, pipelineRollout.Name, float64(0), time.Since(pipelineRollout.Status.PauseStatus.LastPauseBeginTime.Time).Seconds())
 	} else {
 		// otherwise set both metrics back to 0
-		r.setMetric(pipelineRollout.Namespace, pipelineRollout.Name, float64(0), float64(0))
+		r.setPauseMetrics(pipelineRollout.Namespace, pipelineRollout.Name, float64(0), float64(0))
 	}
 
 }
 
-func (r *PipelineRolloutReconciler) setMetric(namespace, name string, pausedVal, pausingVal float64) {
+func (r *PipelineRolloutReconciler) setPauseMetrics(namespace, name string, pausedVal, pausingVal float64) {
 	r.customMetrics.PipelinePausedSeconds.WithLabelValues(namespace, name).Set(pausedVal)
 	r.customMetrics.PipelinePausingSeconds.WithLabelValues(namespace, name).Set(pausingVal)
 }

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -266,12 +265,13 @@ func streamPodLogs(ctx context.Context, client clientgo.Interface, namespace, po
 				return true, nil
 			}
 
-			fmt.Printf("Got error %v, retrying.\n", err)
 			return false, nil
 		})
 
 		if err != nil {
-			log.Fatalf("Failed to stream pod %q logs: %v", podName, err)
+			// TODO: log this as an error using a logger library
+			fmt.Printf("Failed to stream pod %q logs: %v", podName, err)
+			return
 		}
 		defer func() { _ = stream.Close() }()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes an internal issue.

### Modifications

We were seeing a case where a quick pause for updating the image of a PipelineRollout could cause a resource conflict error when updating the child and result in the pauseStatus of the rollout not being updated properly. This would cause the reported pause metrics to use the previously set status resulting in a much longer pause time than we should expect.

This is fixed by moving where we set the metric to avoid any erroneous values.

### Verification

Testing locally with a long pause and seeing that the metric updates properly.

### Backward incompatibilities

N/A
