### PR TITLE
feat: improve templating by evaluating rollout specs with hyphenated arguments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.10.0
+	github.com/valyala/fasttemplate v1.2.2
 	golang.org/x/sync v0.10.0
 	golang.org/x/tools v0.26.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -131,7 +132,6 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/toqueteos/webbrowser v1.2.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.mongodb.org/mongo-driver v1.15.0 // indirect

--- a/internal/controller/common/rollout_controller.go
+++ b/internal/controller/common/rollout_controller.go
@@ -259,8 +259,7 @@ func GetChildName(ctx context.Context, rolloutObject RolloutObject, controller R
 	}
 }
 
-// resolves templated definitions of a child resource with arguments for name and namespace
-// for resources that reference each other, arguments will be dynamically updated with current name of child
+// resolves templated definitions of a resource with any arguments
 func ResolveTemplateSpec(data any, args map[string]interface{}) (map[string]interface{}, error) {
 
 	// marshal data to cast as a string

--- a/internal/controller/common/rollout_controller.go
+++ b/internal/controller/common/rollout_controller.go
@@ -268,10 +268,9 @@ func ResolveTemplateSpec(data any, args map[string]interface{}) (map[string]inte
 	if err != nil {
 		return nil, err
 	}
-	dataString := string(dataBytes)
 
 	// create and execute template with supplied arguments
-	tmpl, err := fasttemplate.NewTemplate(dataString, "{{", "}}")
+	tmpl, err := fasttemplate.NewTemplate(string(dataBytes), "{{", "}}")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/common/rollout_controller_test.go
+++ b/internal/controller/common/rollout_controller_test.go
@@ -13,6 +13,103 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// This tests the ResolveTemplateSpec function
+// This function resolves any templated definition with the provided arguments
+func TestResolveTemplateSpec(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		data           any
+		args           map[string]interface{}
+		expectedOutput map[string]interface{}
+	}{
+		{
+			name: "multiple arguments",
+			data: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configMap": map[string]interface{}{
+						"name":      "test-volume-{{.monovertex-name}}",
+						"namespace": "{{.monovertex-namespace}}",
+					},
+				},
+			},
+			args: map[string]interface{}{
+				".monovertex-name":      "my-monovertex-0",
+				".monovertex-namespace": "test-namespace",
+			},
+			expectedOutput: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configMap": map[string]interface{}{
+						"name":      "test-volume-my-monovertex-0",
+						"namespace": "test-namespace",
+					},
+				},
+			},
+		},
+		{
+			name: "argument is used multiple times",
+			data: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"link.argocd.argoproj.io/external-link": "https://splunk.intuit.com/en-US/app/search/search?q=search%20(index%3Daccounting-ledger%20source%3Diks2%2Fsbg-qbo-ppd-usw2-k8s%2F*%2F{{.monovertex-namespace}}%2F*)%20OR%20(index%3Diks%20source%3Diks2%2Fsbg-qbo-ppd-usw2-k8s%2F*%2F{{.monovertex-namespace}}%2F*)%20kubernetes_pod%3D{{.monovertex-name}}*&display.page.search.mode=fast&dispatch.sample_ratio=1&earliest=-5m&latest=now",
+				},
+				"spec": map[string]interface{}{
+					"configMap": map[string]interface{}{
+						"name":      "test-volume-{{.monovertex-name}}",
+						"namespace": "{{.monovertex-namespace}}",
+					},
+				},
+			},
+			args: map[string]interface{}{
+				".monovertex-name":      "my-monovertex-0",
+				".monovertex-namespace": "test-namespace",
+			},
+			expectedOutput: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"link.argocd.argoproj.io/external-link": "https://splunk.intuit.com/en-US/app/search/search?q=search%20(index%3Daccounting-ledger%20source%3Diks2%2Fsbg-qbo-ppd-usw2-k8s%2F*%2Ftest-namespace%2F*)%20OR%20(index%3Diks%20source%3Diks2%2Fsbg-qbo-ppd-usw2-k8s%2F*%2Ftest-namespace%2F*)%20kubernetes_pod%3Dmy-monovertex-0*&display.page.search.mode=fast&dispatch.sample_ratio=1&earliest=-5m&latest=now",
+				},
+				"spec": map[string]interface{}{
+					"configMap": map[string]interface{}{
+						"name":      "test-volume-my-monovertex-0",
+						"namespace": "test-namespace",
+					},
+				},
+			},
+		},
+		{
+			name: "input is not templated",
+			data: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configMap": map[string]interface{}{
+						"name":      "test-volume-my-monovertex-0",
+						"namespace": "test-namespace",
+					},
+				},
+			},
+			args: map[string]interface{}{
+				".monovertex-name":      "my-monovertex-0",
+				".monovertex-namespace": "test-namespace",
+			},
+			expectedOutput: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"configMap": map[string]interface{}{
+						"name":      "test-volume-my-monovertex-0",
+						"namespace": "test-namespace",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ResolveTemplateSpec(tt.data, tt.args)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedOutput, result)
+		})
+	}
+
+}
+
 // This tests the FindMostCurrentChildOfUpgradeState() function
 // This function both finds the most current child of the upgrade-state, but also recycles any others that are found
 // So, it should only be called if there in fact should be only one child of that upgrade-state in existence

