### PR TITLE
fix: Handle deletions of promoted child gracefully

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -112,6 +112,9 @@ const (
 	// LabelValueDeleteRecreateChild is the value used for the Label `LabelKeyUpgradeStateReason` when `LabelKeyUpgradeState`="recyclable" due to a child being deleted and recreated
 	LabelValueDeleteRecreateChild UpgradeStateReason = "delete-recreate"
 
+	// LabelValueDiscontinueProgressive is the value used for the Label `LabelKeyUpgradeStateReason` when `LabelKeyUpgradeState`="recyclable" due to discontinuing Progressive upgrade process
+	LabelValueDiscontinueProgressive UpgradeStateReason = "discontinue-progressive"
+
 	// LabelValuePurgeOld is the value used for the Label `LabelKeyUpgradeStateReason` when `LabelKeyUpgradeState`="recyclable" if there's a strange case in which there are multiple of a given
 	// child and there should only be one
 	// TODO: reevaluate if we really need that

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -401,6 +401,7 @@ func (r *ISBServiceRolloutReconciler) processExistingISBService(ctx context.Cont
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				numaLogger.WithValues("isbsvcDefinition", *newISBServiceDef).Warn("InterstepBufferService not found.")
+				return 0, nil
 			} else {
 				return 0, fmt.Errorf("error getting InterstepBufferService for status processing: %v", err)
 			}

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -252,13 +252,13 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 		} else {
 
 			// create an object as it doesn't exist
-			numaLogger.Debugf("ISBService %s/%s doesn't exist so creating", isbServiceRollout.Namespace, isbServiceRollout.Name)
-			isbServiceRollout.Status.MarkPending()
-
 			newISBServiceDef, err := r.makeTargetISBServiceDef(ctx, isbServiceRollout)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("error generating ISBService: %v", err)
 			}
+
+			numaLogger.Debugf("ISBService %s/%s doesn't exist so creating", isbServiceRollout.Namespace, newISBServiceDef.GetName())
+			isbServiceRollout.Status.MarkPending()
 			if newISBServiceDef != nil {
 
 				if err = r.createPromotedISBService(ctx, isbServiceRollout, newISBServiceDef); err != nil {

--- a/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
@@ -557,7 +557,7 @@ func Test_reconcile_isbservicerollout_Progressive(t *testing.T) {
 			},
 		},
 		{
-			name:                           "Deleted promoted isbsvc during Progressive failure",
+			name:                           "Handle user deletion of Promoted isbsvc during Progressive failure",
 			newISBSvcSpec:                  ctlrcommon.CreateDefaultISBServiceSpec("2.10.11"),
 			existingPromotedISBSvcDef:      nil,
 			existingPromotedStatefulSetDef: defaultPromotedStatefulSet,

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -222,7 +222,7 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 	if newMonoVertexDef != nil {
 		if promotedMonovertices == nil || len(promotedMonovertices.Items) == 0 {
 
-			numaLogger.Debugf("MonoVertex %s/%s doesn't exist so creating", monoVertexRollout.Namespace, monoVertexRollout.Name)
+			numaLogger.Debugf("MonoVertex %s/%s doesn't exist so creating", monoVertexRollout.Namespace, newMonoVertexDef.GetName())
 			monoVertexRollout.Status.MarkPending()
 
 			if err := r.createPromotedMonoVertex(ctx, monoVertexRollout, newMonoVertexDef); err != nil {

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -344,6 +344,7 @@ func (r *MonoVertexRolloutReconciler) processExistingMonoVertex(ctx context.Cont
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				numaLogger.WithValues("monoVertexDefinition", *existingMonoVertexDef).Warn("MonoVertex not found.")
+				return 0, nil
 			} else {
 				return 0, fmt.Errorf("error getting MonoVertex for status processing: %v", err)
 			}

--- a/internal/controller/monovertexrollout/monovertexrollout_controller_test.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller_test.go
@@ -304,6 +304,15 @@ func Test_processExistingMonoVertex_Progressive(t *testing.T) {
 		map[string]string{
 			common.AnnotationKeyNumaflowInstanceID: "1",
 		})
+	defaultPromotedChildStatus := &apiv1.PromotedMonoVertexStatus{
+		PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
+			PromotedChildStatus: apiv1.PromotedChildStatus{
+				Name: ctlrcommon.DefaultTestMonoVertexRolloutName + "-0",
+			},
+			AllVerticesScaledDown: true,
+			ScaleValues:           map[string]apiv1.ScaleValues{ctlrcommon.DefaultTestMonoVertexRolloutName + "-0": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo}},
+		},
+	}
 
 	testCases := []struct {
 		name                           string
@@ -333,18 +342,11 @@ func Test_processExistingMonoVertex_Progressive(t *testing.T) {
 			initialRolloutNameCount:        1,
 			initialInProgressStrategy:      nil,
 			initialUpgradingChildStatus:    nil,
-			initialPromotedChildStatus: &apiv1.PromotedMonoVertexStatus{
-				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
-					PromotedChildStatus: apiv1.PromotedChildStatus{
-						Name: ctlrcommon.DefaultTestMonoVertexRolloutName + "-0",
-					},
-					AllVerticesScaledDown: true,
-				},
-			},
-			analysisRun:                  false,
-			expectedInProgressStrategy:   apiv1.UpgradeStrategyProgressive,
-			expectedRolloutPhase:         apiv1.PhasePending,
-			expectedProgressiveCondition: metav1.ConditionUnknown,
+			initialPromotedChildStatus:     defaultPromotedChildStatus,
+			analysisRun:                    false,
+			expectedInProgressStrategy:     apiv1.UpgradeStrategyProgressive,
+			expectedRolloutPhase:           apiv1.PhasePending,
+			expectedProgressiveCondition:   metav1.ConditionUnknown,
 			expectedMonoVertices: map[string]common.UpgradeState{
 				ctlrcommon.DefaultTestMonoVertexRolloutName + "-0": common.LabelValueUpgradePromoted,
 				ctlrcommon.DefaultTestMonoVertexRolloutName + "-1": common.LabelValueUpgradeInProgress,
@@ -375,13 +377,7 @@ func Test_processExistingMonoVertex_Progressive(t *testing.T) {
 					},
 				},
 			},
-			initialPromotedChildStatus: &apiv1.PromotedMonoVertexStatus{
-				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
-					PromotedChildStatus: apiv1.PromotedChildStatus{
-						Name: ctlrcommon.DefaultTestMonoVertexRolloutName + "-0",
-					},
-				},
-			},
+			initialPromotedChildStatus:   defaultPromotedChildStatus,
 			analysisRun:                  true,
 			expectedInProgressStrategy:   apiv1.UpgradeStrategyNoOp,
 			expectedRolloutPhase:         apiv1.PhaseDeployed,
@@ -410,14 +406,7 @@ func Test_processExistingMonoVertex_Progressive(t *testing.T) {
 					},
 				},
 			},
