### PR TITLE
fix: Removed foreground deletion from pipeline rollout

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -986,6 +986,10 @@ func (r *ISBServiceRolloutReconciler) listAndDeleteChildISBServices(ctx context.
 	isbServiceList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, numaflowv1.ISBGroupVersionResource.Resource,
 		isbServiceRollout.Namespace, fmt.Sprintf("%s=%s", common.LabelKeyParentRollout, isbServiceRollout.Name), "")
 	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			numaLogger.Warnf("no child ISBServices found for ISBServiceRollout %s/%s: %v", isbServiceRollout.Namespace, isbServiceRollout.Name, err)
+			return false, nil
+		}
 		return false, err
 	}
 	if isbServiceList != nil && len(isbServiceList.Items) > 0 {

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -986,7 +986,7 @@ func (r *ISBServiceRolloutReconciler) listAndDeleteChildISBServices(ctx context.
 	isbServiceList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, numaflowv1.ISBGroupVersionResource.Resource,
 		isbServiceRollout.Namespace, fmt.Sprintf("%s=%s", common.LabelKeyParentRollout, isbServiceRollout.Name), "")
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			numaLogger.Warnf("no child ISBServices found for ISBServiceRollout %s/%s: %v", isbServiceRollout.Namespace, isbServiceRollout.Name, err)
 			return false, nil
 		}

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -1265,7 +1265,7 @@ func (r *PipelineRolloutReconciler) listAndDeleteChildPipelines(ctx context.Cont
 	pipelineList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, numaflowv1.PipelineGroupVersionResource.Resource,
 		pipelineRollout.Namespace, fmt.Sprintf("%s=%s", common.LabelKeyParentRollout, pipelineRollout.Name), "")
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			numaLogger.Warnf("no child pipeline found for PipelineRollout %s/%s: %v", pipelineRollout.Namespace, pipelineRollout.Name, err)
 			return false, nil
 		}

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -342,22 +342,15 @@ func (r *PipelineRolloutReconciler) reconcile(
 	if !pipelineRollout.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting PipelineRollout")
 		if controllerutil.ContainsFinalizer(pipelineRollout, common.FinalizerName) {
-			// TODO: this is a temporary fix to delete the controller and its children
-			// Set the foreground deletion policy so that we will block for children to be cleaned up for any type of deletion action
-			//foreground := metav1.DeletePropagationForeground
-			//if err := r.client.Delete(ctx, pipelineRollout, &client.DeleteOptions{PropagationPolicy: &foreground}); err != nil {
-			//	return 0, nil, err
-			//}
-			//// Get the PipelineRollout live resource
-			//livePipelineRollout, err := getLivePipelineRollout(ctx, pipelineRollout.Name, pipelineRollout.Namespace)
-			//if err != nil {
-			//	if apierrors.IsNotFound(err) {
-			//		numaLogger.Info("PipelineRollout not found, %v", err)
-			//		return 0, nil, nil
-			//	}
-			//	return 0, nil, fmt.Errorf("error getting the live PipelineRollout: %w", err)
-			//}
-			//*pipelineRollout = *livePipelineRollout
+			// delete the PipelineRollout child objects once the PipelineRollout is being deleted
+			requeue, err := r.listAndDeleteChildPipelines(ctx, pipelineRollout)
+			if err != nil {
+				return 0, nil, fmt.Errorf("error deleting pipelineRollout child: %v", err)
+			}
+			// if we have any pipelines that are still in the process of being deleted, requeue
+			if requeue {
+				return 5 * time.Second, nil, nil
+			}
 			controllerutil.RemoveFinalizer(pipelineRollout, common.FinalizerName)
 		}
 		// generate the metrics for the Pipeline deletion.
@@ -636,40 +629,17 @@ func pipelineObservedGenerationCurrent(generation int64, observedGeneration int6
 func (r *PipelineRolloutReconciler) processPipelineStatus(ctx context.Context, pipelineRollout *apiv1.PipelineRollout, existingPipelineDef *unstructured.Unstructured) error {
 	numaLogger := logger.FromContext(ctx)
 
-	// Only fetch the latest pipeline object while deleting the pipeline object, i.e. when pipelineRollout.DeletionTimestamp.IsZero() is false
-	if existingPipelineDef == nil {
-		// determine name of the promoted Pipeline
-		pipelineName, err := ctlrcommon.GetChildName(ctx, pipelineRollout, r, common.LabelValueUpgradePromoted, nil, r.client, true)
+	if existingPipelineDef != nil {
+		pipelineStatus, err := kubernetes.ParseStatus(existingPipelineDef)
 		if err != nil {
-			return fmt.Errorf("Unable to process pipeline status: err=%s", err)
+			return fmt.Errorf("failed to parse Pipeline Status from pipeline CR: %+v, %v", existingPipelineDef, err)
 		}
-		pipelineDef := &unstructured.Unstructured{}
-		pipelineDef.SetGroupVersionKind(numaflowv1.PipelineGroupVersionKind)
-		pipelineDef.SetNamespace(pipelineRollout.Namespace)
-		pipelineDef.SetName(pipelineName)
 
-		livePipelineDef, err := kubernetes.GetLiveResource(ctx, pipelineDef, "pipelines")
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				numaLogger.WithValues("pipelineDefinition", *pipelineDef).Warn("Pipeline not found. Unable to process status during this reconciliation.")
-				return nil
-			} else {
-				return fmt.Errorf("error getting Pipeline for status processing: %v", err)
-			}
-		}
-		existingPipelineDef = livePipelineDef
+		numaLogger.Debugf("pipeline status: %v", pipelineStatus)
+
+		r.setChildResourcesHealthCondition(pipelineRollout, existingPipelineDef, &pipelineStatus)
+		r.setChildResourcesPauseCondition(pipelineRollout, &pipelineStatus)
 	}
-
-	pipelineStatus, err := kubernetes.ParseStatus(existingPipelineDef)
-	if err != nil {
-		return fmt.Errorf("failed to parse Pipeline Status from pipeline CR: %+v, %v", existingPipelineDef, err)
-	}
-
-	numaLogger.Debugf("pipeline status: %v", pipelineStatus)
-
-	r.setChildResourcesHealthCondition(pipelineRollout, existingPipelineDef, &pipelineStatus)
-	r.setChildResourcesPauseCondition(pipelineRollout, &pipelineStatus)
-
 	return nil
 }
 
@@ -1286,4 +1256,30 @@ func getLivePipelineRollout(ctx context.Context, name, namespace string) (*apiv1
 	PipelineRollout.SetGroupVersionKind(apiv1.PipelineRolloutGroupVersionKind)
 
 	return PipelineRollout, err
+}
+
+// listAndDeleteChildPipelines lists all child pipelines and deletes them
+// return true if we need to requeue
+func (r *PipelineRolloutReconciler) listAndDeleteChildPipelines(ctx context.Context, pipelineRollout *apiv1.PipelineRollout) (bool, error) {
+	numaLogger := logger.FromContext(ctx)
+	pipelineList, err := kubernetes.ListLiveResource(ctx, common.NumaflowAPIGroup, common.NumaflowAPIVersion, numaflowv1.PipelineGroupVersionResource.Resource,
+		pipelineRollout.Namespace, fmt.Sprintf("%s=%s", common.LabelKeyParentRollout, pipelineRollout.Name), "")
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			numaLogger.Warnf("no child pipeline found for PipelineRollout %s/%s: %v", pipelineRollout.Namespace, pipelineRollout.Name, err)
+			return false, nil
+		}
+		return false, err
+	}
+	if pipelineList != nil && len(pipelineList.Items) > 0 {
+		// Delete all pipelines that are children of this PipelineRollout
+		numaLogger.Infof("Deleting pipeline %s/%s", pipelineRollout.Namespace, pipelineRollout.Name)
+		for _, pipeline := range pipelineList.Items {
+			if err := r.client.Delete(ctx, &pipeline); err != nil {
+				return false, err
+			}
+		}
+		return true, nil
+	}
+	return false, nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Part of: #704 

### Modifications

- Removed foreground deletion code
- Added logic to delete dependent pipeline before removing the finalizer from pipelineRollout

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->
- Verified in local k8s cluster

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
