### PR TITLE
fix: add ClusterRoles to enable users to read/write NumaflowController resource

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -2003,6 +2003,7 @@ rules:
   - pipelinerollouts
   - isbservicerollouts
   - numaflowcontrollerrollouts
+  - numaflowcontrollers
   - monovertexrollouts
   verbs:
   - create
@@ -2018,6 +2019,7 @@ rules:
   - pipelinerollouts/status
   - isbservicerollouts/status
   - numaflowcontrollerrollouts/status
+  - numaflowcontrollers/status
   - monovertexrollouts/status
   verbs:
   - get
@@ -2035,6 +2037,7 @@ rules:
   - pipelinerollouts
   - isbservicerollouts
   - numaflowcontrollerrollouts
+  - numaflowcontrollers
   - monovertexrollouts
   verbs:
   - create
@@ -2050,6 +2053,7 @@ rules:
   - pipelinerollouts/status
   - isbservicerollouts/status
   - numaflowcontrollerrollouts/status
+  - numaflowcontrollers/status
   - monovertexrollouts/status
   verbs:
   - get
@@ -2067,6 +2071,7 @@ rules:
   - pipelinerollouts
   - isbservicerollouts
   - numaflowcontrollerrollouts
+  - numaflowcontrollers
   - monovertexrollouts
   verbs:
   - get
@@ -2078,6 +2083,7 @@ rules:
   - pipelinerollouts/status
   - isbservicerollouts/status
   - numaflowcontrollerrollouts/status
+  - numaflowcontrollers/status
   - monovertexrollouts/status
   verbs:
   - get

--- a/config/rbac/numaplane-aggregate-to-admin.yaml
+++ b/config/rbac/numaplane-aggregate-to-admin.yaml
@@ -11,6 +11,7 @@ rules:
     - pipelinerollouts
     - isbservicerollouts
     - numaflowcontrollerrollouts
+    - numaflowcontrollers
     - monovertexrollouts
     verbs:
     - create
@@ -26,6 +27,7 @@ rules:
     - pipelinerollouts/status
     - isbservicerollouts/status
     - numaflowcontrollerrollouts/status
+    - numaflowcontrollers/status
     - monovertexrollouts/status
     verbs:
     - get

--- a/config/rbac/numaplane-aggregate-to-edit.yaml
+++ b/config/rbac/numaplane-aggregate-to-edit.yaml
@@ -11,6 +11,7 @@ rules:
     - pipelinerollouts
     - isbservicerollouts
     - numaflowcontrollerrollouts
+    - numaflowcontrollers
     - monovertexrollouts
     verbs:
     - create
@@ -26,6 +27,7 @@ rules:
     - pipelinerollouts/status
     - isbservicerollouts/status
     - numaflowcontrollerrollouts/status
+    - numaflowcontrollers/status
     - monovertexrollouts/status
     verbs:
     - get

--- a/config/rbac/numaplane-aggregate-to-view.yaml
+++ b/config/rbac/numaplane-aggregate-to-view.yaml
@@ -11,6 +11,7 @@ rules:
     - pipelinerollouts
     - isbservicerollouts
     - numaflowcontrollerrollouts
+    - numaflowcontrollers
     - monovertexrollouts
     verbs:
     - get
@@ -22,6 +23,7 @@ rules:
     - pipelinerollouts/status
     - isbservicerollouts/status
     - numaflowcontrollerrollouts/status
+    - numaflowcontrollers/status
     - monovertexrollouts/status
     verbs:
     - get


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

There are some ClusterRoles which are associated with user accounts at Intuit. 

For example, the `numaplane-aggregate-to-admin` ClusterRole is connected to the user accounts which are "DevOps" within the [oss-analytics DevPortal organization](https://devportal.intuit.com/app/dp/project/5407714845444489299/members). 

The ClusterRoles never got updated to include `NumaflowController` CRD


