### PR TITLE
fix: mismatch between FailureReason and child status

### DIFF
--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -299,13 +299,13 @@ func processUpgradingChild(
 	// Otherwise, assess the previous child status.
 	assessment := childStatus.AssessmentResult
 	failureReason := childStatus.FailureReason
-	failureChildStatus := childStatus.ChildStatus.Raw
+	childSts := childStatus.ChildStatus.Raw
 	if childStatus.CanAssess() {
 		assessment, failureReason, err = controller.AssessUpgradingChild(ctx, rolloutObject, existingUpgradingChildDef)
 		if err != nil {
 			return false, 0, err
 		}
-		failureChildStatus, err = json.Marshal(existingUpgradingChildDef.Object["status"])
+		childSts, err = json.Marshal(existingUpgradingChildDef.Object["status"])
 		if err != nil {
 			return false, 0, err
 		}
@@ -329,7 +329,7 @@ func processUpgradingChild(
 		rolloutObject.GetRolloutStatus().MarkProgressiveUpgradeFailed(fmt.Sprintf("New Child Object %s/%s Failed", existingUpgradingChildDef.GetNamespace(), existingUpgradingChildDef.GetName()), rolloutObject.GetRolloutObjectMeta().Generation)
 		childStatus.AssessmentResult = apiv1.AssessmentResultFailure
 		childStatus.FailureReason = failureReason
-		childStatus.ChildStatus.Raw = failureChildStatus
+		childStatus.ChildStatus.Raw = childSts
 		rolloutObject.SetUpgradingChildStatus(childStatus)
 
 		// check if there are any new incoming changes to the desired spec

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -299,8 +299,13 @@ func processUpgradingChild(
 	// Otherwise, assess the previous child status.
 	assessment := childStatus.AssessmentResult
 	failureReason := childStatus.FailureReason
+	failureChildStatus := childStatus.ChildStatus.Raw
 	if childStatus.CanAssess() {
 		assessment, failureReason, err = controller.AssessUpgradingChild(ctx, rolloutObject, existingUpgradingChildDef)
+		if err != nil {
+			return false, 0, err
+		}
+		failureChildStatus, err = json.Marshal(existingUpgradingChildDef.Object["status"])
 		if err != nil {
 			return false, 0, err
 		}
@@ -324,11 +329,7 @@ func processUpgradingChild(
 		rolloutObject.GetRolloutStatus().MarkProgressiveUpgradeFailed(fmt.Sprintf("New Child Object %s/%s Failed", existingUpgradingChildDef.GetNamespace(), existingUpgradingChildDef.GetName()), rolloutObject.GetRolloutObjectMeta().Generation)
 		childStatus.AssessmentResult = apiv1.AssessmentResultFailure
 		childStatus.FailureReason = failureReason
-		rawChildStatus, err := json.Marshal(existingUpgradingChildDef.Object["status"])
-		if err != nil {
-			return false, 0, err
-		}
-		childStatus.ChildStatus.Raw = rawChildStatus
+		childStatus.ChildStatus.Raw = failureChildStatus
 		rolloutObject.SetUpgradingChildStatus(childStatus)
 
 		// check if there are any new incoming changes to the desired spec


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/680

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->
- Fixed the mismatch between FailureReason and child status

### Verification

- Verified in local k8s cluster after deploying the changes, ran `STRATEGY=progressive make test-progressive-e2e` and keep deleting the newly created pod during upgrade to cause failure.
