### PR TITLE
feat: add some important progressive upgrade related fields to the logs

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -113,6 +113,9 @@ type ProgressiveConfig struct {
 
 	// timeout duration which AnalysisRuns cannot continue to run after
 	AnalysisRunTimeout string `json:"analysisRunTimeout" mapstructure:"analysisRunTimeout"`
+
+	// when set to true, adds the rollout, promoted, and upgrading objects to all the log messages during progressive upgrade
+	LogObjects bool `json:"logObjects" mapstructure:"logObjects"`
 }
 
 // DefaultAssessmentSchedule defines a default schedule for each Kind
@@ -381,5 +384,4 @@ func (config *ProgressiveConfig) GetAnalysisRunTimeout() (time.Duration, error) 
 	}
 
 	return time.Duration(analysisRunTimeout) * time.Second, nil
-
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #740 

### Modifications

Added the progressive upgrade `rolloutObject`, `promotedChild`, and `upgradingChild` fields to the logs to help with debugging via Splunk.
Created the `progressive.logObjects` config var to only enable these detailed logs only on clusters.

### Verification

Manually verified the logs locally.

### Backward incompatibilities

None.