### PR TITLE
fix: fix for inline tag on progressive field

### DIFF
--- a/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
@@ -71,68 +71,64 @@ spec:
                 description: PipelineTypeRolloutStrategy specifies the Rollout Strategy
                   for fields shared by Pipeline and MonoVertex
                 properties:
-                  progressive:
-                    description: PipelineTypeProgressiveStrategy specifies the Progressive
-                      Rollout Strategy for fields shared by Pipeline and MonoVertex
+                  analysis:
+                    description: Analysis defines how to perform analysis of health,
+                      outside of basic resource checking
                     properties:
-                      analysis:
-                        description: Analysis defines how to perform analysis of health,
-                          outside of basic resource checking
-                        properties:
-                          args:
-                            description: Arguments can be passed to templates to evaluate
-                              any parameterization
-                            items:
-                              description: AnalysisRunArgument argument to add to
-                                analysisRun
+                      args:
+                        description: Arguments can be passed to templates to evaluate
+                          any parameterization
+                        items:
+                          description: AnalysisRunArgument argument to add to analysisRun
+                          properties:
+                            name:
+                              description: Name argument name
+                              type: string
+                            value:
+                              description: Value a hardcoded value for the argument.
+                                This field is a one of field with valueFrom
+                              type: string
+                            valueFrom:
+                              description: ValueFrom A reference to where the value
+                                is stored. This field is a one of field with valueFrom
                               properties:
-                                name:
-                                  description: Name argument name
-                                  type: string
-                                value:
-                                  description: Value a hardcoded value for the argument.
-                                    This field is a one of field with valueFrom
-                                  type: string
-                                valueFrom:
-                                  description: ValueFrom A reference to where the
-                                    value is stored. This field is a one of field
-                                    with valueFrom
+                                fieldRef:
+                                  description: FieldRef
                                   properties:
-                                    fieldRef:
-                                      description: FieldRef
-                                      properties:
-                                        fieldPath:
-                                          description: 'Required: Path of the field
-                                            to select in the specified API version'
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                    podTemplateHashValue:
-                                      description: PodTemplateHashValue gets the value
-                                        from one of the children ReplicaSet's Pod
-                                        Template Hash
+                                    fieldPath:
+                                      description: 'Required: Path of the field to
+                                        select in the specified API version'
                                       type: string
+                                  required:
+                                  - fieldPath
                                   type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          templates:
-                            description: Templates are used to analyze the AnalysisRun
-                            items:
-                              properties:
-                                clusterScope:
-                                  description: Whether to look for the templateName
-                                    at cluster scope or namespace scope
-                                  type: boolean
-                                templateName:
-                                  description: TemplateName name of template to use
-                                    in AnalysisRun
+                                podTemplateHashValue:
+                                  description: PodTemplateHashValue gets the value
+                                    from one of the children ReplicaSet's Pod Template
+                                    Hash
                                   type: string
                               type: object
-                            type: array
-                        type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      templates:
+                        description: Templates are used to analyze the AnalysisRun
+                        items:
+                          properties:
+                            clusterScope:
+                              description: Whether to look for the templateName at
+                                cluster scope or namespace scope
+                              type: boolean
+                            templateName:
+                              description: TemplateName name of template to use in
+                                AnalysisRun
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  progressive:
+                    properties:
                       assessmentSchedule:
                         description: |-
                           optional string: comma-separated list consisting of:

--- a/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
@@ -76,68 +76,64 @@ spec:
                 description: PipelineTypeRolloutStrategy specifies the Rollout Strategy
                   for fields shared by Pipeline and MonoVertex
                 properties:
-                  progressive:
-                    description: PipelineTypeProgressiveStrategy specifies the Progressive
-                      Rollout Strategy for fields shared by Pipeline and MonoVertex
+                  analysis:
+                    description: Analysis defines how to perform analysis of health,
+                      outside of basic resource checking
                     properties:
-                      analysis:
-                        description: Analysis defines how to perform analysis of health,
-                          outside of basic resource checking
-                        properties:
-                          args:
-                            description: Arguments can be passed to templates to evaluate
-                              any parameterization
-                            items:
-                              description: AnalysisRunArgument argument to add to
-                                analysisRun
+                      args:
+                        description: Arguments can be passed to templates to evaluate
+                          any parameterization
+                        items:
+                          description: AnalysisRunArgument argument to add to analysisRun
+                          properties:
+                            name:
+                              description: Name argument name
+                              type: string
+                            value:
+                              description: Value a hardcoded value for the argument.
+                                This field is a one of field with valueFrom
+                              type: string
+                            valueFrom:
+                              description: ValueFrom A reference to where the value
+                                is stored. This field is a one of field with valueFrom
                               properties:
