### PR TITLE
feat: Add failure reason for progressive rollout

### DIFF
--- a/config/crd/bases/numaplane.numaproj.io_isbservicerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_isbservicerollouts.yaml
@@ -237,6 +237,9 @@ spec:
                           which the assessment result will be computed
                         format: date-time
                         type: string
+                      failureReason:
+                        description: FailureReason indicates the reason for the failure
+                        type: string
                       forcedSuccess:
                         description: ForcedSuccess indicates if this promotion was
                           forced to complete

--- a/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_monovertexrollouts.yaml
@@ -355,6 +355,9 @@ spec:
                           which the assessment result will be computed
                         format: date-time
                         type: string
+                      failureReason:
+                        description: FailureReason indicates the reason for the failure
+                        type: string
                       forcedSuccess:
                         description: ForcedSuccess indicates if this promotion was
                           forced to complete

--- a/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_pipelinerollouts.yaml
@@ -378,6 +378,9 @@ spec:
                           which the assessment result will be computed
                         format: date-time
                         type: string
+                      failureReason:
+                        description: FailureReason indicates the reason for the failure
+                        type: string
                       forcedSuccess:
                         description: ForcedSuccess indicates if this promotion was
                           forced to complete

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -288,6 +288,9 @@ spec:
                           which the assessment result will be computed
                         format: date-time
                         type: string
+                      failureReason:
+                        description: FailureReason indicates the reason for the failure
+                        type: string
                       forcedSuccess:
                         description: ForcedSuccess indicates if this promotion was
                           forced to complete
@@ -668,6 +671,9 @@ spec:
                         description: AssessmentStartTime indicates the time at/after
                           which the assessment result will be computed
                         format: date-time
+                        type: string
+                      failureReason:
+                        description: FailureReason indicates the reason for the failure
                         type: string
                       forcedSuccess:
                         description: ForcedSuccess indicates if this promotion was
@@ -1507,6 +1513,9 @@ spec:
                         description: AssessmentStartTime indicates the time at/after
                           which the assessment result will be computed
                         format: date-time
