### PR TITLE
chore: Run Argo Rollouts when we run Numaplane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,8 @@ start: image
 	./hack/numaflow-controller-def-generator/numaflow-controller-def-generator.sh
 	$(KUBECTL) apply -f $(TEST_MANIFEST_DIR_DEFAULT)/numaplane-ns.yaml
 	$(KUBECTL) kustomize $(TEST_MANIFEST_DIR) | sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/$(IMG):$(BASE_VERSION)/$(IMG):$(VERSION)/' | $(KUBECTL) apply -f -
-
+	$(KUBECTL) apply -f $(TEST_MANIFEST_DIR_DEFAULT)/rollouts-ns.yaml
+	$(KUBECTL) kustomize https://github.com/argoproj/argo-rollouts/manifests/cluster-install?ref=stable | $(KUBECTL) apply -n argo-rollouts -f -
 
 ##@ Build Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ ifeq ($(STRATEGY), progressive)
 TEST_MANIFEST_DIR := $(TEST_PROGRESSIVE_MANIFEST_DIR)
 endif
 
+
+ARGO_ROLLOUTS_PATH ?= https://github.com/argoproj/argo-rollouts/manifests/cluster-install?ref=stable
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -202,7 +205,7 @@ start: image
 	$(KUBECTL) apply -f $(TEST_MANIFEST_DIR_DEFAULT)/numaplane-ns.yaml
 	$(KUBECTL) kustomize $(TEST_MANIFEST_DIR) | sed 's@quay.io/numaproj/@$(IMAGE_NAMESPACE)/@' | sed 's/$(IMG):$(BASE_VERSION)/$(IMG):$(VERSION)/' | $(KUBECTL) apply -f -
 	$(KUBECTL) apply -f $(TEST_MANIFEST_DIR_DEFAULT)/rollouts-ns.yaml
-	$(KUBECTL) kustomize https://github.com/argoproj/argo-rollouts/manifests/cluster-install?ref=stable | $(KUBECTL) apply -n argo-rollouts -f -
+	$(KUBECTL) kustomize $(ARGO_ROLLOUTS_PATH) | $(KUBECTL) apply -n argo-rollouts -f -
 
 ##@ Build Dependencies
 

--- a/tests/manifests/default/kustomization.yaml
+++ b/tests/manifests/default/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../../config/default
-  - https://github.com/argoproj/argo-rollouts/manifests/crds?ref=stable
+  - https://github.com/argoproj/argo-rollouts/manifests/cluster-install?ref=stable
   - ./controller_def_1.4.1.yaml
   - ./controller_def_1.4.2.yaml
   - ./controller_def_1.4.3.yaml

--- a/tests/manifests/default/kustomization.yaml
+++ b/tests/manifests/default/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
   - ../../../config/default
-  - https://github.com/argoproj/argo-rollouts/manifests/cluster-install?ref=stable
+  - https://github.com/argoproj/argo-rollouts/manifests/crds?ref=stable
   - ./controller_def_1.4.1.yaml
   - ./controller_def_1.4.2.yaml
   - ./controller_def_1.4.3.yaml

--- a/tests/manifests/default/kustomization.yaml
+++ b/tests/manifests/default/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 resources:
   - ../../../config/default
-  - https://github.com/argoproj/argo-rollouts/manifests/cluster-install?ref=stable
   - ./controller_def_1.4.1.yaml
   - ./controller_def_1.4.2.yaml
   - ./controller_def_1.4.3.yaml

--- a/tests/manifests/default/rollouts-ns.yaml
+++ b/tests/manifests/default/rollouts-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argo-rollouts


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

Since Numaplane will now require Argo Rollouts, we can run Argo Rollouts whenever we run Numaplane.

This runs argo-rollouts in the "argo-rollouts" namespace, and in a "cluster mode", such that it reconcile from any namespace.


### Verification

standard CI

### Backward incompatibilities

N/A