--- a/internal/controller/common/rollout_controller_test.go
+++ b/internal/controller/common/rollout_controller_test.go
@@ -24,7 +24,7 @@ func TestResolveTemplateSpec(t *testing.T) {
 		expectedOutput map[string]interface{}
 	}{
 		{
-			name: "multiple arguments",
+			name: "standard test",
 			data: map[string]interface{}{
 				"spec": map[string]interface{}{
 					"configMap": map[string]interface{}{

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -57,7 +56,9 @@ import (
 )
 
 const (
-	ControllerISBSVCRollout = "isbsvc-rollout-controller"
+	ControllerISBSVCRollout     = "isbsvc-rollout-controller"
+	TemplateISBServiceName      = ".isbsvc-name"
+	TemplateISBServiceNamespace = ".isbsvc-namespace"
 )
 
 // ISBServiceRolloutReconciler reconciles an ISBServiceRollout object
@@ -855,27 +856,18 @@ func (r *ISBServiceRolloutReconciler) makeISBServiceDefinition(
 	isbsvcName string,
 	metadata apiv1.Metadata,
 ) (*unstructured.Unstructured, error) {
-	args := struct {
-		ISBSvcName      string
-		ISBSvcNamespace string
-	}{
-		ISBSvcName:      isbsvcName,
-		ISBSvcNamespace: isbServiceRollout.Namespace,
+
+	args := map[string]interface{}{
+		TemplateISBServiceName:      isbsvcName,
+		TemplateISBServiceNamespace: isbServiceRollout.Namespace,
 	}
 
-	f := func(data []byte) string {
-		dataString := string(data)
-		dataString = strings.ReplaceAll(dataString, "isbsvc-name", "ISBSvcName")
-		dataString = strings.ReplaceAll(dataString, "isbsvc-namespace", "ISBSvcNamespace")
-		return dataString
-	}
-
-	isbServiceSpec, err := ctlrcommon.ResolveTemplateSpec(isbServiceRollout.Spec.InterStepBufferService.Spec, args, f)
+	isbServiceSpec, err := ctlrcommon.ResolveTemplateSpec(isbServiceRollout.Spec.InterStepBufferService.Spec, args)
 	if err != nil {
 		return nil, err
 	}
 
-	metadataResolved, err := ctlrcommon.ResolveTemplateSpec(metadata, args, f)
+	metadataResolved, err := ctlrcommon.ResolveTemplateSpec(metadata, args)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -57,6 +57,8 @@ import (
 
 const (
 	ControllerMonoVertexRollout = "monovertex-rollout-controller"
+	TemplateMonoVertexName      = ".monovertex-name"
+	TemplateMonoVertexNamespace = ".monovertex-namespace"
 )
 
 // MonoVertexRolloutReconciler reconciles a MonoVertexRollout object
@@ -627,27 +629,18 @@ func (r *MonoVertexRolloutReconciler) makeMonoVertexDefinition(
 	monoVertexName string,
 	metadata apiv1.Metadata,
 ) (*unstructured.Unstructured, error) {
-	args := struct {
-		MonoVertexName      string
-		MonoVertexNamespace string
-	}{
-		MonoVertexName:      monoVertexName,
-		MonoVertexNamespace: monoVertexRollout.Namespace,
+
+	args := map[string]interface{}{
+		TemplateMonoVertexName:      monoVertexName,
+		TemplateMonoVertexNamespace: monoVertexRollout.Namespace,
 	}
 
-	f := func(data []byte) string {
-		dataString := string(data)
-		dataString = strings.ReplaceAll(dataString, "monovertex-name", "MonoVertexName")
-		dataString = strings.ReplaceAll(dataString, "monovertex-namespace", "MonoVertexNamespace")
-		return dataString
-	}
-
-	monoVertexSpec, err := ctlrcommon.ResolveTemplateSpec(monoVertexRollout.Spec.MonoVertex.Spec, args, f)
+	monoVertexSpec, err := ctlrcommon.ResolveTemplateSpec(monoVertexRollout.Spec.MonoVertex.Spec, args)
 	if err != nil {
 		return nil, err
 	}
 
-	metadataResolved, err := ctlrcommon.ResolveTemplateSpec(metadata, args, f)
+	metadataResolved, err := ctlrcommon.ResolveTemplateSpec(metadata, args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

Instead of having the kludgey approach of replacing the hyphenated arguments in a rollout spec before evaluating it as a template, we can utilize the `fasttemplate` package which can evaluate these arguments without error. 

### Verification

Testing multiple Pipeline and MonoVertex rollouts after progressive upgrades to see the values in the child resources are updated properly.

### Backward incompatibilities

n/a
