### PR TITLE
fix: default timeout was returning as nanoseconds instead of seconds

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -369,7 +369,7 @@ func (config *ProgressiveConfig) GetAnalysisRunTimeout() (time.Duration, error) 
 	defaultAnalysisRunTimeout := 1200
 
 	if config.AnalysisRunTimeout == "" {
-		return time.Duration(defaultAnalysisRunTimeout), nil
+		return time.Duration(defaultAnalysisRunTimeout) * time.Second, nil
 	}
 
 	analysisRunTimeout, err := strconv.Atoi(config.AnalysisRunTimeout)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->


### Modifications

Default timeout for analysisRunTimeout was returning as 1200 nanoseconds instead of 1200 seconds (20 minutes).

### Verification

Running with unit tests locally (will be pushed in another PR).

### Backward incompatibilities

n/a
