### PR TITLE
feat: add permittedRiders to numaplane ctrl cm

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -102,6 +102,9 @@ type GlobalConfig struct {
 	// TODO: remove when no longer needed
 	// FeatureFlagDisallowProgressiveForNonMonoVertex is a TEMPORARY feature flag to disable progressive upgrades for resources other than MonoVertex
 	FeatureFlagDisallowProgressiveForNonMonoVertex bool `json:"featureFlagDisallowProgressiveForNonMonoVertex" mapstructure:"featureFlagDisallowProgressiveForNonMonoVertex"`
+
+	// List of permitted Kinds for Riders
+	PermittedRiders []string `json:"permittedRiders" mapstructure:"permittedRiders"`
 }
 
 type ProgressiveConfig struct {

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -1053,6 +1053,13 @@ func (r *ISBServiceRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.
 		unstruc.SetName(fmt.Sprintf("%s-%s", unstruc.GetName(), isbsvcName))
 		desiredRiders = append(desiredRiders, riders.Rider{Definition: unstruc, RequiresProgressive: rider.Progressive})
 	}
+
+	// verify that desiredRiders are all permitted Kinds
+	err := riders.VerifyRiders(desiredRiders)
+	if err != nil {
+		return desiredRiders, err
+	}
+
 	return desiredRiders, nil
 }
 

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -833,6 +833,13 @@ func (r *MonoVertexRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.
 		unstruc.SetName(fmt.Sprintf("%s-%s", unstruc.GetName(), monoVertexName))
 		desiredRiders = append(desiredRiders, riders.Rider{Definition: unstruc, RequiresProgressive: rider.Progressive})
 	}
+
+	// verify that desiredRiders are all permitted Kinds
+	err := riders.VerifyRiders(desiredRiders)
+	if err != nil {
+		return desiredRiders, err
+	}
+
 	return desiredRiders, nil
 }
 

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -1363,6 +1363,13 @@ func (r *PipelineRolloutReconciler) GetDesiredRiders(rolloutObject ctlrcommon.Ro
 			desiredRiders = append(desiredRiders, riders.Rider{Definition: unstruc, RequiresProgressive: rider.Progressive})
 		}
 	}
+
+	// TODO: verify riders are whitelisted
+	err := riders.VerifyRiders(desiredRiders)
+	if err != nil {
+		return desiredRiders, err
+	}
+
 	return desiredRiders, nil
 }
 

--- a/tests/manifests/default/config.yaml
+++ b/tests/manifests/default/config.yaml
@@ -7,3 +7,6 @@ group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=
 group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
 defaultUpgradeStrategy: "pause-and-drain"
 childStatusAssessmentSchedule: "120,60,10"
+permittedRiders:
+- "VerticalPodAutoscaler"
+- "ConfigMap"

--- a/tests/manifests/special-cases/no-strategy/controller-config.yaml
+++ b/tests/manifests/special-cases/no-strategy/controller-config.yaml
@@ -19,3 +19,6 @@ data:
         - kind: InterstepBufferService
           schedule: "0,0,10"
       analysisRunTimeout: "1200"
+    permittedRiders:
+    - "VerticalPodAutoscaler"
+    - "ConfigMap"

--- a/tests/manifests/special-cases/progressive/controller-config.yaml
+++ b/tests/manifests/special-cases/progressive/controller-config.yaml
@@ -17,3 +17,6 @@ data:
         - kind: InterstepBufferService
           schedule: "0,0,10"
       analysisRunTimeout: "1200"
+    permittedRiders:
+    - "VerticalPodAutoscaler"
+    - "ConfigMap"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #719 

### Modifications

Adds the `permittedRiders` field to the Numaplane controller configmap. 

If a Kind is specified here, it will allow Riders of this Kind to created for MonoVertex/Pipeline/ISBService rollouts. If a non-specified Kind is used for a submitted Rider, the controller will return an error.


### Verification

Created a MonoVertexRollout locally with VPA and ConfigMap riders to test good case. Added Secret rider and checked both that Secret was not created and the controller was returning an error.

### Backward incompatibilities

n/a
