### PR TITLE
fix: post-failure code was referring to the old upgrading child rather than the new one

### DIFF
--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -380,9 +380,12 @@ func processUpgradingChild(
 			return false, 0, err
 		}
 
-		// if so, create a new upgrading one and mark the existing one for garbage collection
+		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+		// Replace existing Upgrading child with new one and mark the existing one for garbage collection
+		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 		if needsUpdating {
-			_, needRequeue, err := startUpgradeProcess(ctx, rolloutObject, existingPromotedChildDef, controller, c)
+			needRequeue := false
+			newUpgradingChildDef, needRequeue, err = startUpgradeProcess(ctx, rolloutObject, existingPromotedChildDef, controller, c)
 			if err != nil {
 				return false, 0, err
 			}
@@ -392,6 +395,7 @@ func processUpgradingChild(
 
 			numaLogger.WithValues("old child", existingUpgradingChildDef.GetName(), "new child", newUpgradingChildDef.GetName()).Debug("replacing 'upgrading' child")
 			reasonFailure := common.LabelValueProgressiveFailure
+			// mark recyclable the existing upgrading child
 			err = ctlrcommon.UpdateUpgradeState(ctx, c, common.LabelValueUpgradeRecyclable, &reasonFailure, existingUpgradingChildDef)
 			if err != nil {
 				return false, 0, err
@@ -399,17 +403,19 @@ func processUpgradingChild(
 		}
 		childStatus = rolloutObject.GetUpgradingChildStatus()
 
-		// do post-upgrade process if we haven't (check that AssessmentResult is not set just in case)
+		// After creating the new Upgradng child, do post-upgrade process (check that AssessmentResult is not set just in case) and return
 		if !childStatus.InitializationComplete && childStatus.AssessmentResult == apiv1.AssessmentResultUnknown {
 
-			needsRequeue, err := startPostUpgradeProcess(ctx, rolloutObject, existingPromotedChildDef, existingUpgradingChildDef, controller, c)
+			needsRequeue, err := startPostUpgradeProcess(ctx, rolloutObject, existingPromotedChildDef, newUpgradingChildDef, controller, c)
 			if needsRequeue {
 				return false, common.DefaultRequeueDelay, err
 			} else {
 				return false, 0, err
 			}
 		}
+		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+		// if we didn't return above, we are just handling standard failure case with no new Upgrading child to replace the old one
 		requeue, err := controller.ProcessPromotedChildPostFailure(ctx, rolloutObject, existingPromotedChildDef, c)
 		if err != nil {
 			return false, 0, err
@@ -636,7 +642,7 @@ func startPostUpgradeProcess(
 	ctx context.Context,
 	rolloutObject ProgressiveRolloutObject,
 	existingPromotedChild *unstructured.Unstructured,
-	existingUpgradingChild *unstructured.Unstructured,
+	newUpgradingChild *unstructured.Unstructured,
 	controller progressiveController,
 	c client.Client,
 ) (bool, error) {
@@ -644,7 +650,7 @@ func startPostUpgradeProcess(
 
 	numaLogger.WithValues(
 		"promoted child", existingPromotedChild.GetName(),
-		"upgading child", existingUpgradingChild).Debug("starting post upgrade process")
+		"upgading child", newUpgradingChild).Debug("starting post upgrade process")
 
 	requeue, err := controller.ProcessPromotedChildPostUpgrade(ctx, rolloutObject, existingPromotedChild, c)
 	if err != nil {
@@ -653,7 +659,7 @@ func startPostUpgradeProcess(
 	if requeue {
 		return true, nil
 	}
-	requeue, err = controller.ProcessUpgradingChildPostUpgrade(ctx, rolloutObject, existingUpgradingChild, c)
+	requeue, err = controller.ProcessUpgradingChildPostUpgrade(ctx, rolloutObject, newUpgradingChild, c)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

This fixes a bug in which after failure case, the previous "upgrading child" was being used to perform `ProcessUpgradingChildPostUpgrade()` rather than the new one.

Thankfully, only ISBServiceRollout implements anything that happens in `ProcessUpgradingChildPostUpgrade()` at least, but it was operating on the wrong child.


### Verification

Updated ISBServiceRollout to cause failure. Then updated a second time. Observed that the PDB created was for the new isbsvc.

### Backward incompatibilities

n/a