-			initialPromotedChildStatus: &apiv1.PromotedMonoVertexStatus{
-				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
-					PromotedChildStatus: apiv1.PromotedChildStatus{
-						Name: ctlrcommon.DefaultTestMonoVertexRolloutName + "-0",
-					},
-					AllVerticesScaledDown: true,
-				},
-			},
+			initialPromotedChildStatus:   defaultPromotedChildStatus,
 			analysisRun:                  false,
 			expectedInProgressStrategy:   apiv1.UpgradeStrategyNoOp,
 			expectedRolloutPhase:         apiv1.PhaseDeployed,
@@ -458,15 +447,7 @@ func Test_processExistingMonoVertex_Progressive(t *testing.T) {
 					},
 				},
 			},
-			initialPromotedChildStatus: &apiv1.PromotedMonoVertexStatus{
-				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
-					PromotedChildStatus: apiv1.PromotedChildStatus{
-						Name: ctlrcommon.DefaultTestMonoVertexRolloutName + "-0",
-					},
-					AllVerticesScaledDown: true,
-					ScaleValues:           map[string]apiv1.ScaleValues{ctlrcommon.DefaultTestMonoVertexRolloutName + "-0": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo}},
-				},
-			},
+			initialPromotedChildStatus:   defaultPromotedChildStatus,
 			analysisRun:                  false,
 			expectedInProgressStrategy:   apiv1.UpgradeStrategyProgressive,
 			expectedRolloutPhase:         apiv1.PhasePending,
@@ -500,14 +481,7 @@ func Test_processExistingMonoVertex_Progressive(t *testing.T) {
 					},
 				},
 			},
-			initialPromotedChildStatus: &apiv1.PromotedMonoVertexStatus{
-				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
-					PromotedChildStatus: apiv1.PromotedChildStatus{
-						Name: ctlrcommon.DefaultTestMonoVertexRolloutName + "-0",
-					},
-					ScaleValues: map[string]apiv1.ScaleValues{ctlrcommon.DefaultTestMonoVertexRolloutName + "-0": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo}},
-				},
-			},
+			initialPromotedChildStatus:   defaultPromotedChildStatus,
 			analysisRun:                  true,
 			expectedInProgressStrategy:   apiv1.UpgradeStrategyProgressive,
 			expectedRolloutPhase:         apiv1.PhasePending,

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -384,10 +384,6 @@ func (r *PipelineRolloutReconciler) reconcile(
 
 	var existingPipelineDef *unstructured.Unstructured
 
-	// get current in progress strategy if there is one
-	inProgressStrategy := r.inProgressStrategyMgr.GetStrategy(ctx, pipelineRollout)
-	inProgressStrategySet := inProgressStrategy != apiv1.UpgradeStrategyNoOp
-
 	if newPipelineDef == nil {
 		// we couldn't create the Pipeline definition: we need to check again later
 		requeueDelay = common.DefaultRequeueDelay
@@ -432,6 +428,10 @@ func (r *PipelineRolloutReconciler) reconcile(
 			}
 		}
 	}
