### PR TITLE
fix: Temporarily comment the foreground deletion

### DIFF
--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -195,21 +195,22 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 	if !monoVertexRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting MonoVertexRollout")
 		if controllerutil.ContainsFinalizer(monoVertexRollout, common.FinalizerName) {
+			// TODO: this is a temporary fix to delete the controller and its children
 			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
-			foreground := metav1.DeletePropagationForeground
-			if err := r.client.Delete(ctx, monoVertexRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
-				return ctrl.Result{}, err
-			}
-			// Get the monoVertexRollout live resource
-			liveMonoVertexRollout, err := getLiveMonovertexRollout(ctx, monoVertexRollout.Name, monoVertexRollout.Namespace)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					numaLogger.Info("MonoVertxRollout not found, %v", err)
-					return ctrl.Result{}, nil
-				}
-				return ctrl.Result{}, fmt.Errorf("error getting the live monoVertex rollout: %w", err)
-			}
-			*monoVertexRollout = *liveMonoVertexRollout
+			//foreground := metav1.DeletePropagationForeground
+			//if err := r.client.Delete(ctx, monoVertexRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
+			//	return ctrl.Result{}, err
+			//}
+			//// Get the monoVertexRollout live resource
+			//liveMonoVertexRollout, err := getLiveMonovertexRollout(ctx, monoVertexRollout.Name, monoVertexRollout.Namespace)
+			//if err != nil {
+			//	if apierrors.IsNotFound(err) {
+			//		numaLogger.Info("MonoVertxRollout not found, %v", err)
+			//		return ctrl.Result{}, nil
+			//	}
+			//	return ctrl.Result{}, fmt.Errorf("error getting the live monoVertex rollout: %w", err)
+			//}
+			//*monoVertexRollout = *liveMonoVertexRollout
 			controllerutil.RemoveFinalizer(monoVertexRollout, common.FinalizerName)
 		}
 		// generate metrics for MonoVertex deletion

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -34,7 +34,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	yamlserializer "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
@@ -763,14 +762,4 @@ func (r *NumaflowControllerReconciler) areDependentResourcesDeleted(ctx context.
 	}
 
 	return false, fmt.Errorf("dependent resources are not deleted")
-}
-
-func getLiveNumaflowController(ctx context.Context, name, namespace string) (*apiv1.NumaflowController, error) {
-	numaflowController, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().NumaflowControllers(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	numaflowController.SetGroupVersionKind(apiv1.NumaflowControllerGroupVersionKind)
-
-	return numaflowController, err
 }

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -228,21 +228,22 @@ func (r *NumaflowControllerReconciler) reconcile(
 		numaLogger.Info("Deleting NumaflowController")
 		r.recorder.Eventf(controller, corev1.EventTypeNormal, "Deleting", "Deleting NumaflowController")
 		if controllerutil.ContainsFinalizer(controller, common.FinalizerName) {
+			// TODO: this is a temporary fix to delete the controller and its children
 			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
-			foreground := metav1.DeletePropagationForeground
-			if err := r.client.Delete(ctx, controller, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
-				return ctrl.Result{}, err
-			}
-			// Get the controller live resource
-			liveController, err := getLiveNumaflowController(ctx, controller.Name, controller.Namespace)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					numaLogger.Info("NumaflowController not found, %v", err)
-					return ctrl.Result{}, nil
-				}
-				return ctrl.Result{}, fmt.Errorf("error getting the live controller: %w", err)
-			}
-			*controller = *liveController
+			//foreground := metav1.DeletePropagationForeground
+			//if err := r.client.Delete(ctx, controller, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
+			//	return ctrl.Result{}, err
+			//}
+			//// Get the controller live resource
+			//liveController, err := getLiveNumaflowController(ctx, controller.Name, controller.Namespace)
+			//if err != nil {
+			//	if apierrors.IsNotFound(err) {
+			//		numaLogger.Info("NumaflowController not found, %v", err)
+			//		return ctrl.Result{}, nil
+			//	}
+			//	return ctrl.Result{}, fmt.Errorf("error getting the live controller: %w", err)
+			//}
+			//*controller = *liveController
 			// Check if dependent resources are deleted, if not then requeue
 			if ok, err := r.areDependentResourcesDeleted(ctx, controller); !ok || err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete dependent resources: %v", err)

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -195,21 +195,22 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 		r.recorder.Eventf(nfcRollout, corev1.EventTypeNormal, "Deleting", "Deleting NumaflowControllerRollout")
 		if controllerutil.ContainsFinalizer(nfcRollout, common.FinalizerName) {
 			ppnd.GetPauseModule().DeletePauseRequest(controllerKey)
+			// TODO: this is a temporary fix to delete the controller and its children
 			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
-			foreground := metav1.DeletePropagationForeground
-			if err := r.client.Delete(ctx, nfcRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
-				return ctrl.Result{}, err
-			}
-			// Get the nfcRollout live resource
-			liveControllerRollout, err := getLiveNumaflowControllerRollout(ctx, nfcRollout.Name, nfcRollout.Namespace)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					numaLogger.Info("NumaflowControllerRollout not found, %v", err)
-					return ctrl.Result{}, nil
-				}
-				return ctrl.Result{}, fmt.Errorf("error getting the live numaflow controller rollout: %w", err)
-			}
-			*nfcRollout = *liveControllerRollout
+			//foreground := metav1.DeletePropagationForeground
+			//if err := r.client.Delete(ctx, nfcRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
+			//	return ctrl.Result{}, err
+			//}
+			//// Get the nfcRollout live resource
+			//liveControllerRollout, err := getLiveNumaflowControllerRollout(ctx, nfcRollout.Name, nfcRollout.Namespace)
+			//if err != nil {
+			//	if apierrors.IsNotFound(err) {
+			//		numaLogger.Info("NumaflowControllerRollout not found, %v", err)
+			//		return ctrl.Result{}, nil
+			//	}
+			//	return ctrl.Result{}, fmt.Errorf("error getting the live numaflow controller rollout: %w", err)
+			//}
+			//*nfcRollout = *liveControllerRollout
 			controllerutil.RemoveFinalizer(nfcRollout, common.FinalizerName)
 		}
 

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -607,13 +607,3 @@ func generateNewNumaflowControllerDef(nfcRollout *apiv1.NumaflowControllerRollou
 
 	return newNumaflowControllerDef, nil
 }
