### PR TITLE
chore: progressive E2E tests to check ISBService status when Pipeline upgrade fails

### DIFF
--- a/tests/e2e/progressive-monovertex-e2e/monovertex_test.go
+++ b/tests/e2e/progressive-monovertex-e2e/monovertex_test.go
@@ -80,7 +80,7 @@ func TestProgressiveE2E(t *testing.T) {
 		BeforeSuiteSetup()
 	})
 
-	RunSpecs(t, "Progressive E2E Suite")
+	RunSpecs(t, "Progressive MonoVertex E2E Suite")
 }
 
 var _ = Describe("Progressive MonoVertex E2E", Serial, func() {

--- a/tests/e2e/progressive-pipeline-e2e/pipeline_test.go
+++ b/tests/e2e/progressive-pipeline-e2e/pipeline_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -122,7 +123,7 @@ func TestProgressiveE2E(t *testing.T) {
 		BeforeSuiteSetup()
 	})
 
-	RunSpecs(t, "Progressive E2E Suite")
+	RunSpecs(t, "Progressive Pipeline E2E Suite")
 }
 
 var _ = Describe("Progressive Pipeline and ISBService E2E", Serial, func() {
@@ -326,6 +327,63 @@ var _ = Describe("Progressive Pipeline and ISBService E2E", Serial, func() {
 		// Verify the previously promoted pipeline was deleted
 		VerifyVerticesPodsRunning(Namespace, GetInstanceName(pipelineRolloutName, 0), initialPipelineSpecVerticesZero, ComponentVertex)
 		VerifyPipelineDeletion(GetInstanceName(pipelineRolloutName, 0))
+
+		DeletePipelineRollout(pipelineRolloutName)
+	})
+
+	It("Should validate ISBService as failure when Pipeline upgrade assesses in failure", func() {
+		By("Creating a PipelineRollout")
+		CreatePipelineRollout(pipelineRolloutName, Namespace, initialPipelineSpec, false, &defaultStrategy)
+
+		By("Verifying that the Pipeline spec is as expected")
+		originalPipelineSpecISBSvcName := initialPipelineSpec.InterStepBufferServiceName
+		initialPipelineSpec.InterStepBufferServiceName = GetInstanceName(isbServiceRolloutName, 3)
+		VerifyPipelineSpec(Namespace, pipelineRolloutName, func(retrievedPipelineSpec numaflowv1.PipelineSpec) bool {
+			return reflect.DeepEqual(retrievedPipelineSpec, initialPipelineSpec)
+		})
+		initialPipelineSpec.InterStepBufferServiceName = originalPipelineSpecISBSvcName
+		VerifyPipelineRolloutInProgressStrategy(pipelineRolloutName, apiv1.UpgradeStrategyNoOp)
+		VerifyPipelineRolloutHealthy(pipelineRolloutName)
+
+		By("Updating the Pipeline Topology to cause a Progressive change - Failure case")
+		updatedPipelineSpec := initialPipelineSpec.DeepCopy()
+		updatedPipelineSpec.Vertices[1].UDF = &numaflowv1.UDF{Builtin: &numaflowv1.Function{
+			Name: "badcat",
+		}}
+		rawSpec, err := json.Marshal(updatedPipelineSpec)
+		Expect(err).ShouldNot(HaveOccurred())
+		UpdatePipelineRolloutInK8S(Namespace, pipelineRolloutName, func(pipelineRollout apiv1.PipelineRollout) (apiv1.PipelineRollout, error) {
+			pipelineRollout.Spec.Pipeline.Spec.Raw = rawSpec
+			return pipelineRollout, nil
+		})
+
+		By("Updating the ISBService to cause a Progressive change")
+		updatedISBServiceSpec := initialISBServiceSpec.DeepCopy()
+		updatedISBServiceSpec.JetStream.Version = validJetstreamVersion
+		rawSpec, err = json.Marshal(updatedISBServiceSpec)
+		Expect(err).ShouldNot(HaveOccurred())
+		UpdateISBServiceRolloutInK8S(isbServiceRolloutName, func(isbSvcRollout apiv1.ISBServiceRollout) (apiv1.ISBServiceRollout, error) {
+			isbSvcRollout.Spec.InterStepBufferService.Spec.Raw = rawSpec
+			return isbSvcRollout, nil
+		})
+
+		VerifyPromotedPipelineScaledDownForProgressive(pipelineRolloutName, GetInstanceName(pipelineRolloutName, 0))
+		VerifyPipelineRolloutProgressiveStatus(pipelineRolloutName, GetInstanceName(pipelineRolloutName, 0), GetInstanceName(pipelineRolloutName, 1), true, apiv1.AssessmentResultFailure, defaultStrategy.Progressive.ForcePromote)
+
+		// Verify that when the "upgrading" Pipeline fails, it scales down to 0 Pods, and the "promoted" Pipeline scales back up
+		initialPipelineSpecVertices := []numaflowv1.AbstractVertex{}
+		for _, vertex := range initialPipelineSpec.Vertices {
+			initialPipelineSpecVertices = append(initialPipelineSpecVertices, numaflowv1.AbstractVertex{Name: vertex.Name, Scale: vertex.Scale})
+		}
+		VerifyVerticesPodsRunning(Namespace, GetInstanceName(pipelineRolloutName, 0), initialPipelineSpecVertices, ComponentVertex)
+		initialPipelineSpecVerticesZero := []numaflowv1.AbstractVertex{}
+		for _, vertex := range initialPipelineSpec.Vertices {
+			initialPipelineSpecVerticesZero = append(initialPipelineSpecVerticesZero, numaflowv1.AbstractVertex{Name: vertex.Name, Scale: numaflowv1.Scale{Min: ptr.To(int32(0)), Max: ptr.To(int32(0))}})
+		}
+		VerifyVerticesPodsRunning(Namespace, GetInstanceName(pipelineRolloutName, 1), initialPipelineSpecVerticesZero, ComponentVertex)
+
+		VerifyISBServiceRolloutProgressiveStatus(isbServiceRolloutName, GetInstanceName(isbServiceRolloutName, 3), GetInstanceName(isbServiceRolloutName, 4), apiv1.AssessmentResultFailure,
+			fmt.Sprintf("Pipeline %s failed while upgrading", GetInstanceName(pipelineRolloutName, 1)))
 
 		DeletePipelineRollout(pipelineRolloutName)
 	})

--- a/tests/e2e/progressive-pipeline-e2e/pipeline_test.go
+++ b/tests/e2e/progressive-pipeline-e2e/pipeline_test.go
@@ -326,7 +326,7 @@ var _ = Describe("Progressive Pipeline and ISBService E2E", Serial, func() {
 		VerifyVerticesPodsRunning(Namespace, GetInstanceName(pipelineRolloutName, 1), initialPipelineSpecVerticesZero, ComponentVertex)
 
 		// Verify ISBServiceRollout Progressive Status
-		VerifyISBServiceRolloutProgressiveStatus(isbServiceRolloutName, GetInstanceName(isbServiceRolloutName, 3), GetInstanceName(isbServiceRolloutName, 4), apiv1.AssessmentResultFailure,
+		VerifyISBServiceRolloutProgressiveStatus(isbServiceRolloutName, GetInstanceName(isbServiceRolloutName, 2), GetInstanceName(isbServiceRolloutName, 3), apiv1.AssessmentResultFailure,
 			fmt.Sprintf("Pipeline %s failed while upgrading", GetInstanceName(pipelineRolloutName, 1)))
 
 		DeletePipelineRollout(pipelineRolloutName)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #756 

### Modifications

When updating Pipeline and associated ISBService at the same time, check that the ISBService Progressive Status is failed if the upgrading Pipeline has failed (even if the ISBService change is good).

### Verification

E2E tests pass.

### Backward incompatibilities

None.