-                                name:
-                                  description: Name argument name
-                                  type: string
-                                value:
-                                  description: Value a hardcoded value for the argument.
-                                    This field is a one of field with valueFrom
-                                  type: string
-                                valueFrom:
-                                  description: ValueFrom A reference to where the
-                                    value is stored. This field is a one of field
-                                    with valueFrom
+                                fieldRef:
+                                  description: FieldRef
                                   properties:
-                                    fieldRef:
-                                      description: FieldRef
-                                      properties:
-                                        fieldPath:
-                                          description: 'Required: Path of the field
-                                            to select in the specified API version'
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                    podTemplateHashValue:
-                                      description: PodTemplateHashValue gets the value
-                                        from one of the children ReplicaSet's Pod
-                                        Template Hash
+                                    fieldPath:
+                                      description: 'Required: Path of the field to
+                                        select in the specified API version'
                                       type: string
+                                  required:
+                                  - fieldPath
                                   type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          templates:
-                            description: Templates are used to analyze the AnalysisRun
-                            items:
-                              properties:
-                                clusterScope:
-                                  description: Whether to look for the templateName
-                                    at cluster scope or namespace scope
-                                  type: boolean
-                                templateName:
-                                  description: TemplateName name of template to use
-                                    in AnalysisRun
+                                podTemplateHashValue:
+                                  description: PodTemplateHashValue gets the value
+                                    from one of the children ReplicaSet's Pod Template
+                                    Hash
                                   type: string
                               type: object
-                            type: array
-                        type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      templates:
+                        description: Templates are used to analyze the AnalysisRun
+                        items:
+                          properties:
+                            clusterScope:
+                              description: Whether to look for the templateName at
+                                cluster scope or namespace scope
+                              type: boolean
+                            templateName:
+                              description: TemplateName name of template to use in
+                                AnalysisRun
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  progressive:
+                    properties:
                       assessmentSchedule:
                         description: |-
                           optional string: comma-separated list consisting of:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -385,68 +385,64 @@ spec:
                 description: PipelineTypeRolloutStrategy specifies the Rollout Strategy
                   for fields shared by Pipeline and MonoVertex
                 properties:
-                  progressive:
-                    description: PipelineTypeProgressiveStrategy specifies the Progressive
-                      Rollout Strategy for fields shared by Pipeline and MonoVertex
+                  analysis:
+                    description: Analysis defines how to perform analysis of health,
+                      outside of basic resource checking
                     properties:
-                      analysis:
-                        description: Analysis defines how to perform analysis of health,
-                          outside of basic resource checking
-                        properties:
-                          args:
-                            description: Arguments can be passed to templates to evaluate
-                              any parameterization
-                            items:
-                              description: AnalysisRunArgument argument to add to
-                                analysisRun
+                      args:
+                        description: Arguments can be passed to templates to evaluate
+                          any parameterization
+                        items:
+                          description: AnalysisRunArgument argument to add to analysisRun
+                          properties:
+                            name:
+                              description: Name argument name
+                              type: string
+                            value:
+                              description: Value a hardcoded value for the argument.
+                                This field is a one of field with valueFrom
+                              type: string
+                            valueFrom:
+                              description: ValueFrom A reference to where the value
+                                is stored. This field is a one of field with valueFrom
                               properties:
-                                name:
-                                  description: Name argument name
-                                  type: string
-                                value:
-                                  description: Value a hardcoded value for the argument.
-                                    This field is a one of field with valueFrom
-                                  type: string
-                                valueFrom:
-                                  description: ValueFrom A reference to where the
-                                    value is stored. This field is a one of field
-                                    with valueFrom
+                                fieldRef:
+                                  description: FieldRef
                                   properties:
-                                    fieldRef:
-                                      description: FieldRef
-                                      properties:
-                                        fieldPath:
-                                          description: 'Required: Path of the field
-                                            to select in the specified API version'
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                    podTemplateHashValue:
-                                      description: PodTemplateHashValue gets the value
-                                        from one of the children ReplicaSet's Pod
-                                        Template Hash
+                                    fieldPath:
+                                      description: 'Required: Path of the field to
+                                        select in the specified API version'
                                       type: string
+                                  required:
+                                  - fieldPath
                                   type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          templates:
-                            description: Templates are used to analyze the AnalysisRun
-                            items:
-                              properties:
-                                clusterScope:
-                                  description: Whether to look for the templateName
-                                    at cluster scope or namespace scope
-                                  type: boolean
-                                templateName:
-                                  description: TemplateName name of template to use
-                                    in AnalysisRun
+                                podTemplateHashValue:
+                                  description: PodTemplateHashValue gets the value
+                                    from one of the children ReplicaSet's Pod Template
+                                    Hash
                                   type: string
                               type: object
-                            type: array
-                        type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      templates:
+                        description: Templates are used to analyze the AnalysisRun
+                        items:
+                          properties:
+                            clusterScope:
+                              description: Whether to look for the templateName at
+                                cluster scope or namespace scope
+                              type: boolean
+                            templateName:
+                              description: TemplateName name of template to use in
+                                AnalysisRun
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  progressive:
+                    properties:
                       assessmentSchedule:
                         description: |-
                           optional string: comma-separated list consisting of:
