### PR TITLE
fix: Removing existing finalizer for monovertex and controller

### DIFF
--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -19,7 +19,6 @@ package monovertexrollout
 import (
 	"context"
 	"fmt"
-
 	"strings"
 	"time"
 
@@ -35,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	runtimecontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -175,6 +175,11 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 	defer func() {
 		r.customMetrics.SetMonoVerticesRolloutHealth(monoVertexRollout.Namespace, monoVertexRollout.Name, string(monoVertexRollout.Status.Phase))
 	}()
+
+	// Remove the finalizer if it still exists in the MonoVertexRollout, as finalizer is no longer needed for MonoVertexRollout
+	if controllerutil.ContainsFinalizer(monoVertexRollout, common.FinalizerName) {
+		controllerutil.RemoveFinalizer(monoVertexRollout, common.FinalizerName)
+	}
 
 	// Update metrics if monoVertexRollout is being deleted
 	if !monoVertexRollout.DeletionTimestamp.IsZero() {

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -32,6 +32,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -113,6 +114,7 @@ func NewNumaflowControllerReconciler(
 
 //+kubebuilder:rbac:groups=numaplane.numaproj.io,resources=numaflowcontrollers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=numaplane.numaproj.io,resources=numaflowcontrollers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=numaplane.numaproj.io,resources=numaflowcontrollers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -166,6 +168,18 @@ func (r *NumaflowControllerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	// Update the resource definition (everything except the Status subresource)
+	if r.needsUpdate(numaflowControllerOrig, numaflowController) {
+		if err := r.client.Patch(ctx, numaflowController, client.MergeFrom(numaflowControllerOrig)); err != nil {
+			r.ErrorHandler(ctx, numaflowController, err, "UpdateFailed", "Failed to update NumaflowController")
+			if statusUpdateErr := r.updateNumaflowControllerStatusToFailed(ctx, numaflowController, err); statusUpdateErr != nil {
+				r.ErrorHandler(ctx, numaflowController, statusUpdateErr, "UpdateStatusFailed", "Failed to update status of NumaflowController")
+				return ctrl.Result{}, statusUpdateErr
+			}
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Update the Status subresource
 	if numaflowController.DeletionTimestamp.IsZero() { // would've already been deleted
 		statusUpdateErr := r.updateNumaflowControllerStatus(ctx, numaflowController)
@@ -178,6 +192,20 @@ func (r *NumaflowControllerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	numaLogger.Debug("reconciliation successful")
 	r.recorder.Eventf(numaflowController, corev1.EventTypeNormal, "ReconcileSuccess", "Reconciliation successful")
 	return result, nil
+}
+
+func (r *NumaflowControllerReconciler) needsUpdate(old, new *apiv1.NumaflowController) bool {
+	if old == nil {
+		return true
+	}
+
+	// check for any fields we might update in the Spec - generally we'd only update a Finalizer or maybe something in the metadata
+	// TODO: we would need to update this if we ever add anything else, like a label or annotation - unless there's a generic check that makes sense
+	if !equality.Semantic.DeepEqual(old.Finalizers, new.Finalizers) {
+		return true
+	}
+
+	return false
 }
 
 // reconcile does the real logic

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -43,6 +43,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	runtimecontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -191,6 +192,11 @@ func (r *NumaflowControllerReconciler) reconcile(
 	defer func() {
 		r.customMetrics.SetNumaflowControllersHealth(controller.Namespace, controller.Name, string(controller.Status.Phase))
 	}()
+
+	// Remove the finalizer if it still exists in the controller, as finalizer is no longer needed for the controller.
+	if controllerutil.ContainsFinalizer(controller, common.FinalizerName) {
+		controllerutil.RemoveFinalizer(controller, common.FinalizerName)
+	}
 
 	if !controller.DeletionTimestamp.IsZero() {
 		numaLogger.Info("Deleting NumaflowController")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/704

### Modifications
This change will fix the issue regarding finalizer left on resource after deletion.
- Removing existing finalizer for monovertex and controller

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification
- Verified on local k8s

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
