### PR TITLE
fix: log line formatting

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -128,7 +128,7 @@ func (r *ISBServiceRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	isbServiceRollout, err := getLiveISBServiceRollout(ctx, req.NamespacedName.Name, req.NamespacedName.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			numaLogger.Info("ISBServiceRollout not found, %v", err)
+			numaLogger.Infof("ISBServiceRollout not found, %v", err)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("error getting the live ISB Service rollout: %w", err)
@@ -792,7 +792,7 @@ func (r *ISBServiceRolloutReconciler) updateISBServiceRolloutStatus(ctx context.
 		liveISBServiceRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().ISBServiceRollouts(isbServiceRollout.Namespace).Get(ctx, isbServiceRollout.Name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				numaLogger.Info("ISBServiceRollout not found, %v", err)
+				numaLogger.Infof("ISBServiceRollout not found, %v", err)
 				return nil
 			}
 			return fmt.Errorf("error getting the live ISBServiceRollout after attempting to update the ISBServiceRollout Status: %w", err)

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -127,7 +127,7 @@ func (r *MonoVertexRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	monoVertexRollout, err := getLiveMonovertexRollout(ctx, req.NamespacedName.Name, req.NamespacedName.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			numaLogger.Info("MonoVertxRollout not found, %v", err)
+			numaLogger.Infof("MonoVertxRollout not found, %v", err)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("error getting the live monoVertex rollout: %w", err)
@@ -514,7 +514,7 @@ func (r *MonoVertexRolloutReconciler) updateMonoVertexRolloutStatus(ctx context.
 		liveRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().MonoVertexRollouts(monoVertexRollout.Namespace).Get(ctx, monoVertexRollout.Name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				numaLogger.Info("MonoVertxRollout not found, %v", err)
+				numaLogger.Infof("MonoVertxRollout not found, %v", err)
 				return nil
 			}
 			return fmt.Errorf("error getting the live MonoVertexRollout after attempting to update the MonoVertexRollout Status: %w", err)

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -174,7 +174,7 @@ func (r *PipelineRolloutReconciler) processPipelineRollout(ctx context.Context, 
 	pipelineRollout, err := getLivePipelineRollout(ctx, namespacedName.Name, namespacedName.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			numaLogger.Info("PipelineRollout not found, %v", err)
+			numaLogger.Infof("PipelineRollout not found, %v", err)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("error getting the live PipelineRollout: %w", err)
@@ -857,7 +857,7 @@ func (r *PipelineRolloutReconciler) updatePipelineRolloutStatus(ctx context.Cont
 		livePipelineRollout, err := kubernetes.NumaplaneClient.NumaplaneV1alpha1().PipelineRollouts(pipelineRollout.Namespace).Get(ctx, pipelineRollout.Name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				numaLogger.Info("PipelineRollout not found, %v", err)
+				numaLogger.Infof("PipelineRollout not found, %v", err)
 				return nil
 			}
 			return fmt.Errorf("error getting the live PipelineRollout after attempting to update the PipelineRollout Status: %w", err)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

I noticed some log lines which were accidentally written using `Info()` rather than `Infof()`.

### Verification

N/A

### Backward incompatibilities

N/A
