### PR TITLE
fix: add OwnerReferences to created AnalysisRuns

### DIFF
--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -53,7 +53,8 @@ func (r *MonoVertexRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 		if err := r.client.Get(ctx, client.ObjectKey{Name: existingUpgradingChildDef.GetName(), Namespace: existingUpgradingChildDef.GetNamespace()}, analysisRun); err != nil {
 			if apierrors.IsNotFound(err) {
 				// analysisRun is created the first time the upgrading child is assessed
-				err := progressive.CreateAnalysisRun(ctx, analysis, existingUpgradingChildDef, r.client)
+				ownerRef := *metav1.NewControllerRef(mvtxRollout.GetObjectMeta(), apiv1.MonoVertexRolloutGroupVersionKind)
+				err := progressive.CreateAnalysisRun(ctx, analysis, existingUpgradingChildDef, ownerRef, r.client)
 				if err != nil {
 					return apiv1.AssessmentResultUnknown, "", err
 				}

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaplane/internal/controller/progressive"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
 	"github.com/numaproj/numaplane/internal/util/logger"
@@ -53,7 +54,7 @@ func (r *MonoVertexRolloutReconciler) AssessUpgradingChild(ctx context.Context, 
 		if err := r.client.Get(ctx, client.ObjectKey{Name: existingUpgradingChildDef.GetName(), Namespace: existingUpgradingChildDef.GetNamespace()}, analysisRun); err != nil {
 			if apierrors.IsNotFound(err) {
 				// analysisRun is created the first time the upgrading child is assessed
-				ownerRef := *metav1.NewControllerRef(mvtxRollout.GetObjectMeta(), apiv1.MonoVertexRolloutGroupVersionKind)
+				ownerRef := *metav1.NewControllerRef(&metav1.ObjectMeta{Name: existingUpgradingChildDef.GetName(), Namespace: existingUpgradingChildDef.GetNamespace(), UID: existingUpgradingChildDef.GetUID()}, numaflowv1.MonoVertexGroupVersionKind)
 				err := progressive.CreateAnalysisRun(ctx, analysis, existingUpgradingChildDef, ownerRef, r.client)
 				if err != nil {
 					return apiv1.AssessmentResultUnknown, "", err

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -103,7 +103,8 @@ func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, ro
 		if err := r.client.Get(ctx, client.ObjectKey{Name: existingUpgradingChildDef.GetName(), Namespace: existingUpgradingChildDef.GetNamespace()}, analysisRun); err != nil {
 			if apierrors.IsNotFound(err) {
 				// analysisRun is created the first time the upgrading child is assessed
-				err := progressive.CreateAnalysisRun(ctx, analysis, existingUpgradingChildDef, r.client)
+				ownerRef := *metav1.NewControllerRef(pipelineRollout.GetObjectMeta(), apiv1.PipelineRolloutGroupVersionKind)
+				err := progressive.CreateAnalysisRun(ctx, analysis, existingUpgradingChildDef, ownerRef, r.client)
 				if err != nil {
 					return apiv1.AssessmentResultUnknown, "", err
 				}

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -103,7 +103,7 @@ func (r *PipelineRolloutReconciler) AssessUpgradingChild(ctx context.Context, ro
 		if err := r.client.Get(ctx, client.ObjectKey{Name: existingUpgradingChildDef.GetName(), Namespace: existingUpgradingChildDef.GetNamespace()}, analysisRun); err != nil {
 			if apierrors.IsNotFound(err) {
 				// analysisRun is created the first time the upgrading child is assessed
-				ownerRef := *metav1.NewControllerRef(pipelineRollout.GetObjectMeta(), apiv1.PipelineRolloutGroupVersionKind)
+				ownerRef := *metav1.NewControllerRef(&metav1.ObjectMeta{Name: existingUpgradingChildDef.GetName(), Namespace: existingUpgradingChildDef.GetNamespace(), UID: existingUpgradingChildDef.GetUID()}, numaflowv1.PipelineGroupVersionKind)
 				err := progressive.CreateAnalysisRun(ctx, analysis, existingUpgradingChildDef, ownerRef, r.client)
 				if err != nil {
 					return apiv1.AssessmentResultUnknown, "", err

--- a/internal/controller/progressive/analysis.go
+++ b/internal/controller/progressive/analysis.go
@@ -91,6 +91,7 @@ Parameters:
   - analysis: struct which contains templateRefs to AnalysisTemplates and ClusterAnalysisTemplates and arguments that can be passed
     and override values already specified in the templates
   - existingUpgradingChildDef: the definition of the upgrading child as an unstructured object.
+  - ownerReference: reference to the upgrading child this AnalysisRun is associated with - ensures cleanup
   - client: the client used for interacting with the Kubernetes API.
 
 Returns:
@@ -124,7 +125,7 @@ func CreateAnalysisRun(ctx context.Context, analysis apiv1.Analysis, existingUpg
 		return err
 	}
 
-	// set ownerReference to guarantee AnalysisRun deletion when rollout is cleaned up
+	// set ownerReference to guarantee AnalysisRun deletion when owner is cleaned up
 	analysisRun.SetOwnerReferences([]metav1.OwnerReference{ownerReference})
 	if err = client.Create(ctx, analysisRun); err != nil {
 		return err

--- a/internal/controller/progressive/analysis.go
+++ b/internal/controller/progressive/analysis.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -95,7 +96,7 @@ Parameters:
 Returns:
   - An error if any issues occur during processing.
 */
-func CreateAnalysisRun(ctx context.Context, analysis apiv1.Analysis, existingUpgradingChildDef *unstructured.Unstructured, client client.Client) error {
+func CreateAnalysisRun(ctx context.Context, analysis apiv1.Analysis, existingUpgradingChildDef *unstructured.Unstructured, ownerReference metav1.OwnerReference, client client.Client) error {
 
 	// find all specified templates to merge into single AnalysisRun
 	analysisTemplates, clusterAnalysisTemplates, err := GetAnalysisTemplatesFromRefs(ctx, &analysis.Templates, existingUpgradingChildDef.GetNamespace(), client)
@@ -123,6 +124,8 @@ func CreateAnalysisRun(ctx context.Context, analysis apiv1.Analysis, existingUpg
 		return err
 	}
 
+	// set ownerReference to guarantee AnalysisRun deletion when rollout is cleaned up
+	analysisRun.SetOwnerReferences([]metav1.OwnerReference{ownerReference})
 	if err = client.Create(ctx, analysisRun); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #691 

### Modifications

Fixes issue where we were not adding an OwnerReference to related AnalysisRuns that are created during a Progressive upgrade that uses them.

### Verification

Running progressive upgrades locally on MonoVertexRollout and checking the created AnalysisRun is created with a ownerReference and is deleted when the rollout is.

```
- apiVersion: argoproj.io/v1alpha1
  kind: AnalysisRun
  metadata:
    creationTimestamp: "2025-04-07T23:59:28Z"
    generation: 2
    labels:
      app.kubernetes.io/part-of: numaplane
    name: my-monovertex-1
    namespace: example-namespace
    ownerReferences:
    - apiVersion: numaflow.numaproj.io/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: MonoVertex
      name: my-monovertex-1
      uid: 1cf0d96d-0cda-4fd7-890c-30ff3caf2f55
    resourceVersion: "890142"
    uid: 8ed46273-5310-4cee-922e-415e10909d8f
```

### Backward incompatibilities

n/a