@@ -1193,68 +1189,64 @@ spec:
                 description: PipelineTypeRolloutStrategy specifies the Rollout Strategy
                   for fields shared by Pipeline and MonoVertex
                 properties:
-                  progressive:
-                    description: PipelineTypeProgressiveStrategy specifies the Progressive
-                      Rollout Strategy for fields shared by Pipeline and MonoVertex
+                  analysis:
+                    description: Analysis defines how to perform analysis of health,
+                      outside of basic resource checking
                     properties:
-                      analysis:
-                        description: Analysis defines how to perform analysis of health,
-                          outside of basic resource checking
-                        properties:
-                          args:
-                            description: Arguments can be passed to templates to evaluate
-                              any parameterization
-                            items:
-                              description: AnalysisRunArgument argument to add to
-                                analysisRun
+                      args:
+                        description: Arguments can be passed to templates to evaluate
+                          any parameterization
+                        items:
+                          description: AnalysisRunArgument argument to add to analysisRun
+                          properties:
+                            name:
+                              description: Name argument name
+                              type: string
+                            value:
+                              description: Value a hardcoded value for the argument.
+                                This field is a one of field with valueFrom
+                              type: string
+                            valueFrom:
+                              description: ValueFrom A reference to where the value
+                                is stored. This field is a one of field with valueFrom
                               properties:
-                                name:
-                                  description: Name argument name
-                                  type: string
-                                value:
-                                  description: Value a hardcoded value for the argument.
-                                    This field is a one of field with valueFrom
-                                  type: string
-                                valueFrom:
-                                  description: ValueFrom A reference to where the
-                                    value is stored. This field is a one of field
-                                    with valueFrom
+                                fieldRef:
+                                  description: FieldRef
                                   properties:
-                                    fieldRef:
-                                      description: FieldRef
-                                      properties:
-                                        fieldPath:
-                                          description: 'Required: Path of the field
-                                            to select in the specified API version'
-                                          type: string
-                                      required:
-                                      - fieldPath
-                                      type: object
-                                    podTemplateHashValue:
-                                      description: PodTemplateHashValue gets the value
-                                        from one of the children ReplicaSet's Pod
-                                        Template Hash
+                                    fieldPath:
+                                      description: 'Required: Path of the field to
+                                        select in the specified API version'
                                       type: string
+                                  required:
+                                  - fieldPath
                                   type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          templates:
-                            description: Templates are used to analyze the AnalysisRun
-                            items:
-                              properties:
-                                clusterScope:
-                                  description: Whether to look for the templateName
-                                    at cluster scope or namespace scope
-                                  type: boolean
-                                templateName:
-                                  description: TemplateName name of template to use
-                                    in AnalysisRun
+                                podTemplateHashValue:
+                                  description: PodTemplateHashValue gets the value
+                                    from one of the children ReplicaSet's Pod Template
+                                    Hash
                                   type: string
                               type: object
-                            type: array
-                        type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      templates:
+                        description: Templates are used to analyze the AnalysisRun
+                        items:
+                          properties:
+                            clusterScope:
+                              description: Whether to look for the templateName at
+                                cluster scope or namespace scope
+                              type: boolean
+                            templateName:
+                              description: TemplateName name of template to use in
+                                AnalysisRun
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  progressive:
+                    properties:
                       assessmentSchedule:
                         description: |-
                           optional string: comma-separated list consisting of:

--- a/pkg/apis/numaplane/v1alpha1/shared_types.go
+++ b/pkg/apis/numaplane/v1alpha1/shared_types.go
@@ -46,12 +46,12 @@ const (
 
 // PipelineTypeRolloutStrategy specifies the Rollout Strategy for fields shared by Pipeline and MonoVertex
 type PipelineTypeRolloutStrategy struct {
-	PipelineTypeProgressiveStrategy `json:"progressive,omitempty"`
+	PipelineTypeProgressiveStrategy `json:",inline"`
 }
 
 // PipelineTypeProgressiveStrategy specifies the Progressive Rollout Strategy for fields shared by Pipeline and MonoVertex
 type PipelineTypeProgressiveStrategy struct {
-	Progressive ProgressiveStrategy `json:",inline"`
+	Progressive ProgressiveStrategy `json:"progressive,omitempty"`
 
 	Analysis Analysis `json:"analysis,omitempty"`
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Inline tag was set on the Progressive field instead of the PipelineTypeProgressiveStrategy on the PipelineTypeRolloutStrategy struct. This was causing the [E2E tests I'm working on](https://github.com/numaproj/numaplane/pull/660) to fail adding the strategy to the MonoVertex spec.

### Verification

E2E tests create the MonoVertex with the expected strategy.

### Backward incompatibilities

None.