+                        type: string
+                      failureReason:
+                        description: FailureReason indicates the reason for the failure
                         type: string
                       forcedSuccess:
                         description: ForcedSuccess indicates if this promotion was

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -34,7 +34,7 @@ func (r *ISBServiceRolloutReconciler) CreateUpgradingChildDefinition(ctx context
 
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
 // This implements a function of the progressiveController interface
-func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, apiv1.AssessmentFailureReason, error) {
+func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, string, error) {
 	numaLogger := logger.FromContext(ctx).WithValues("upgrading child", fmt.Sprintf("%s/%s", existingUpgradingChildDef.GetNamespace(), existingUpgradingChildDef.GetName()))
 
 	// TODO: For now, just assessing the health of the underlying Pipelines; need to also assess the health of the isbsvc itself
@@ -69,7 +69,7 @@ func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 		switch pipelineRollout.Status.ProgressiveStatus.UpgradingPipelineStatus.AssessmentResult {
 		case apiv1.AssessmentResultFailure:
 			numaLogger.WithValues("pipeline", upgradingPipelineStatus.Name).Debug("pipeline is failed")
-			return apiv1.AssessmentResultFailure, apiv1.AssessmentFailureReason(fmt.Sprintf("Pipeline %s failed while upgrading", upgradingPipelineStatus.Name)), nil
+			return apiv1.AssessmentResultFailure, fmt.Sprintf("Pipeline %s failed while upgrading", upgradingPipelineStatus.Name), nil
 		case apiv1.AssessmentResultUnknown:
 			numaLogger.WithValues("pipeline", upgradingPipelineStatus.Name).Debug("pipeline assessment is unknown")
 			return apiv1.AssessmentResultUnknown, "", nil

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -34,7 +34,7 @@ func (r *ISBServiceRolloutReconciler) CreateUpgradingChildDefinition(ctx context
 
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
 // This implements a function of the progressiveController interface
-func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error) {
+func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, apiv1.AssessmentFailureReason, error) {
 	numaLogger := logger.FromContext(ctx).WithValues("upgrading child", fmt.Sprintf("%s/%s", existingUpgradingChildDef.GetNamespace(), existingUpgradingChildDef.GetName()))
 
 	// TODO: For now, just assessing the health of the underlying Pipelines; need to also assess the health of the isbsvc itself
@@ -45,17 +45,17 @@ func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 	// What is the name of the ISBServiceRollout?
 	isbsvcRolloutName, found := existingUpgradingChildDef.GetLabels()[common.LabelKeyParentRollout]
 	if !found {
-		return apiv1.AssessmentResultUnknown, fmt.Errorf("There is no Label named %q for isbsvc %s/%s; can't make assessment for progressive",
+		return apiv1.AssessmentResultUnknown, "", fmt.Errorf("There is no Label named %q for isbsvc %s/%s; can't make assessment for progressive",
 			common.LabelKeyParentRollout, existingUpgradingChildDef.GetNamespace(), existingUpgradingChildDef.GetName())
 	}
 	// get all PipelineRollouts using this ISBServiceRollout
 	pipelineRollouts, err := r.getPipelineRolloutList(ctx, existingUpgradingChildDef.GetNamespace(), isbsvcRolloutName)
 	if err != nil {
-		return apiv1.AssessmentResultUnknown, fmt.Errorf("Error getting PipelineRollouts: %s", err.Error())
+		return apiv1.AssessmentResultUnknown, "", fmt.Errorf("Error getting PipelineRollouts: %s", err.Error())
 	}
 	if len(pipelineRollouts) == 0 {
 		numaLogger.Warn("Found no PipelineRollouts using ISBServiceRollout: so isbsvc is deemed Successful") // not typical but could happen
-		return apiv1.AssessmentResultSuccess, nil
+		return apiv1.AssessmentResultSuccess, "", nil
 	}
 
 	// for each PipelineRollout, we need to check that its current Upgrading Status is for a Pipeline which is in fact using this isbsvc
@@ -64,22 +64,22 @@ func (r *ISBServiceRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 		upgradingPipelineStatus := pipelineRollout.Status.ProgressiveStatus.UpgradingPipelineStatus
 		if upgradingPipelineStatus == nil || upgradingPipelineStatus.InterStepBufferServiceName != existingUpgradingChildDef.GetName() {
 			numaLogger.WithValues("pipelinerollout", pipelineRollout.GetName()).Debug("can't assess ISBService; pipeline is not yet upgrading with this ISBService")
-			return apiv1.AssessmentResultUnknown, nil
+			return apiv1.AssessmentResultUnknown, "", nil
 		}
 		switch pipelineRollout.Status.ProgressiveStatus.UpgradingPipelineStatus.AssessmentResult {
 		case apiv1.AssessmentResultFailure:
 			numaLogger.WithValues("pipeline", upgradingPipelineStatus.Name).Debug("pipeline is failed")
-			return apiv1.AssessmentResultFailure, nil
+			return apiv1.AssessmentResultFailure, apiv1.AssessmentFailureReason(fmt.Sprintf("Pipeline %s failed while upgrading", upgradingPipelineStatus.Name)), nil
 		case apiv1.AssessmentResultUnknown:
 			numaLogger.WithValues("pipeline", upgradingPipelineStatus.Name).Debug("pipeline assessment is unknown")
-			return apiv1.AssessmentResultUnknown, nil
+			return apiv1.AssessmentResultUnknown, "", nil
 		case apiv1.AssessmentResultSuccess:
 			numaLogger.WithValues("pipeline", upgradingPipelineStatus.Name).Debug("pipeline succeeded")
 
 		}
 	}
 
-	return apiv1.AssessmentResultSuccess, nil
+	return apiv1.AssessmentResultSuccess, "", nil
 }
 
 func (r *ISBServiceRolloutReconciler) ProcessPromotedChildPreUpgrade(

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -43,7 +43,7 @@ func (r *MonoVertexRolloutReconciler) CreateUpgradingChildDefinition(ctx context
 
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
 // This implements a function of the progressiveController interface
-func (r *MonoVertexRolloutReconciler) AssessUpgradingChild(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, apiv1.AssessmentFailureReason, error) {
+func (r *MonoVertexRolloutReconciler) AssessUpgradingChild(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, string, error) {
 	mvtxRollout := rolloutObject.(*apiv1.MonoVertexRollout)
 	analysis := mvtxRollout.GetAnalysis()
 	// only check for and create AnalysisRuns if templates are specified

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -63,7 +63,7 @@ func (r *PipelineRolloutReconciler) CreateUpgradingChildDefinition(ctx context.C
 
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
 // This implements a function of the progressiveController interface
-func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, apiv1.AssessmentFailureReason, error) {
+func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, string, error) {
 	verifyReplicasFunc := func(existingUpgradingChildDef *unstructured.Unstructured) (bool, string, error) {
 		verticesList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion,
 			numaflowv1.VertexGroupVersionResource.Resource, existingUpgradingChildDef.GetNamespace(),
@@ -90,11 +90,8 @@ func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, ro
 				break
 			}
 		}
-		if !areAllVerticesReplicasReady {
-			return areAllVerticesReplicasReady, replicasFailureReason, nil
-		}
 
-		return areAllVerticesReplicasReady, "", nil
+		return areAllVerticesReplicasReady, replicasFailureReason, nil
 	}
 
 	pipelineRollout := rolloutObject.(*apiv1.PipelineRollout)

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -63,33 +63,38 @@ func (r *PipelineRolloutReconciler) CreateUpgradingChildDefinition(ctx context.C
 
 // AssessUpgradingChild makes an assessment of the upgrading child to determine if it was successful, failed, or still not known
 // This implements a function of the progressiveController interface
-func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error) {
-	verifyReplicasFunc := func(existingUpgradingChildDef *unstructured.Unstructured) (bool, error) {
+func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, apiv1.AssessmentFailureReason, error) {
+	verifyReplicasFunc := func(existingUpgradingChildDef *unstructured.Unstructured) (bool, string, error) {
 		verticesList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion,
 			numaflowv1.VertexGroupVersionResource.Resource, existingUpgradingChildDef.GetNamespace(),
 			fmt.Sprintf("%s=%s", common.LabelKeyNumaflowPodPipelineName, existingUpgradingChildDef.GetName()), "")
 		if err != nil {
-			return false, err
+			return false, "", err
 		}
 
 		if verticesList == nil {
-			return false, errors.New("the pipeline vertices list is nil, this should not occur")
+			return false, "", errors.New("the pipeline vertices list is nil, this should not occur")
 		}
 
 		areAllVerticesReplicasReady := true
+		var replicasFailureReason string
 		for _, vertex := range verticesList.Items {
-			areVertexReplicasReady, err := progressive.AreVertexReplicasReady(&vertex)
+			areVertexReplicasReady, failureReason, err := progressive.AreVertexReplicasReady(&vertex)
 			if err != nil {
-				return false, err
+				return false, "", err
 			}
 
 			if !areVertexReplicasReady {
 				areAllVerticesReplicasReady = false
+				replicasFailureReason = failureReason
 				break
 			}
 		}
+		if !areAllVerticesReplicasReady {
+			return areAllVerticesReplicasReady, replicasFailureReason, nil
+		}
 
-		return areAllVerticesReplicasReady, nil
+		return areAllVerticesReplicasReady, "", nil
 	}
 
 	pipelineRollout := rolloutObject.(*apiv1.PipelineRollout)
@@ -103,11 +108,11 @@ func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, ro
 				// analysisRun is created the first time the upgrading child is assessed
 				err := progressive.CreateAnalysisRun(ctx, analysis, existingUpgradingChildDef, r.client)
 				if err != nil {
-					return apiv1.AssessmentResultUnknown, err
+					return apiv1.AssessmentResultUnknown, "", err
 				}
 				analysisStatus := pipelineRollout.GetAnalysisStatus()
 				if analysisStatus == nil {
-					return apiv1.AssessmentResultUnknown, errors.New("analysisStatus not set")
+					return apiv1.AssessmentResultUnknown, "", errors.New("analysisStatus not set")
 				}
 				// analysisStatus is updated with name of AnalysisRun (which is the same name as the upgrading child)
 				// and start time for its assessment
@@ -116,7 +121,7 @@ func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, ro
 				analysisStatus.StartTime = &timeNow
 				pipelineRollout.SetAnalysisStatus(analysisStatus)
 			} else {
-				return apiv1.AssessmentResultUnknown, err
+				return apiv1.AssessmentResultUnknown, "", err
 			}
 		}
 

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -427,7 +427,7 @@ func CalculateFailureReason(replicasFailureReason, phase string, failedCondition
 	if phase == "Failed" {
 		return "child phase is in Failed state"
 	} else if failedCondition != nil {
-		return fmt.Sprintf("condition %s is %s", failedCondition.Type, failedCondition.Reason)
+		return fmt.Sprintf("condition %s is False for Reason: %s", failedCondition.Type, failedCondition.Reason)
 	} else {
 		return replicasFailureReason
 	}

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -40,14 +40,14 @@ func (fpc fakeProgressiveController) ChildNeedsUpdating(ctx context.Context, exi
 	return false, nil
 }
 
-func (fpc fakeProgressiveController) AssessUpgradingChild(ctx context.Context, rolloutObject ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, error) {
+func (fpc fakeProgressiveController) AssessUpgradingChild(ctx context.Context, rolloutObject ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, apiv1.AssessmentFailureReason, error) {
 	switch existingUpgradingChildDef.GetName() {
 	case "test-success":
-		return apiv1.AssessmentResultSuccess, nil
+		return apiv1.AssessmentResultSuccess, "", nil
 	case "test-failure":
-		return apiv1.AssessmentResultFailure, nil
+		return apiv1.AssessmentResultFailure, "test-fail-reason", nil
 	default:
-		return apiv1.AssessmentResultUnknown, nil
+		return apiv1.AssessmentResultUnknown, "", nil
 	}
 }
 
@@ -542,6 +542,7 @@ func Test_AreVertexReplicasReady(t *testing.T) {
 		desiredReplicas *int64
 		readyReplicas   *int64
 		expectedResult  bool
+		failureReason   string
 	}{
 		{
 			name:            "desired = 0, ready = 0",
@@ -554,6 +555,7 @@ func Test_AreVertexReplicasReady(t *testing.T) {
 			desiredReplicas: ptr.To(int64(3)),
 			readyReplicas:   ptr.To(int64(0)),
 			expectedResult:  false,
+			failureReason:   "readyReplicas=0 is less than desiredReplicas=3",
 		},
 		{
 			name:            "desired = 0, ready > 0",
@@ -572,6 +574,7 @@ func Test_AreVertexReplicasReady(t *testing.T) {
 			desiredReplicas: ptr.To(int64(3)),
 			readyReplicas:   ptr.To(int64(2)),
 			expectedResult:  false,
+			failureReason:   "readyReplicas=2 is less than desiredReplicas=3",
 		},
 		{
 			name:            "desired > 0, ready > 0, desired = ready",
@@ -608,6 +611,7 @@ func Test_AreVertexReplicasReady(t *testing.T) {
 			desiredReplicas: ptr.To(int64(3)),
 			readyReplicas:   nil,
 			expectedResult:  false,
+			failureReason:   "readyReplicas=0 is less than desiredReplicas=3",
 		},
 	}
 
@@ -627,8 +631,9 @@ func Test_AreVertexReplicasReady(t *testing.T) {
 				_ = unstructured.SetNestedField(unstr.Object, *tc.readyReplicas, "status", "readyReplicas")
 			}
 
-			actualResult, actualErr := AreVertexReplicasReady(unstr)
+			actualResult, failureReason, actualErr := AreVertexReplicasReady(unstr)
 
+			assert.Equal(t, tc.failureReason, failureReason)
 			assert.Nil(t, actualErr)
 			assert.Equal(t, tc.expectedResult, actualResult)
 		})

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -40,7 +40,7 @@ func (fpc fakeProgressiveController) ChildNeedsUpdating(ctx context.Context, exi
 	return false, nil
 }
 
-func (fpc fakeProgressiveController) AssessUpgradingChild(ctx context.Context, rolloutObject ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, apiv1.AssessmentFailureReason, error) {
+func (fpc fakeProgressiveController) AssessUpgradingChild(ctx context.Context, rolloutObject ProgressiveRolloutObject, existingUpgradingChildDef *unstructured.Unstructured) (apiv1.AssessmentResult, string, error) {
 	switch existingUpgradingChildDef.GetName() {
 	case "test-success":
 		return apiv1.AssessmentResultSuccess, "", nil

--- a/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/monovertexrollout_types.go
@@ -178,6 +178,7 @@ func (monoVertexRollout *MonoVertexRollout) ResetUpgradingChildStatus(upgradingM
 				Name:              upgradingMonoVertex.GetName(),
 				AssessmentEndTime: nil,
 				AssessmentResult:  AssessmentResultUnknown,
+				FailureReason:     "",
 			},
 			Analysis: AnalysisStatus{},
 		},

--- a/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/pipelinerollout_types.go
@@ -199,6 +199,7 @@ func (pipelineRollout *PipelineRollout) ResetUpgradingChildStatus(upgradingPipel
 				Name:              upgradingPipeline.GetName(),
 				AssessmentEndTime: nil,
 				AssessmentResult:  AssessmentResultUnknown,
+				FailureReason:     "",
 			},
 			Analysis: AnalysisStatus{},
 		},

--- a/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
@@ -24,7 +24,6 @@ import (
 )
 
 type AssessmentResult string
-type AssessmentFailureReason string
 
 const (
 	AssessmentResultSuccess = "Success"
@@ -45,7 +44,7 @@ type UpgradingChildStatus struct {
 	// ForcedSuccess indicates if this promotion was forced to complete
 	ForcedSuccess bool `json:"forcedSuccess,omitempty"`
 	// FailureReason indicates the reason for the failure
-	FailureReason AssessmentFailureReason `json:"failureReason,omitempty"`
+	FailureReason string `json:"failureReason,omitempty"`
 }
 
 type UpgradingPipelineTypeStatus struct {

--- a/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/progressive_status_types.go
@@ -24,6 +24,7 @@ import (
 )
 
 type AssessmentResult string
+type AssessmentFailureReason string
 
 const (
 	AssessmentResultSuccess = "Success"
@@ -43,6 +44,8 @@ type UpgradingChildStatus struct {
 	AssessmentEndTime *metav1.Time `json:"assessmentEndTime,omitempty"`
 	// ForcedSuccess indicates if this promotion was forced to complete
 	ForcedSuccess bool `json:"forcedSuccess,omitempty"`
+	// FailureReason indicates the reason for the failure
+	FailureReason AssessmentFailureReason `json:"failureReason,omitempty"`
 }
 
 type UpgradingPipelineTypeStatus struct {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Part of: https://github.com/numaproj/numaplane/issues/670

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->
- Add progressive rollout failure reason in case of failure

### Verification

Verified in local kubernetes cluster
```bash
  Progressive Status:
    Promoted Mono Vertex Status:
      Name:                               test-monovertex-rollout-0
      Scale Values Restored To Original:  true
    Upgrading Mono Vertex Status:
      Analysis:
        Phase:
      Assessment End Time:     2025-03-26T14:57:58Z
      Assessment Result:       Failure
      Assessment Start Time:   2025-03-26T14:56:58Z
      Failure Reason:          readyReplicas=1 is less than desiredReplicas=3
      Name:                    test-monovertex-rollout-1
      Original Scale Min Max:  {"max":null,"min":5}
  Upgrade In Progress:         Progressive
```

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
