### PR TITLE
chore: sink to blackhole to avoid 'too many open files' error

### DIFF
--- a/tests/e2e/functional-monovertex-e2e/monovertex_test.go
+++ b/tests/e2e/functional-monovertex-e2e/monovertex_test.go
@@ -46,11 +46,7 @@ var (
 		},
 		Sink: &numaflowv1.Sink{
 			AbstractSink: numaflowv1.AbstractSink{
-				UDSink: &numaflowv1.UDSink{
-					Container: &numaflowv1.Container{
-						Image: "quay.io/numaio/numaflow-go/sink-log:stable",
-					},
-				},
+				Blackhole: &numaflowv1.Blackhole{},
 			},
 		},
 	}

--- a/tests/e2e/functional-nc-e2e/numaflow-controller_test.go
+++ b/tests/e2e/functional-nc-e2e/numaflow-controller_test.go
@@ -100,11 +100,7 @@ var (
 		},
 		Sink: &numaflowv1.Sink{
 			AbstractSink: numaflowv1.AbstractSink{
-				UDSink: &numaflowv1.UDSink{
-					Container: &numaflowv1.Container{
-						Image: "quay.io/numaio/numaflow-go/sink-log:stable",
-					},
-				},
+				Blackhole: &numaflowv1.Blackhole{},
 			},
 		},
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Replaced UDSink with Balckhole sink to avoid `too many open files` error.


### Verification

E2E tests not showing that error.

### Backward incompatibilities

None.
