### PR TITLE
feat: Riders for pipeline and isbsvc

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_isbservicerollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_isbservicerollout.yaml
@@ -7,6 +7,14 @@ spec:
   strategy:
     progressive:
       assessmentSchedule: "0,60,10"
+  riders:
+    - definition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: source-configmap
+        data:
+          something: something
   interStepBufferService:
     #uncomment for Progressive rollout to set Numaflow Controller instance:
     #metadata:

--- a/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
@@ -10,6 +10,18 @@ spec:
     analysis:
       args:
       templates:
+  riders:
+    - perVertex: true
+      definition:
+        apiVersion: autoscaling.k8s.io/v1beta2
+        kind: VerticalPodAutoscaler
+        metadata: 
+          name: vpa
+        spec:
+          targetRef: 
+            apiVersion: numaproj.io/v1alpha1
+            kind: Vertex
+            name: '{{.pipeline-name}}-{{.vertex-name}}'
   pipeline:
     #uncomment for Progressive rollout to set Numaflow Controller instance:
     #metadata:

--- a/internal/controller/common/rollout_controller.go
+++ b/internal/controller/common/rollout_controller.go
@@ -27,7 +27,11 @@ type RolloutController interface {
 	Recycle(ctx context.Context, childObject *unstructured.Unstructured, c client.Client) (bool, error)
 
 	// GetDesiredRiders gets the list of Riders as specified in the RolloutObject, templated for the specific child name and
-	// based on the child definition
+	// based on the child definition.
+	// Note the child name can be different from child.GetName()
+	// The child name is what's used for templating the Rider definition, while the `child` is really only used by the PipelineRolloutReconciler
+	// in the case of "per-vertex" Riders. In this case, it's necessary to use the existing child's name to template in order to effectively compare whether the
+	// Rider has changed, but use the latest child definition to derive the current list of Vertices that need Riders.
 	GetDesiredRiders(rolloutObject RolloutObject, childName string, child *unstructured.Unstructured) ([]riders.Rider, error)
 
 	// GetExistingRiders gets the list of Riders that already exists, either for the Promoted child or the Upgrading child depending on the value of "upgrading"

--- a/internal/controller/common/rollout_controller.go
+++ b/internal/controller/common/rollout_controller.go
@@ -26,8 +26,9 @@ type RolloutController interface {
 	// Recycle deletes child; returns true if it was in fact deleted
 	Recycle(ctx context.Context, childObject *unstructured.Unstructured, c client.Client) (bool, error)
 
-	// GetDesiredRiders gets the list of Riders as specified in the RolloutObject, templated for the specific child definition
-	GetDesiredRiders(rolloutObject RolloutObject, child *unstructured.Unstructured) ([]riders.Rider, error)
+	// GetDesiredRiders gets the list of Riders as specified in the RolloutObject, templated for the specific child name and
+	// based on the child definition
+	GetDesiredRiders(rolloutObject RolloutObject, childName string, child *unstructured.Unstructured) ([]riders.Rider, error)
 
 	// GetExistingRiders gets the list of Riders that already exists, either for the Promoted child or the Upgrading child depending on the value of "upgrading"
 	GetExistingRiders(ctx context.Context, rolloutObject RolloutObject, upgrading bool) (unstructured.UnstructuredList, error)
@@ -277,7 +278,7 @@ func CreateRidersForNewChild(
 ) error {
 
 	// create definitions for riders by templating what's defined in the Rollout definition with the child definition
-	newRiders, err := controller.GetDesiredRiders(rolloutObject, child)
+	newRiders, err := controller.GetDesiredRiders(rolloutObject, child.GetName(), child)
 	if err != nil {
 		return fmt.Errorf("error getting desired Riders for child %s: %s", child.GetName(), err)
 	}

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -266,6 +266,9 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 				if err = r.applyPodDisruptionBudget(ctx, newISBServiceDef); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to apply PodDisruptionBudget for ISBService %s, err: %v", newISBServiceDef.GetName(), err)
 				}
+				if err := ctlrcommon.CreateRidersForNewChild(ctx, r, isbServiceRollout, newISBServiceDef, r.client); err != nil {
+					return ctrl.Result{}, fmt.Errorf("error creating riders: %s", err)
+				}
 
 				isbServiceRollout.Status.MarkDeployed(isbServiceRollout.Generation)
 				r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerISBSVCRollout, "create").Observe(time.Since(startTime).Seconds())
@@ -338,24 +341,35 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 
 	numaLogger := logger.FromContext(ctx)
 
+	// get the list of Riders that we need based on the PipelineRollout definition
+	currentRiderList, err := r.GetDesiredRiders(isbServiceRollout, existingISBServiceDef.GetName(), newISBServiceDef)
+	if err != nil {
+		return 0, fmt.Errorf("error getting desired Riders for pipeline %s: %s", existingISBServiceDef.GetName(), err)
+	}
+	// get the list of Riders that we have now (for promoted child)
+	existingRiderList, err := r.GetExistingRiders(ctx, isbServiceRollout, false)
+	if err != nil {
+		return 0, fmt.Errorf("error getting existing Riders for pipeline %s: %s", existingISBServiceDef.GetName(), err)
+	}
+
 	// update our Status with the ISBService's Status
 	r.processISBServiceStatus(ctx, existingISBServiceDef, isbServiceRollout)
 
 	// determine if we're trying to update the ISBService spec
 	// if it's a simple change, direct apply
 	// if not, it will require PPND or Progressive
-	isbServiceNeedsToUpdate, upgradeStrategyType, needsRecreate, _, _, _, err := usde.ResourceNeedsUpdating(ctx, newISBServiceDef, existingISBServiceDef, []riders.Rider{}, unstructured.UnstructuredList{})
+	needsUpdate, upgradeStrategyType, needsRecreate, riderAdditions, riderModifications, riderDeletions, err := usde.ResourceNeedsUpdating(ctx, newISBServiceDef, existingISBServiceDef, currentRiderList, existingRiderList)
 	if err != nil {
 		return 0, err
 	}
 	numaLogger.
-		WithValues("isbserviceNeedsToUpdate", isbServiceNeedsToUpdate, "upgradeStrategyType", upgradeStrategyType).
+		WithValues("needsUpdate", needsUpdate, "upgradeStrategyType", upgradeStrategyType).
 		Debug("Upgrade decision result")
 
 	// set the Status appropriately to "Pending" or "Deployed"
-	// if isbServiceNeedsToUpdate - this means there's a mismatch between the desired ISBService spec and actual ISBService spec
+	// if needsUpdate - this means there's a mismatch between the desired ISBService spec and actual ISBService spec
 	// Note that this will be reset to "Deployed" later on if a deployment occurs
-	if isbServiceNeedsToUpdate {
+	if needsUpdate {
 		isbServiceRollout.Status.MarkPending()
 	} else {
 		isbServiceRollout.Status.MarkDeployed(isbServiceRollout.Generation)
@@ -394,6 +408,20 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 		newISBServiceDef = r.merge(existingISBServiceDef, newISBServiceDef)
 	}
 
+	// Roll out any changes to Riders in K8S
+	// Note for Progressive we have special logic, since the update needs to be for the upgrading child
+	if inProgressStrategy != apiv1.UpgradeStrategyProgressive {
+		if inProgressStrategy != apiv1.UpgradeStrategyNoOp {
+			// update the cluster to reflect the Rider additions, modifications, and deletions
+			if err := riders.UpdateRidersInK8S(ctx, newISBServiceDef, riderAdditions, riderModifications, riderDeletions, r.client); err != nil {
+				return 0, err
+			}
+		}
+
+		// update the list of riders in the Status
+		r.SetCurrentRiderList(isbServiceRollout, currentRiderList)
+	}
+
 	switch inProgressStrategy {
 	case apiv1.UpgradeStrategyPPND:
 
@@ -402,7 +430,7 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 			return 0, fmt.Errorf("error determining if ISBService is updating: %v", err)
 		}
 
-		done, err := ppnd.ProcessChildObjectWithPPND(ctx, r.client, isbServiceRollout, r, isbServiceNeedsToUpdate, isbServiceIsUpdating, func() error {
+		done, err := ppnd.ProcessChildObjectWithPPND(ctx, r.client, isbServiceRollout, r, needsUpdate, isbServiceIsUpdating, func() error {
 			r.recorder.Eventf(isbServiceRollout, corev1.EventTypeNormal, "PipelinesPaused", "All Pipelines have paused for ISBService update")
 			err = r.updateISBService(ctx, isbServiceRollout, newISBServiceDef, needsRecreate)
 			if err != nil {
@@ -415,6 +443,7 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 		if err != nil {
 			return 0, err
 		}
+
 		if done {
 			r.inProgressStrategyMgr.UnsetStrategy(ctx, isbServiceRollout)
 		} else {
@@ -424,11 +453,18 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 	case apiv1.UpgradeStrategyProgressive:
 		numaLogger.Debug("processing InterstepBufferService with Progressive")
 
-		done, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, isbServiceRollout, existingISBServiceDef, isbServiceNeedsToUpdate, r, r.client)
+		done, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, isbServiceRollout, existingISBServiceDef, needsUpdate, r, r.client)
 		if err != nil {
-			return 0, fmt.Errorf("Error processing isbsvc with progressive: %s", err.Error())
+			return 0, fmt.Errorf("error processing isbsvc with progressive: %s", err.Error())
 		}
 		if done {
+			// update the list of riders in the Status based on our child which was just promoted
+			currentRiderList, err := r.GetDesiredRiders(isbServiceRollout, existingISBServiceDef.GetName(), newISBServiceDef)
+			if err != nil {
+				return 0, fmt.Errorf("error getting desired Riders for pipeline %s: %s", newISBServiceDef.GetName(), err)
+			}
+			r.SetCurrentRiderList(isbServiceRollout, currentRiderList)
+
 			r.inProgressStrategyMgr.UnsetStrategy(ctx, isbServiceRollout)
 		} else {
 
@@ -451,6 +487,7 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 		if err != nil {
 			return 0, fmt.Errorf("error updating ISBService, %s: %v", inProgressStrategy, err)
 		}
+
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerISBSVCRollout, "update").Observe(time.Since(syncStartTime).Seconds())
 	case apiv1.UpgradeStrategyNoOp:
 		break
@@ -473,7 +510,7 @@ func (r *ISBServiceRolloutReconciler) updateISBService(ctx context.Context, isbS
 		// enqueue Pipeline Rollouts because they will need to be marked "recyclable" as well
 		err = r.enqueueAllPipelineROsForChildISBSvc(ctx, newISBServiceDef)
 		if err != nil {
-			return fmt.Errorf("Failed to enqueue pipelines after marking isbservice as recyclable: %s", err.Error())
+			return fmt.Errorf("failed to enqueue pipelines after marking isbservice as recyclable: %s", err.Error())
 		}
 	} else {
 		if err := kubernetes.UpdateResource(ctx, r.client, newISBServiceDef); err != nil {
@@ -546,9 +583,9 @@ func (r *ISBServiceRolloutReconciler) isISBServiceUpdating(ctx context.Context, 
 		return false, false, err
 	}
 
-	isbServiceNeedsToUpdate := !util.CompareStructNumTypeAgnostic(existingSpecAsMap, newSpecAsMap)
+	needsUpdate := !util.CompareStructNumTypeAgnostic(existingSpecAsMap, newSpecAsMap)
 
-	return isbServiceNeedsToUpdate, !isbServiceReconciled, nil
+	return needsUpdate, !isbServiceReconciled, nil
 }
 
 func (r *ISBServiceRolloutReconciler) getPipelineRolloutList(ctx context.Context, isbRolloutNamespace string, isbsvcRolloutName string) ([]apiv1.PipelineRollout, error) {
@@ -993,14 +1030,38 @@ func getLiveISBServiceRollout(ctx context.Context, name, namespace string) (*api
 }
 
 func (r *ISBServiceRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.RolloutObject, isbsvcName string, isbsvcDef *unstructured.Unstructured) ([]riders.Rider, error) {
+	isbServiceRollout := rolloutObject.(*apiv1.ISBServiceRollout)
 	desiredRiders := []riders.Rider{}
-	// TODO
+	for _, rider := range isbServiceRollout.Spec.Riders {
+		var asMap map[string]interface{}
+		if err := util.StructToStruct(rider.Definition, &asMap); err != nil {
+			return desiredRiders, fmt.Errorf("rider definition could not converted to map: %w", err)
+		}
+		resolvedMap, err := util.ResolveTemplateSpec(asMap, map[string]interface{}{
+			TemplateISBServiceName:      isbsvcName,
+			TemplateISBServiceNamespace: isbServiceRollout.Namespace,
+		})
+		if err != nil {
+			return desiredRiders, err
+		}
+		unstruc := unstructured.Unstructured{}
+		unstruc.Object = resolvedMap
+		unstruc.SetNamespace(isbServiceRollout.Namespace)
+		unstruc.SetName(fmt.Sprintf("%s-%s", unstruc.GetName(), isbsvcName))
+		desiredRiders = append(desiredRiders, riders.Rider{Definition: unstruc, RequiresProgressive: rider.Progressive})
+	}
 	return desiredRiders, nil
 }
 
 func (r *ISBServiceRolloutReconciler) GetExistingRiders(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, upgrading bool) (unstructured.UnstructuredList, error) {
-	// TODO
-	return unstructured.UnstructuredList{}, nil
+	isbServiceRollout := rolloutObject.(*apiv1.ISBServiceRollout)
+
+	ridersList := isbServiceRollout.Status.Riders // use the Riders for the promoted isbservice
+	if upgrading {
+		ridersList = isbServiceRollout.Status.ProgressiveStatus.UpgradingISBServiceStatus.Riders // use the Riders for the upgrading isbservice
+	}
+
+	return riders.GetRidersFromK8S(ctx, isbServiceRollout.GetNamespace(), ridersList, r.client)
 }
 
 // listAndDeleteChildISBServices lists all child ISBServices and deletes them
@@ -1031,4 +1092,12 @@ func (r *ISBServiceRolloutReconciler) listAndDeleteChildISBServices(ctx context.
 
 func (r *ISBServiceRolloutReconciler) SetCurrentRiderList(rolloutObject ctlrcommon.RolloutObject, riders []riders.Rider) {
 
+	isbServiceRollout := rolloutObject.(*apiv1.ISBServiceRollout)
+	isbServiceRollout.Status.Riders = make([]apiv1.RiderStatus, len(riders))
+	for index, rider := range riders {
+		isbServiceRollout.Status.Riders[index] = apiv1.RiderStatus{
+			GroupVersionKind: kubernetes.SchemaGVKToMetaGVK(rider.Definition.GroupVersionKind()),
+			Name:             rider.Definition.GetName(),
+		}
+	}
 }

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -992,7 +992,7 @@ func getLiveISBServiceRollout(ctx context.Context, name, namespace string) (*api
 	return isbServiceRollout, err
 }
 
-func (r *ISBServiceRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.RolloutObject, isbsvc *unstructured.Unstructured) ([]riders.Rider, error) {
+func (r *ISBServiceRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.RolloutObject, isbsvcName string, isbsvcDef *unstructured.Unstructured) ([]riders.Rider, error) {
 	desiredRiders := []riders.Rider{}
 	// TODO
 	return desiredRiders, nil

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -1029,6 +1029,9 @@ func getLiveISBServiceRollout(ctx context.Context, name, namespace string) (*api
 	return isbServiceRollout, err
 }
 
+// Get the list of Riders that we need based on what's defined in the MonoVertexRollout, templated according to the isbsvc child's name
+// (isbsvcDef is not used and comes from the RolloutController interface)
+
 func (r *ISBServiceRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.RolloutObject, isbsvcName string, isbsvcDef *unstructured.Unstructured) ([]riders.Rider, error) {
 	isbServiceRollout := rolloutObject.(*apiv1.ISBServiceRollout)
 	desiredRiders := []riders.Rider{}
@@ -1053,6 +1056,8 @@ func (r *ISBServiceRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.
 	return desiredRiders, nil
 }
 
+// Get the Riders that have been deployed
+// If "upgrading==true", return those which are associated with the Upgrading isbsvc; otherwise return those which are associated with the Promoted one
 func (r *ISBServiceRolloutReconciler) GetExistingRiders(ctx context.Context, rolloutObject ctlrcommon.RolloutObject, upgrading bool) (unstructured.UnstructuredList, error) {
 	isbServiceRollout := rolloutObject.(*apiv1.ISBServiceRollout)
 

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -341,15 +341,15 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 
 	numaLogger := logger.FromContext(ctx)
 
-	// get the list of Riders that we need based on the PipelineRollout definition
+	// get the list of Riders that we need based on the ISBServiceRollout definition
 	currentRiderList, err := r.GetDesiredRiders(isbServiceRollout, existingISBServiceDef.GetName(), newISBServiceDef)
 	if err != nil {
-		return 0, fmt.Errorf("error getting desired Riders for pipeline %s: %s", existingISBServiceDef.GetName(), err)
+		return 0, fmt.Errorf("error getting desired Riders for isbsvc %s: %s", existingISBServiceDef.GetName(), err)
 	}
 	// get the list of Riders that we have now (for promoted child)
 	existingRiderList, err := r.GetExistingRiders(ctx, isbServiceRollout, false)
 	if err != nil {
-		return 0, fmt.Errorf("error getting existing Riders for pipeline %s: %s", existingISBServiceDef.GetName(), err)
+		return 0, fmt.Errorf("error getting existing Riders for isbsvc %s: %s", existingISBServiceDef.GetName(), err)
 	}
 
 	// update our Status with the ISBService's Status
@@ -1029,7 +1029,7 @@ func getLiveISBServiceRollout(ctx context.Context, name, namespace string) (*api
 	return isbServiceRollout, err
 }
 
-// Get the list of Riders that we need based on what's defined in the MonoVertexRollout, templated according to the isbsvc child's name
+// Get the list of Riders that we need based on what's defined in the ISBServiceRollout, templated according to the isbsvc child's name
 // (isbsvcDef is not used and comes from the RolloutController interface)
 
 func (r *ISBServiceRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.RolloutObject, isbsvcName string, isbsvcDef *unstructured.Unstructured) ([]riders.Rider, error) {

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -810,7 +810,8 @@ func getLiveMonovertexRollout(ctx context.Context, name, namespace string) (*api
 	return monoVertexRollout, err
 }
 
-// Get the list of Riders that we need based on what's defined in the MonoVertexRollout, templated according to the monoVertex child
+// Get the list of Riders that we need based on what's defined in the MonoVertexRollout, templated according to the monoVertex child's name
+// (monoVertexDef is not used and comes from the RolloutController interface)
 func (r *MonoVertexRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.RolloutObject, monoVertexName string, monoVertexDef *unstructured.Unstructured) ([]riders.Rider, error) {
 	monoVertexRollout := rolloutObject.(*apiv1.MonoVertexRollout)
 	desiredRiders := []riders.Rider{}

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -67,6 +67,7 @@ const (
 	numWorkers                = 16 // can consider making configurable
 
 	TemplatePipelineName      = ".pipeline-name"
+	TemplateVertexName        = ".vertex-name"
 	TemplatePipelineNamespace = ".pipeline-namespace"
 )
 
@@ -417,6 +418,9 @@ func (r *PipelineRolloutReconciler) reconcile(
 			if err != nil {
 				return 0, nil, err
 			}
+			if err := ctlrcommon.CreateRidersForNewChild(ctx, r, pipelineRollout, newPipelineDef, r.client); err != nil {
+				return 0, nil, fmt.Errorf("error creating riders: %s", err)
+			}
 			pipelineRollout.Status.MarkDeployed(pipelineRollout.Generation)
 			r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerPipelineRollout, "create").Observe(time.Since(syncStartTime).Seconds())
 		} else {
@@ -502,6 +506,17 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 
 	numaLogger := logger.FromContext(ctx)
 
+	// get the list of Riders that we need based on the PipelineRollout definition
+	currentRiderList, err := r.GetDesiredRiders(pipelineRollout, existingPipelineDef.GetName(), newPipelineDef)
+	if err != nil {
+		return 0, fmt.Errorf("error getting desired Riders for MonoVertex %s: %s", existingPipelineDef.GetName(), err)
+	}
+	// get the list of Riders that we have now (for promoted child)
+	existingRiderList, err := r.GetExistingRiders(ctx, pipelineRollout, false)
+	if err != nil {
+		return 0, fmt.Errorf("error getting existing Riders for MonoVertex %s: %s", existingPipelineDef.GetName(), err)
+	}
+
 	// what is the preferred strategy for this namespace?
 	userPreferredStrategy, err := usde.GetUserStrategy(ctx, newPipelineDef.GetNamespace(), existingPipelineDef.GetKind())
 	if err != nil {
@@ -510,17 +525,17 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 
 	// does the Resource need updating, and if so how?
 	// TODO: handle recreate parameter
-	pipelineNeedsToUpdate, upgradeStrategyType, _, _, _, _, err := usde.ResourceNeedsUpdating(ctx, newPipelineDef, existingPipelineDef, []riders.Rider{}, unstructured.UnstructuredList{})
+	needsUpdate, upgradeStrategyType, _, riderAdditions, riderModifications, riderDeletions, err := usde.ResourceNeedsUpdating(ctx, newPipelineDef, existingPipelineDef, currentRiderList, existingRiderList)
 	if err != nil {
 		return 0, err
 	}
 
 	numaLogger.
-		WithValues("pipelineNeedsToUpdate", pipelineNeedsToUpdate, "upgradeStrategyType", upgradeStrategyType).
+		WithValues("needsUpdate", needsUpdate, "upgradeStrategyType", upgradeStrategyType).
 		Debug("Upgrade decision result")
 
-	// set the Status appropriately to "Pending" or "Deployed" depending on whether pipeline needs to update
-	if pipelineNeedsToUpdate {
+	// set the Status appropriately to "Pending" or "Deployed" depending on whether rollout needs to update
+	if needsUpdate {
 		pipelineRollout.Status.MarkPending()
 	} else {
 		pipelineRollout.Status.MarkDeployed(pipelineRollout.Generation)
@@ -588,15 +603,29 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 		if done {
 			r.inProgressStrategyMgr.UnsetStrategy(ctx, pipelineRollout)
 		}
+		// update the cluster to reflect the Rider additions, modifications, and deletions
+		if err := riders.UpdateRidersInK8S(ctx, newPipelineDef, riderAdditions, riderModifications, riderDeletions, r.client); err != nil {
+			return 0, err
+		}
+
+		// update the list of riders in the Status
+		r.SetCurrentRiderList(pipelineRollout, currentRiderList)
 
 	case apiv1.UpgradeStrategyProgressive:
 		numaLogger.Debug("processing pipeline with Progressive")
 
-		done, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, pipelineRollout, existingPipelineDef, pipelineNeedsToUpdate, r, r.client)
+		done, progressiveRequeueDelay, err := progressive.ProcessResource(ctx, pipelineRollout, existingPipelineDef, needsUpdate, r, r.client)
 		if err != nil {
 			return 0, err
 		}
 		if done {
+			// update the list of riders in the Status based on our child which was just promoted
+			currentRiderList, err := r.GetDesiredRiders(pipelineRollout, existingPipelineDef.GetName(), newPipelineDef)
+			if err != nil {
+				return 0, fmt.Errorf("error getting desired Riders for MonoVertex %s: %s", newPipelineDef.GetName(), err)
+			}
+			r.SetCurrentRiderList(pipelineRollout, currentRiderList)
+
 			// we need to prevent the possibility that we're done but we fail to update the Progressive Status
 			// therefore, we publish Rollout.Status here, so if that fails, then we won't be "done" and so we'll come back in here to try again
 			err = r.updatePipelineRolloutStatus(ctx, pipelineRollout)
@@ -610,15 +639,23 @@ func (r *PipelineRolloutReconciler) processExistingPipeline(ctx context.Context,
 		}
 
 	default:
-		if pipelineNeedsToUpdate && upgradeStrategyType == apiv1.UpgradeStrategyApply {
+		if needsUpdate && upgradeStrategyType == apiv1.UpgradeStrategyApply {
 			if err := updatePipelineSpec(ctx, r.client, newPipelineDef); err != nil {
 				return 0, err
 			}
 			pipelineRollout.Status.MarkDeployed(pipelineRollout.Generation)
+
+			// update the cluster to reflect the Rider additions, modifications, and deletions
+			if err := riders.UpdateRidersInK8S(ctx, newPipelineDef, riderAdditions, riderModifications, riderDeletions, r.client); err != nil {
+				return 0, err
+			}
 		}
+
+		// update the list of riders in the Status
+		r.SetCurrentRiderList(pipelineRollout, currentRiderList)
 	}
 
-	if pipelineNeedsToUpdate {
+	if needsUpdate {
 		r.customMetrics.ReconciliationDuration.WithLabelValues(ControllerPipelineRollout, "update").Observe(time.Since(syncStartTime).Seconds())
 	}
 
@@ -1272,9 +1309,54 @@ func getLivePipelineRollout(ctx context.Context, name, namespace string) (*apiv1
 	return PipelineRollout, err
 }
 
-func (r *PipelineRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.RolloutObject, pipeline *unstructured.Unstructured) ([]riders.Rider, error) {
+func (r *PipelineRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.RolloutObject, pipelineName string, pipelineDef *unstructured.Unstructured) ([]riders.Rider, error) {
+	pipelineRollout := rolloutObject.(*apiv1.PipelineRollout)
 	desiredRiders := []riders.Rider{}
-	// TODO
+	for _, rider := range pipelineRollout.Spec.Riders {
+
+		var asMap map[string]interface{}
+		if err := util.StructToStruct(rider.Definition, &asMap); err != nil {
+			return desiredRiders, fmt.Errorf("rider definition could not converted to map: %w", err)
+		}
+
+		if rider.PerVertex {
+			// create one Rider per Vertex
+			vertices, _, err := unstructured.NestedSlice(pipelineDef.Object, "spec", "vertices")
+			if err != nil {
+				return desiredRiders, err
+			}
+			for _, vertex := range vertices {
+				vertexName := vertex.(map[string]interface{})["name"]
+				resolvedMap, err := util.ResolveTemplateSpec(asMap, map[string]interface{}{
+					TemplatePipelineName:      pipelineName,
+					TemplatePipelineNamespace: pipelineRollout.Namespace,
+					TemplateVertexName:        vertexName,
+				})
+				if err != nil {
+					return desiredRiders, err
+				}
+				unstruc := unstructured.Unstructured{}
+				unstruc.Object = resolvedMap
+				unstruc.SetNamespace(pipelineRollout.Namespace)
+				unstruc.SetName(fmt.Sprintf("%s-%s-%s", unstruc.GetName(), pipelineName, vertexName))
+				desiredRiders = append(desiredRiders, riders.Rider{Definition: unstruc, RequiresProgressive: rider.Progressive})
+			}
+		} else {
+			// create one Rider for the Pipeline
+			resolvedMap, err := util.ResolveTemplateSpec(asMap, map[string]interface{}{
+				TemplatePipelineName:      pipelineName,
+				TemplatePipelineNamespace: pipelineRollout.Namespace,
+			})
+			if err != nil {
+				return desiredRiders, err
+			}
+			unstruc := unstructured.Unstructured{}
+			unstruc.Object = resolvedMap
+			unstruc.SetNamespace(pipelineRollout.Namespace)
+			unstruc.SetName(fmt.Sprintf("%s-%s", unstruc.GetName(), pipelineName))
+			desiredRiders = append(desiredRiders, riders.Rider{Definition: unstruc, RequiresProgressive: rider.Progressive})
+		}
+	}
 	return desiredRiders, nil
 }
 

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -1309,6 +1309,12 @@ func getLivePipelineRollout(ctx context.Context, name, namespace string) (*apiv1
 	return PipelineRollout, err
 }
 
+// GetDesiredRiders gets the list of Riders as specified in the PipelineRollout, templated for the specific pipeline name and
+// based on the pipeline definition.
+// Note the pipelineName can be different from pipelineDef.GetName().
+// The pipelineName is what's used for templating the Rider definition, while the pipelineDef is really only used in the case of "per-vertex" Riders.
+// In this case, it's necessary to use the existing pipeline's name to template in order to effectively compare whether the Rider has changed, but
+// use the latest pipeline definition to derive the current list of Vertices that need Riders.
 func (r *PipelineRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.RolloutObject, pipelineName string, pipelineDef *unstructured.Unstructured) ([]riders.Rider, error) {
 	pipelineRollout := rolloutObject.(*apiv1.PipelineRollout)
 	desiredRiders := []riders.Rider{}

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -475,7 +475,7 @@ func rolloutNeedsUpdating(
 	} else {
 		// if child doesn't need updating, let's see if any Riders do
 		// (additions, modifications, or deletions)
-		needsUpdating, err = ridersNeedUpdating(ctx, controller, rolloutObject, existingUpgradingChildDef)
+		needsUpdating, err = ridersNeedUpdating(ctx, controller, rolloutObject, existingUpgradingChildDef, newUpgradingChildDef)
 		if err != nil {
 			return false, err
 		}
@@ -484,8 +484,13 @@ func rolloutNeedsUpdating(
 }
 
 // Do any Riders need updating? (including additions, modifications, or deletions)
-func ridersNeedUpdating(ctx context.Context, controller progressiveController, rolloutObject ctlrcommon.RolloutObject, existingChild *unstructured.Unstructured) (bool, error) {
-	newRiders, err := controller.GetDesiredRiders(rolloutObject, existingChild)
+func ridersNeedUpdating(
+	ctx context.Context,
+	controller progressiveController,
+	rolloutObject ctlrcommon.RolloutObject,
+	existingUpgradingChildDef *unstructured.Unstructured,
+	newUpgradingChildDef *unstructured.Unstructured) (bool, error) {
+	newRiders, err := controller.GetDesiredRiders(rolloutObject, existingUpgradingChildDef.GetName(), newUpgradingChildDef)
 	if err != nil {
 		return false, err
 	}
@@ -495,7 +500,7 @@ func ridersNeedUpdating(ctx context.Context, controller progressiveController, r
 		return false, err
 	}
 
-	needUpdating, _, _, _, _, err := usde.RidersNeedUpdating(ctx, existingChild.GetNamespace(), existingChild.GetKind(), existingChild.GetName(),
+	needUpdating, _, _, _, _, err := usde.RidersNeedUpdating(ctx, existingUpgradingChildDef.GetNamespace(), existingUpgradingChildDef.GetKind(), existingUpgradingChildDef.GetName(),
 		newRiders, existingRiders)
 	if err != nil {
 		return false, err
@@ -704,7 +709,7 @@ func startPostUpgradeProcess(
 	numaLogger.Debug("starting post upgrade process")
 
 	// Create Riders for the new Upgrading child
-	newRiders, err := controller.GetDesiredRiders(rolloutObject, newUpgradingChild)
+	newRiders, err := controller.GetDesiredRiders(rolloutObject, newUpgradingChild.GetName(), newUpgradingChild)
 	if err != nil {
 		return false, err
 	}

--- a/internal/controller/progressive/progressive_test.go
+++ b/internal/controller/progressive/progressive_test.go
@@ -39,7 +39,7 @@ func (fpc fakeProgressiveController) Recycle(ctx context.Context, childObject *u
 	return false, nil
 }
 
-func (fpc fakeProgressiveController) GetDesiredRiders(rolloutObject ctlrcommon.RolloutObject, isbsvc *unstructured.Unstructured) ([]riders.Rider, error) {
+func (fpc fakeProgressiveController) GetDesiredRiders(rolloutObject ctlrcommon.RolloutObject, name string, childDef *unstructured.Unstructured) ([]riders.Rider, error) {
 	desiredRiders := []riders.Rider{}
 	return desiredRiders, nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

Incorporate the same Rider functionality into Pipeline and isbsvc.

Main difference: Pipeline also implements "per-vertex" capability. In order to do this, I realized I needed to adjust the signature for `GetDesiredRiders()` to add another argument. 

### Verification

Tried different scenarios for riders for pipeline and isbsvc, both with progressive and ppnd strategy. For pipeline, specifically tried a per-vertex VPA resource. 

Also did some retesting of MonoVertex since I changed a little bit there.

### Backward incompatibilities

N/A
