### PR TITLE
feat:  adding label to upgrading child will force promotion during progressive upgrade

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -128,6 +128,9 @@ const (
 	// LabelKeyNumaflowPodMonoVertexVertexName is the label key used to identify the pod associated to a specific monovertex vertex
 	LabelKeyNumaflowPodMonoVertexVertexName = "numaflow.numaproj.io/mono-vertex-name"
 
+	// LabelKeyForcePromote is the label key used to force promote the upgrading child during a progressive upgrade
+	LabelKeyForcePromote = "numaplane.numaproj.io/force-promote"
+
 	// AnnotationKeyNumaflowInstanceID is the annotation passed to Numaflow Controller so it knows whether it should reconcile the resource
 	AnnotationKeyNumaflowInstanceID = "numaflow.numaproj.io/instance"
 

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -278,8 +278,14 @@ func processUpgradingChild(
 	}
 	childStatus = rolloutObject.GetUpgradingChildStatus()
 
-	// check for Force Promote set in Progressive strategy to force success logic
-	if rolloutObject.GetProgressiveStrategy().ForcePromote {
+	forcePromote := false
+	_, ok := existingUpgradingChildDef.GetLabels()[common.LabelKeyForcePromote]
+	if ok {
+		forcePromote = true
+	}
+
+	// check for Force Promote set in Progressive strategy to force success logic OR if promoted child has force-promote label
+	if rolloutObject.GetProgressiveStrategy().ForcePromote || forcePromote {
 		childStatus.ForcedSuccess = true
 
 		done, err := declareSuccess(ctx, rolloutObject, controller, existingPromotedChildDef, existingUpgradingChildDef, childStatus, c)

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -284,7 +284,7 @@ func processUpgradingChild(
 		forcePromote = true
 	}
 
-	// check for Force Promote set in Progressive strategy to force success logic OR if promoted child has force-promote label
+	// check for Force Promote set in Progressive strategy to force success logic OR if upgrading child has force-promote label
 	if rolloutObject.GetProgressiveStrategy().ForcePromote || forcePromote {
 		childStatus.ForcedSuccess = true
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

Currently we have a force-promote field on the parent rollout which can be set to force promote a child even if the progressive upgrade is failed. This may cause issues for later progressive upgrades however if the user does not remember to remove or set this field to false for their next upgrades.

To remedy this, we can check for a `force-promote` label on the upgrading child during the assessment and force a success that way. Thus when the current upgrade happens, this child becomes the currently promoted and the label will be ignored. 

### Verification

Testing locally with failed progressive upgrade that passes after setting the label on the upgrading child.

### Backward incompatibilities

n/a