-
-func getLiveNumaflowControllerRollout(ctx context.Context, name, namespace string) (*apiv1.NumaflowControllerRollout, error) {
-	numaflowControllerRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().NumaflowControllerRollouts(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	numaflowControllerRollout.SetGroupVersionKind(apiv1.NumaflowControllerRolloutGroupVersionKind)
-
-	return numaflowControllerRollout, err
-}

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -342,21 +342,22 @@ func (r *PipelineRolloutReconciler) reconcile(
 	if !pipelineRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting PipelineRollout")
 		if controllerutil.ContainsFinalizer(pipelineRollout, common.FinalizerName) {
+			// TODO: this is a temporary fix to delete the controller and its children
 			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
-			foreground := metav1.DeletePropagationForeground
-			if err := r.client.Delete(ctx, pipelineRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
-				return 0, nil, err
-			}
-			// Get the PipelineRollout live resource
-			livePipelineRollout, err := getLivePipelineRollout(ctx, pipelineRollout.Name, pipelineRollout.Namespace)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					numaLogger.Info("PipelineRollout not found, %v", err)
-					return 0, nil, nil
-				}
-				return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
-			}
-			*pipelineRollout = *livePipelineRollout
+			//foreground := metav1.DeletePropagationForeground
+			//if err := r.client.Delete(ctx, pipelineRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
+			//	return 0, nil, err
+			//}
+			//// Get the PipelineRollout live resource
+			//livePipelineRollout, err := getLivePipelineRollout(ctx, pipelineRollout.Name, pipelineRollout.Namespace)
+			//if err != nil {
+			//	if apierrors.IsNotFound(err) {
+			//		numaLogger.Info("PipelineRollout not found, %v", err)
+			//		return 0, nil, nil
+			//	}
+			//	return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
+			//}
+			//*pipelineRollout = *livePipelineRollout
 			controllerutil.RemoveFinalizer(pipelineRollout, common.FinalizerName)
 		}
 		// generate the metrics for the Pipeline deletion.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Modifications

- Temporarily comment the foreground deletion code, unless we have a proper fix by this issue https://github.com/numaproj/numaplane/issues/704


### Verification

- Verified in local k8s cluster, now parent resource is not waiting for child to get deleted.

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
