### PR TITLE
fix: update e2e tests to use foreground deletion

### DIFF
--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -294,7 +294,8 @@ func createISBServiceRolloutSpec(name, namespace string, isbServiceSpec numaflow
 // delete ISBServiceRollout and verify deletion
 func DeleteISBServiceRollout(name string) {
 	By("Deleting ISBServiceRollout")
-	err := isbServiceRolloutClient.Delete(ctx, name, metav1.DeleteOptions{})
+	foregroundDeletion := metav1.DeletePropagationForeground
+	err := isbServiceRolloutClient.Delete(ctx, name, metav1.DeleteOptions{PropagationPolicy: &foregroundDeletion})
 	Expect(err).ShouldNot(HaveOccurred())
 
 	CheckEventually("Verifying ISBServiceRollout deletion", func() bool {

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -327,7 +327,8 @@ func createMonoVertexRolloutSpec(name, namespace string, spec numaflowv1.MonoVer
 // delete MonoVertexRollout and verify deletion
 func DeleteMonoVertexRollout(name string) {
 	By("Deleting MonoVertexRollout")
-	err := monoVertexRolloutClient.Delete(ctx, name, metav1.DeleteOptions{})
+	foregroundDeletion := metav1.DeletePropagationForeground
+	err := monoVertexRolloutClient.Delete(ctx, name, metav1.DeleteOptions{PropagationPolicy: &foregroundDeletion})
 	Expect(err).ShouldNot(HaveOccurred())
 
 	CheckEventually("Verifying MonoVertexRollout deletion", func() bool {

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -188,7 +188,8 @@ func createNumaflowControllerRolloutSpec(name, namespace, version string) *apiv1
 // delete NumaflowControllerRollout and verify deletion
 func DeleteNumaflowControllerRollout() {
 	By("Deleting NumaflowControllerRollout")
-	err := numaflowControllerRolloutClient.Delete(ctx, numaflowControllerRolloutName, metav1.DeleteOptions{})
+	foregroundDeletion := metav1.DeletePropagationForeground
+	err := numaflowControllerRolloutClient.Delete(ctx, numaflowControllerRolloutName, metav1.DeleteOptions{PropagationPolicy: &foregroundDeletion})
 	Expect(err).ShouldNot(HaveOccurred())
 
 	CheckEventually("Verifying NumaflowControllerRollout deletion", func() bool {

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -423,7 +423,8 @@ func createPipelineRolloutSpec(name, namespace string, pipelineSpec numaflowv1.P
 func DeletePipelineRollout(name string) {
 
 	By("Deleting PipelineRollout")
-	err := pipelineRolloutClient.Delete(ctx, name, metav1.DeleteOptions{})
+	foregroundDeletion := metav1.DeletePropagationForeground
+	err := pipelineRolloutClient.Delete(ctx, name, metav1.DeleteOptions{PropagationPolicy: &foregroundDeletion})
 	Expect(err).ShouldNot(HaveOccurred())
 
 	CheckEventually("Verifying PipelineRollout deletion", func() bool {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

The ["progressive" e2e test](https://github.com/numaproj/numaplane/actions/runs/14695594402/job/41236765099?pr=724) seems to be flakey - after MonoVertexRollout is deleted, for some reason the test creates a new MonoVertexRollout before it's truly been deleted from Kubernetes.

Trying foreground deletion (instead of background) which should hopefully wait until the deletion has fully occurred before the test continues.


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
