### PR TITLE
feat: add templating for monovertex/pipeline/isbservice spec and metadata

### DIFF
--- a/internal/controller/common/rollout_controller.go
+++ b/internal/controller/common/rollout_controller.go
@@ -285,11 +285,11 @@ func ResolveTemplateSpec(data any, args any, f func([]byte) string) (map[string]
 	}
 
 	// unmarshal into map to be returned and used for resource spec
-	var ret map[string]interface{}
-	err = json.Unmarshal(buf.Bytes(), &ret)
+	var resolvedTmpl map[string]interface{}
+	err = json.Unmarshal(buf.Bytes(), &resolvedTmpl)
 	if err != nil {
 		return nil, err
 	}
 
-	return ret, nil
+	return resolvedTmpl, nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #706 

### Modifications

Adds support for templated definitions of child resources in MonoVertexRollout, PipelineRollout and ISBServiceRollout. This is needed to allow for our rider resources to be referenced by child resources and vice versa.

### Verification

Adding an annotation and a volume to each a MonoVertexRollout, PipelineRollout and ISBServiceRollout which use the arguments we currently support for name and namespace. Below is the MonoVertexRollout spec and the resulting MonoVertex child after a progressive upgrade. 

Rollout spec: 

```
apiVersion: numaplane.numaproj.io/v1alpha1
kind: MonoVertexRollout
metadata:
  name: my-monovertex
  namespace: example-namespace
spec:
  strategy:
    progressive:
      assessmentSchedule: "60,60,10"
    analysis:
      args:
      templates:
  monoVertex:
    #uncomment for Progressive rollout to set Numaflow Controller instance:
    metadata:
      annotations:
        link.argocd.argoproj.io/external-link: https://sbg.nonprod.splunk.intuit.com/en-US/app/search/search?q=search%20(index%3Daccounting-ledger%20source%3Diks2%2Fsbg-qbo-ppd-usw2-k8s%2F*%2F{{.monovertex-namespace}}%2F*)%20OR%20(index%3Diks%20source%3Diks2%2Fsbg-qbo-ppd-usw2-k8s%2F*%2F{{.monovertex-namespace}}%2F*)%20kubernetes_pod%3D{{.monovertex-name}}*&display.page.search.mode=fast&dispatch.sample_ratio=1&earliest=-5m&latest=now
    #    numaflow.numaproj.io/instance: "0"
    spec:
      scale:
        min: 2
        max: 3
        lookbackSeconds: 60
      source:
        udsource:
          container:
            image: quay.io/numaio/numaflow-go/source-simple-source:stable
        transformer:
          container:
            image: docker.intuit.com/quay-rmt/numaio/numaflow-rs/source-transformer-now:stable
      sink:
        udsink:
          container:
            # image: quay.io/numaio/numaflow-go/sink-log:stable
            image: quay.io/numaio/numaflow-java/simple-sink:stable
        volumes:
        - name: test-volume
          configMap:
            name: test-volume-{{.monovertex-name}}
```

Child before and after progressive update (status omitted) :
```
apiVersion: v1
items: 
- apiVersion: numaflow.numaproj.io/v1alpha1
  kind: MonoVertex
  metadata:
    annotations:
      link.argocd.argoproj.io/external-link: https://sbg.nonprod.splunk.intuit.com/en-US/app/search/search?q=search%20(index%3Daccounting-ledger%20source%3Diks2%2Fsbg-qbo-ppd-usw2-k8s%2F*%2Fexample-namespace%2F*)%20OR%20(index%3Diks%20source%3Diks2%2Fsbg-qbo-ppd-usw2-k8
s%2F*%2Fexample-namespace%2F*)%20kubernetes_pod%3Dmy-monovertex-0*&display.page.search.mode=fast&dispatch.sample_ratio=1&earliest=-5m&latest=now
    creationTimestamp: "2025-04-22T21:54:02Z"
    generation: 1
    labels:
      numaplane.numaproj.io/parent-rollout-name: my-monovertex
      numaplane.numaproj.io/upgrade-state: promoted
    name: my-monovertex-0
    namespace: example-namespace
    ownerReferences:
    - apiVersion: numaplane.numaproj.io/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: MonoVertexRollout
      name: my-monovertex
      uid: 533970c3-7c7e-4aef-88da-a065a905ab01
    resourceVersion: "1334257"
    uid: 1b5f6b9d-6549-4447-a77a-3f81ba79f027
  spec:
    scale:
      lookbackSeconds: 60
      max: 3
      min: 2
    sink:
      udsink:
        container:
          image: quay.io/numaio/numaflow-java/simple-sink:stable
      volumes:
      - configMap:
          name: test-volume-my-monovertex-0
        name: test-volume
    source:
      transformer:
        container:
          image: docker.intuit.com/quay-rmt/numaio/numaflow-rs/source-transformer-now:stable
      udsource:
        container:
          image: quay.io/numaio/numaflow-go/source-simple-source:stable
```

```
apiVersion: v1
items: 
- apiVersion: numaflow.numaproj.io/v1alpha1
  kind: MonoVertex
  metadata:
    annotations:
      link.argocd.argoproj.io/external-link: https://sbg.nonprod.splunk.intuit.com/en-US/app/search/search?q=search%20(index%3Daccounting-ledger%20source%3Diks2%2Fsbg-qbo-ppd-usw2-k8s%2F*%2Fexample-namespace%2F*)%20OR%20(index%3Diks%20source%3Diks2%2Fsbg-qbo-ppd-usw2-k8
s%2F*%2Fexample-namespace%2F*)%20kubernetes_pod%3Dmy-monovertex-1*&display.page.search.mode=fast&dispatch.sample_ratio=1&earliest=-5m&latest=now
    creationTimestamp: "2025-04-22T21:55:27Z"
    generation: 2
    labels:
      numaplane.numaproj.io/parent-rollout-name: my-monovertex
      numaplane.numaproj.io/upgrade-state: promoted
      numaplane.numaproj.io/upgrade-state-reason: progressive-success
    name: my-monovertex-1
    namespace: example-namespace
    ownerReferences:
    - apiVersion: numaplane.numaproj.io/v1alpha1
      blockOwnerDeletion: true
      controller: true
      kind: MonoVertexRollout
      name: my-monovertex
      uid: 533970c3-7c7e-4aef-88da-a065a905ab01
    resourceVersion: "1334890"
    uid: ae6ac36f-2b56-48ed-ae25-b879b3abf16c
  spec:
    scale:
      lookbackSeconds: 60
      max: 3
      min: 2
    sink:
      udsink:
        container:
          image: quay.io/numaio/numaflow-go/sink-log:stable
      volumes:
      - configMap:
          name: test-volume-my-monovertex-1
        name: test-volume
    source:
      transformer:
        container:
          image: docker.intuit.com/quay-rmt/numaio/numaflow-rs/source-transformer-now:stable
      udsource:
        container:
          image: quay.io/numaio/numaflow-go/source-simple-source:stable
```

### Backward incompatibilities

Older versions of Numaplane will not be able to reconcile these templated definitions of child resources. Older rollouts of updated versions of Numaplane will work the same as rollouts using no templating are not affected.