+
+	// get current in progress strategy if there is one
+	inProgressStrategy := r.inProgressStrategyMgr.GetStrategy(ctx, pipelineRollout)
+	inProgressStrategySet := inProgressStrategy != apiv1.UpgradeStrategyNoOp
 
 	// clean up recyclable pipelines
 	allDeleted, err := r.garbageCollectChildren(ctx, pipelineRollout)

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -395,7 +395,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 
 		if promotedPipelines == nil || len(promotedPipelines.Items) == 0 {
 
-			numaLogger.Debugf("Pipeline %s/%s doesn't exist so creating", pipelineRollout.Namespace, pipelineRollout.Name)
+			numaLogger.Debugf("Pipeline %s/%s doesn't exist so creating", pipelineRollout.Namespace, newPipelineDef.GetName())
 			pipelineRollout.Status.MarkPending()
 
 			if err = r.createPromotedPipeline(ctx, pipelineRollout, newPipelineDef); err != nil {

--- a/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
@@ -971,7 +971,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 	testCases := []struct {
 		name                        string
 		newPipelineSpec             numaflowv1.PipelineSpec
-		existingPromotedPipelineDef numaflowv1.Pipeline
+		existingPromotedPipelineDef *numaflowv1.Pipeline
 		existingUpgradePipelineDef  *numaflowv1.Pipeline
 		initialRolloutPhase         apiv1.Phase
 		initialRolloutNameCount     int
@@ -988,7 +988,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 		{
 			name:            "spec difference results in Progressive",
 			newPipelineSpec: pipelineSpecWithTopologyChange,
-			existingPromotedPipelineDef: *createPipeline(
+			existingPromotedPipelineDef: createPipeline(
 				numaflowv1.PipelinePhaseRunning,
 				numaflowv1.Status{},
 				false,
@@ -1015,7 +1015,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 		{
 			name:            "Progressive deployed successfully",
 			newPipelineSpec: pipelineSpecWithTopologyChange,
-			existingPromotedPipelineDef: *createPipeline(
+			existingPromotedPipelineDef: createPipeline(
 				numaflowv1.PipelinePhaseRunning,
 				numaflowv1.Status{},
 				false,
@@ -1083,7 +1083,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 		{
 			name:            "Progressive deployment failed",
 			newPipelineSpec: pipelineSpecWithTopologyChange,
-			existingPromotedPipelineDef: *createPipeline(
+			existingPromotedPipelineDef: createPipeline(
 				numaflowv1.PipelinePhaseRunning,
 				numaflowv1.Status{},
 				false,
@@ -1156,7 +1156,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 		{
 			name:            "Progressive deployment failed - going back to original spec",
 			newPipelineSpec: pipelineSpec, // this matches the original spec
-			existingPromotedPipelineDef: *createPipeline(
+			existingPromotedPipelineDef: createPipeline(
 				numaflowv1.PipelinePhaseRunning,
 				numaflowv1.Status{},
 				false,
@@ -1230,7 +1230,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 		{
 			name:            "Clean up after progressive upgrade",
 			newPipelineSpec: pipelineSpecWithTopologyChange,
-			existingPromotedPipelineDef: *createPipeline(
+			existingPromotedPipelineDef: createPipeline(
 				numaflowv1.PipelinePhasePaused,
 				numaflowv1.Status{},
 				true,
@@ -1266,7 +1266,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 		{
 			name:            "Clean up after progressive upgrade: pipeline still pausing",
 			newPipelineSpec: pipelineSpecWithTopologyChange,
-			existingPromotedPipelineDef: *createPipeline(
+			existingPromotedPipelineDef: createPipeline(
 				numaflowv1.PipelinePhasePausing,
 				numaflowv1.Status{},
 				false,
@@ -1299,6 +1299,70 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			expectedPipelines: map[string]common.UpgradeState{
 				ctlrcommon.DefaultTestPipelineRolloutName + "-0": common.LabelValueUpgradeRecyclable,
 				ctlrcommon.DefaultTestPipelineRolloutName + "-1": common.LabelValueUpgradePromoted,
+			},
+		},
+		{
+			name:                        "Handle user deletion of promoted pipeline during Progressive",
+			newPipelineSpec:             pipelineSpec, // this matches the original spec
+			existingPromotedPipelineDef: nil,
+			existingUpgradePipelineDef: ctlrcommon.CreateTestPipelineOfSpec(
+				runningPipelineSpecWithTopologyChange, ctlrcommon.DefaultTestPipelineRolloutName+"-1",
+				numaflowv1.PipelinePhaseFailed,
+				numaflowv1.Status{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(numaflowv1.PipelineConditionDaemonServiceHealthy),
+							Status: metav1.ConditionFalse,
+						},
+					},
+				},
+				false,
+				map[string]string{
+					common.LabelKeyISBServiceRONameForPipeline:    ctlrcommon.DefaultTestISBSvcRolloutName,
+					common.LabelKeyISBServiceChildNameForPipeline: ctlrcommon.DefaultTestISBSvcName,
+					common.LabelKeyUpgradeState:                   string(common.LabelValueUpgradeInProgress),
+					common.LabelKeyParentRollout:                  ctlrcommon.DefaultTestPipelineRolloutName,
+				},
+				map[string]string{}),
+			initialRolloutPhase:       apiv1.PhasePending,
+			initialRolloutNameCount:   2,
+			initialInProgressStrategy: &progressiveUpgradeStrategy,
+			initialUpgradingChildStatus: &apiv1.UpgradingPipelineStatus{
+				UpgradingPipelineTypeStatus: apiv1.UpgradingPipelineTypeStatus{
+					UpgradingChildStatus: apiv1.UpgradingChildStatus{
+						Name:                   ctlrcommon.DefaultTestPipelineRolloutName + "-1",
+						AssessmentStartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+						AssessmentEndTime:      &metav1.Time{Time: time.Now().Add(-30 * time.Second)},
+						AssessmentResult:       apiv1.AssessmentResultFailure,
+						InitializationComplete: true,
+					},
+				},
+				OriginalScaleMinMax: []apiv1.VertexScaleDefinition{
+					{VertexName: "in", ScaleDefinition: nil},
+					{VertexName: "cat", ScaleDefinition: nil},
+					{VertexName: "cat-2", ScaleDefinition: nil},
+					{VertexName: "out", ScaleDefinition: nil},
+				},
+			},
+			initialPromotedChildStatus: &apiv1.PromotedPipelineStatus{
+				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
+					PromotedChildStatus: apiv1.PromotedChildStatus{
+						Name: ctlrcommon.DefaultTestPipelineRolloutName + "-0",
+					},
+					AllVerticesScaledDown: true,
+					ScaleValues: map[string]apiv1.ScaleValues{
+						"in":  {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
+						"cat": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
+						"out": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
+					},
+				},
+			},
+			expectedInProgressStrategy: apiv1.UpgradeStrategyNoOp,
+			expectedRolloutPhase:       apiv1.PhaseDeployed,
+
+			// the Failed Pipeline which is marked "recyclable" gets deleted right away due to the fact that it's in "Failed" state and therefore can't pause
+			expectedPipelines: map[string]common.UpgradeState{
+				ctlrcommon.DefaultTestPipelineRolloutName + "-2": common.LabelValueUpgradePromoted,
 			},
 		},
 	}
@@ -1338,9 +1402,11 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			}
 
 			// create the already-existing Pipeline in Kubernetes
-			existingPipelineDef := &tc.existingPromotedPipelineDef
-			existingPipelineDef.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(rollout.GetObjectMeta(), apiv1.PipelineRolloutGroupVersionKind)}
-			ctlrcommon.CreatePipelineInK8S(ctx, t, numaflowClientSet, existingPipelineDef)
+			if tc.existingPromotedPipelineDef != nil {
+				existingPipelineDef := tc.existingPromotedPipelineDef
+				existingPipelineDef.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(rollout.GetObjectMeta(), apiv1.PipelineRolloutGroupVersionKind)}
+				ctlrcommon.CreatePipelineInK8S(ctx, t, numaflowClientSet, existingPipelineDef)
+			}
 
 			if tc.existingUpgradePipelineDef != nil {
 				existingUpgradePipelineDef := tc.existingUpgradePipelineDef

--- a/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
@@ -1006,6 +1006,25 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			Status: metav1.ConditionFalse,
 		},
 	}
+	successfulUpgradingChildStatus := &apiv1.UpgradingPipelineStatus{
+		UpgradingPipelineTypeStatus: apiv1.UpgradingPipelineTypeStatus{
+			UpgradingChildStatus: apiv1.UpgradingChildStatus{
+				Name:                   ctlrcommon.DefaultTestPipelineRolloutName + "-1",
+				AssessmentStartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+				AssessmentEndTime:      &metav1.Time{Time: time.Now().Add(-30 * time.Second)},
+				AssessmentResult:       apiv1.AssessmentResultSuccess,
+				InitializationComplete: true,
+			},
+		},
+		OriginalScaleMinMax: []apiv1.VertexScaleDefinition{
+			{VertexName: "in", ScaleDefinition: nil},
+			{VertexName: "cat", ScaleDefinition: nil},
+			{VertexName: "cat-2", ScaleDefinition: nil},
+			{VertexName: "out", ScaleDefinition: nil},
+		},
+	}
+	failedUpgradingChildStatus := successfulUpgradingChildStatus.DeepCopy()
+	failedUpgradingChildStatus.UpgradingChildStatus.AssessmentResult = apiv1.AssessmentResultFailure
 
 	testCases := []struct {
 		name                        string
@@ -1050,23 +1069,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			initialRolloutPhase:         apiv1.PhasePending,
 			initialRolloutNameCount:     2,
 			initialInProgressStrategy:   &progressiveUpgradeStrategy,
-			initialUpgradingChildStatus: &apiv1.UpgradingPipelineStatus{
-				UpgradingPipelineTypeStatus: apiv1.UpgradingPipelineTypeStatus{
-					UpgradingChildStatus: apiv1.UpgradingChildStatus{
-						Name:                   ctlrcommon.DefaultTestPipelineRolloutName + "-1",
-						AssessmentStartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
-						AssessmentEndTime:      &metav1.Time{Time: time.Now().Add(-30 * time.Second)},
-						AssessmentResult:       apiv1.AssessmentResultSuccess,
-						InitializationComplete: true,
-					},
-				},
-				OriginalScaleMinMax: []apiv1.VertexScaleDefinition{
-					{VertexName: "in", ScaleDefinition: nil},
-					{VertexName: "cat", ScaleDefinition: nil},
-					{VertexName: "cat-2", ScaleDefinition: nil},
-					{VertexName: "out", ScaleDefinition: nil},
-				},
-			},
+			initialUpgradingChildStatus: successfulUpgradingChildStatus,
 			initialPromotedChildStatus: &apiv1.PromotedPipelineStatus{
 				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
 					PromotedChildStatus: apiv1.PromotedChildStatus{
@@ -1091,23 +1094,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			initialRolloutPhase:         apiv1.PhasePending,
 			initialRolloutNameCount:     2,
 			initialInProgressStrategy:   &progressiveUpgradeStrategy,
-			initialUpgradingChildStatus: &apiv1.UpgradingPipelineStatus{
-				UpgradingPipelineTypeStatus: apiv1.UpgradingPipelineTypeStatus{
-					UpgradingChildStatus: apiv1.UpgradingChildStatus{
-						Name:                   ctlrcommon.DefaultTestPipelineRolloutName + "-1",
-						AssessmentStartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
-						AssessmentEndTime:      &metav1.Time{Time: time.Now().Add(-30 * time.Second)},
-						AssessmentResult:       apiv1.AssessmentResultFailure,
-						InitializationComplete: true,
-					},
-				},
-				OriginalScaleMinMax: []apiv1.VertexScaleDefinition{
-					{VertexName: "in", ScaleDefinition: nil},
-					{VertexName: "cat", ScaleDefinition: nil},
-					{VertexName: "cat-2", ScaleDefinition: nil},
-					{VertexName: "out", ScaleDefinition: nil},
-				},
-			},
+			initialUpgradingChildStatus: failedUpgradingChildStatus,
 			initialPromotedChildStatus: &apiv1.PromotedPipelineStatus{
 				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
 					PromotedChildStatus: apiv1.PromotedChildStatus{
@@ -1137,23 +1124,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			initialRolloutPhase:         apiv1.PhasePending,
 			initialRolloutNameCount:     2,
 			initialInProgressStrategy:   &progressiveUpgradeStrategy,
-			initialUpgradingChildStatus: &apiv1.UpgradingPipelineStatus{
-				UpgradingPipelineTypeStatus: apiv1.UpgradingPipelineTypeStatus{
-					UpgradingChildStatus: apiv1.UpgradingChildStatus{
-						Name:                   ctlrcommon.DefaultTestPipelineRolloutName + "-1",
-						AssessmentStartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
-						AssessmentEndTime:      &metav1.Time{Time: time.Now().Add(-30 * time.Second)},
-						AssessmentResult:       apiv1.AssessmentResultFailure,
-						InitializationComplete: true,
-					},
-				},
-				OriginalScaleMinMax: []apiv1.VertexScaleDefinition{
-					{VertexName: "in", ScaleDefinition: nil},
-					{VertexName: "cat", ScaleDefinition: nil},
-					{VertexName: "cat-2", ScaleDefinition: nil},
-					{VertexName: "out", ScaleDefinition: nil},
-				},
-			},
+			initialUpgradingChildStatus: failedUpgradingChildStatus,
 			initialPromotedChildStatus: &apiv1.PromotedPipelineStatus{
 				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
 					PromotedChildStatus: apiv1.PromotedChildStatus{
@@ -1248,23 +1219,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			initialRolloutPhase:         apiv1.PhasePending,
 			initialRolloutNameCount:     2,
 			initialInProgressStrategy:   &progressiveUpgradeStrategy,
-			initialUpgradingChildStatus: &apiv1.UpgradingPipelineStatus{
-				UpgradingPipelineTypeStatus: apiv1.UpgradingPipelineTypeStatus{
-					UpgradingChildStatus: apiv1.UpgradingChildStatus{
-						Name:                   ctlrcommon.DefaultTestPipelineRolloutName + "-1",
-						AssessmentStartTime:    &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
-						AssessmentEndTime:      &metav1.Time{Time: time.Now().Add(-30 * time.Second)},
-						AssessmentResult:       apiv1.AssessmentResultFailure,
-						InitializationComplete: true,
-					},
-				},
-				OriginalScaleMinMax: []apiv1.VertexScaleDefinition{
-					{VertexName: "in", ScaleDefinition: nil},
-					{VertexName: "cat", ScaleDefinition: nil},
-					{VertexName: "cat-2", ScaleDefinition: nil},
-					{VertexName: "out", ScaleDefinition: nil},
-				},
-			},
+			initialUpgradingChildStatus: failedUpgradingChildStatus,
 			initialPromotedChildStatus: &apiv1.PromotedPipelineStatus{
 				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
 					PromotedChildStatus: apiv1.PromotedChildStatus{

--- a/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
@@ -1006,6 +1006,20 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			Status: metav1.ConditionFalse,
 		},
 	}
+	defaultPromotedChildStatus := &apiv1.PromotedPipelineStatus{
+		PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
+			PromotedChildStatus: apiv1.PromotedChildStatus{
+				Name: ctlrcommon.DefaultTestPipelineRolloutName + "-0",
+			},
+			AllVerticesScaledDown: true,
+			ScaleValues: map[string]apiv1.ScaleValues{
+				"in":  {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
+				"cat": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
+				"out": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
+			},
+		},
+	}
+
 	successfulUpgradingChildStatus := &apiv1.UpgradingPipelineStatus{
 		UpgradingPipelineTypeStatus: apiv1.UpgradingPipelineTypeStatus{
 			UpgradingChildStatus: apiv1.UpgradingChildStatus{
@@ -1070,16 +1084,9 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			initialRolloutNameCount:     2,
 			initialInProgressStrategy:   &progressiveUpgradeStrategy,
 			initialUpgradingChildStatus: successfulUpgradingChildStatus,
-			initialPromotedChildStatus: &apiv1.PromotedPipelineStatus{
-				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
-					PromotedChildStatus: apiv1.PromotedChildStatus{
-						Name: ctlrcommon.DefaultTestPipelineRolloutName + "-0",
-					},
-					AllVerticesScaledDown: true,
-				},
-			},
-			expectedInProgressStrategy: apiv1.UpgradeStrategyNoOp,
-			expectedRolloutPhase:       apiv1.PhaseDeployed,
+			initialPromotedChildStatus:  defaultPromotedChildStatus,
+			expectedInProgressStrategy:  apiv1.UpgradeStrategyNoOp,
+			expectedRolloutPhase:        apiv1.PhaseDeployed,
 
 			expectedPipelines: map[string]common.UpgradeState{
 				ctlrcommon.DefaultTestPipelineRolloutName + "-0": common.LabelValueUpgradeRecyclable,
@@ -1095,21 +1102,9 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			initialRolloutNameCount:     2,
 			initialInProgressStrategy:   &progressiveUpgradeStrategy,
 			initialUpgradingChildStatus: failedUpgradingChildStatus,
-			initialPromotedChildStatus: &apiv1.PromotedPipelineStatus{
-				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
-					PromotedChildStatus: apiv1.PromotedChildStatus{
-						Name: ctlrcommon.DefaultTestPipelineRolloutName + "-0",
-					},
-					AllVerticesScaledDown: true,
-					ScaleValues: map[string]apiv1.ScaleValues{
-						"in":  {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
-						"cat": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
-						"out": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
-					},
-				},
-			},
-			expectedInProgressStrategy: apiv1.UpgradeStrategyProgressive,
-			expectedRolloutPhase:       apiv1.PhasePending,
+			initialPromotedChildStatus:  defaultPromotedChildStatus,
+			expectedInProgressStrategy:  apiv1.UpgradeStrategyProgressive,
+			expectedRolloutPhase:        apiv1.PhasePending,
 
 			expectedPipelines: map[string]common.UpgradeState{
 				ctlrcommon.DefaultTestPipelineRolloutName + "-0": common.LabelValueUpgradePromoted,
@@ -1125,21 +1120,9 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			initialRolloutNameCount:     2,
 			initialInProgressStrategy:   &progressiveUpgradeStrategy,
 			initialUpgradingChildStatus: failedUpgradingChildStatus,
-			initialPromotedChildStatus: &apiv1.PromotedPipelineStatus{
-				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
-					PromotedChildStatus: apiv1.PromotedChildStatus{
-						Name: ctlrcommon.DefaultTestPipelineRolloutName + "-0",
-					},
-					AllVerticesScaledDown: true,
-					ScaleValues: map[string]apiv1.ScaleValues{
-						"in":  {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
-						"cat": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
-						"out": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
-					},
-				},
-			},
-			expectedInProgressStrategy: apiv1.UpgradeStrategyProgressive,
-			expectedRolloutPhase:       apiv1.PhaseDeployed,
+			initialPromotedChildStatus:  defaultPromotedChildStatus,
+			expectedInProgressStrategy:  apiv1.UpgradeStrategyProgressive,
+			expectedRolloutPhase:        apiv1.PhaseDeployed,
 
 			// the Failed Pipeline which is marked "recyclable" gets deleted right away due to the fact that it's in "Failed" state and therefore can't pause
 			expectedPipelines: map[string]common.UpgradeState{
@@ -1220,21 +1203,9 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			initialRolloutNameCount:     2,
 			initialInProgressStrategy:   &progressiveUpgradeStrategy,
 			initialUpgradingChildStatus: failedUpgradingChildStatus,
-			initialPromotedChildStatus: &apiv1.PromotedPipelineStatus{
-				PromotedPipelineTypeStatus: apiv1.PromotedPipelineTypeStatus{
-					PromotedChildStatus: apiv1.PromotedChildStatus{
-						Name: ctlrcommon.DefaultTestPipelineRolloutName + "-0",
-					},
-					AllVerticesScaledDown: true,
-					ScaleValues: map[string]apiv1.ScaleValues{
-						"in":  {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
-						"cat": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
-						"out": {OriginalScaleMinMax: ctlrcommon.DefaultScaleJSONString, ScaleTo: ctlrcommon.DefaultScaleTo},
-					},
-				},
-			},
-			expectedInProgressStrategy: apiv1.UpgradeStrategyNoOp,
-			expectedRolloutPhase:       apiv1.PhaseDeployed,
+			initialPromotedChildStatus:  defaultPromotedChildStatus,
+			expectedInProgressStrategy:  apiv1.UpgradeStrategyNoOp,
+			expectedRolloutPhase:        apiv1.PhaseDeployed,
 
 			// the Failed Pipeline which is marked "recyclable" gets deleted right away due to the fact that it's in "Failed" state and therefore can't pause
 			expectedPipelines: map[string]common.UpgradeState{

--- a/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
@@ -968,6 +968,17 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 
 	progressiveUpgradeStrategy := apiv1.UpgradeStrategyProgressive
 
+	defaultPromotedPipelineDef := createPipeline(
+		numaflowv1.PipelinePhaseRunning,
+		numaflowv1.Status{},
+		false,
+		map[string]string{
+			common.LabelKeyISBServiceRONameForPipeline:    ctlrcommon.DefaultTestISBSvcRolloutName,
+			common.LabelKeyISBServiceChildNameForPipeline: ctlrcommon.DefaultTestISBSvcName,
+			common.LabelKeyUpgradeState:                   string(common.LabelValueUpgradePromoted),
+			common.LabelKeyParentRollout:                  ctlrcommon.DefaultTestPipelineRolloutName,
+		})
+
 	testCases := []struct {
 		name                        string
 		newPipelineSpec             numaflowv1.PipelineSpec
@@ -986,18 +997,9 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 
 	}{
 		{
-			name:            "spec difference results in Progressive",
-			newPipelineSpec: pipelineSpecWithTopologyChange,
-			existingPromotedPipelineDef: createPipeline(
-				numaflowv1.PipelinePhaseRunning,
-				numaflowv1.Status{},
-				false,
-				map[string]string{
-					common.LabelKeyISBServiceRONameForPipeline:    ctlrcommon.DefaultTestISBSvcRolloutName,
-					common.LabelKeyISBServiceChildNameForPipeline: ctlrcommon.DefaultTestISBSvcName,
-					common.LabelKeyUpgradeState:                   string(common.LabelValueUpgradePromoted),
-					common.LabelKeyParentRollout:                  ctlrcommon.DefaultTestPipelineRolloutName,
-				}),
+			name:                        "spec difference results in Progressive",
+			newPipelineSpec:             pipelineSpecWithTopologyChange,
+			existingPromotedPipelineDef: defaultPromotedPipelineDef,
 			existingUpgradePipelineDef:  nil,
 			initialRolloutPhase:         apiv1.PhaseDeployed,
 			initialRolloutNameCount:     1,
@@ -1013,18 +1015,9 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			},
 		},
 		{
-			name:            "Progressive deployed successfully",
-			newPipelineSpec: pipelineSpecWithTopologyChange,
-			existingPromotedPipelineDef: createPipeline(
-				numaflowv1.PipelinePhaseRunning,
-				numaflowv1.Status{},
-				false,
-				map[string]string{
-					common.LabelKeyISBServiceRONameForPipeline:    ctlrcommon.DefaultTestISBSvcRolloutName,
-					common.LabelKeyISBServiceChildNameForPipeline: ctlrcommon.DefaultTestISBSvcName,
-					common.LabelKeyUpgradeState:                   string(common.LabelValueUpgradePromoted),
-					common.LabelKeyParentRollout:                  ctlrcommon.DefaultTestPipelineRolloutName,
-				}),
+			name:                        "Progressive deployed successfully",
+			newPipelineSpec:             pipelineSpecWithTopologyChange,
+			existingPromotedPipelineDef: defaultPromotedPipelineDef,
 			existingUpgradePipelineDef: ctlrcommon.CreateTestPipelineOfSpec(
 				pipelineSpecWithTopologyChange, ctlrcommon.DefaultTestPipelineRolloutName+"-1",
 				numaflowv1.PipelinePhaseRunning,
@@ -1081,18 +1074,9 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			},
 		},
 		{
-			name:            "Progressive deployment failed",
-			newPipelineSpec: pipelineSpecWithTopologyChange,
-			existingPromotedPipelineDef: createPipeline(
-				numaflowv1.PipelinePhaseRunning,
-				numaflowv1.Status{},
-				false,
-				map[string]string{
-					common.LabelKeyISBServiceRONameForPipeline:    ctlrcommon.DefaultTestISBSvcRolloutName,
-					common.LabelKeyISBServiceChildNameForPipeline: ctlrcommon.DefaultTestISBSvcName,
-					common.LabelKeyUpgradeState:                   string(common.LabelValueUpgradePromoted),
-					common.LabelKeyParentRollout:                  ctlrcommon.DefaultTestPipelineRolloutName,
-				}),
+			name:                        "Progressive deployment failed",
+			newPipelineSpec:             pipelineSpecWithTopologyChange,
+			existingPromotedPipelineDef: defaultPromotedPipelineDef,
 			existingUpgradePipelineDef: ctlrcommon.CreateTestPipelineOfSpec(
 				runningPipelineSpecWithTopologyChange, ctlrcommon.DefaultTestPipelineRolloutName+"-1",
 				numaflowv1.PipelinePhaseFailed,
@@ -1154,18 +1138,9 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			},
 		},
 		{
-			name:            "Progressive deployment failed - going back to original spec",
-			newPipelineSpec: pipelineSpec, // this matches the original spec
-			existingPromotedPipelineDef: createPipeline(
-				numaflowv1.PipelinePhaseRunning,
-				numaflowv1.Status{},
-				false,
-				map[string]string{
-					common.LabelKeyISBServiceRONameForPipeline:    ctlrcommon.DefaultTestISBSvcRolloutName,
-					common.LabelKeyISBServiceChildNameForPipeline: ctlrcommon.DefaultTestISBSvcName,
-					common.LabelKeyUpgradeState:                   string(common.LabelValueUpgradePromoted),
-					common.LabelKeyParentRollout:                  ctlrcommon.DefaultTestPipelineRolloutName,
-				}),
+			name:                        "Progressive deployment failed - going back to original spec",
+			newPipelineSpec:             pipelineSpec, // this matches the original spec
+			existingPromotedPipelineDef: defaultPromotedPipelineDef,
 			existingUpgradePipelineDef: ctlrcommon.CreateTestPipelineOfSpec(
 				runningPipelineSpecWithTopologyChange, ctlrcommon.DefaultTestPipelineRolloutName+"-1", // the one that's currently "upgrading" is the one with the topology change
 				numaflowv1.PipelinePhaseFailed,
@@ -1228,19 +1203,9 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 			},
 		},
 		{
-			name:            "Clean up after progressive upgrade",
-			newPipelineSpec: pipelineSpecWithTopologyChange,
-			existingPromotedPipelineDef: createPipeline(
-				numaflowv1.PipelinePhasePaused,
-				numaflowv1.Status{},
-				true,
-				map[string]string{
-					common.LabelKeyISBServiceRONameForPipeline:    ctlrcommon.DefaultTestISBSvcRolloutName,
-					common.LabelKeyISBServiceChildNameForPipeline: ctlrcommon.DefaultTestISBSvcName,
-					common.LabelKeyUpgradeState:                   string(common.LabelValueUpgradeRecyclable),
-					common.LabelKeyUpgradeStateReason:             string(common.LabelValueProgressiveSuccess),
-					common.LabelKeyParentRollout:                  ctlrcommon.DefaultTestPipelineRolloutName,
-				}),
+			name:                        "Clean up after progressive upgrade",
+			newPipelineSpec:             pipelineSpecWithTopologyChange,
+			existingPromotedPipelineDef: defaultPromotedPipelineDef,
 			existingUpgradePipelineDef: ctlrcommon.CreateTestPipelineOfSpec(
 				runningPipelineSpecWithTopologyChange, ctlrcommon.DefaultTestPipelineRolloutName+"-1",
 				numaflowv1.PipelinePhaseRunning,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #739 

### Modifications

If a user deletes a Promoted child while in the middle of Progressive upgrade (could be prior to Assessment or after it's failed), then in addition to the Promoted child being recreated, any Upgrading children are deleted and then `upgradeInProgress` field is set back to "".


### Verification

For each of the 3 rollouts, tested prior to Assessment and after Assessment failure. Then I also, just in case, did a subsequent Progressive upgrade just to make sure that worked fine too. 


### Backward incompatibilities

N/A
