### PR TITLE
fix: correctly handle scale.max=0 case for MonoVertex and Pipeline

### DIFF
--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -352,7 +352,8 @@ func scaleDownUpgradingMonoVertex(
 		upgradingChildScaleTo := scaleValue.Initial - scaleValue.ScaleTo
 		// if for some reason there were no Pods running in the promoted MonoVertex at the time (i.e. maybe some failure) and the Max was not set to 0 explicitly,
 		// then we don't want to set our Pods to 0 so set to 1 at least
-		if upgradingChildScaleTo <= 0 && originalScaleMinMax != nil && originalScaleMinMax.Max != nil && *originalScaleMinMax.Max != 0 {
+		maxZero := originalScaleMinMax != nil && originalScaleMinMax.Max != nil && *originalScaleMinMax.Max == 0
+		if upgradingChildScaleTo <= 0 && !maxZero {
 			upgradingChildScaleTo = 1
 		}
 

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -352,7 +352,7 @@ func scaleDownUpgradingMonoVertex(
 		upgradingChildScaleTo := scaleValue.Initial - scaleValue.ScaleTo
 		// if for some reason there were no Pods running in the promoted MonoVertex at the time (i.e. maybe some failure) and the Max was not set to 0 explicitly,
 		// then we don't want to set our Pods to 0 so set to 1 at least
-		if upgradingChildScaleTo <= 0 && originalScaleMinMax.Max != nil && *originalScaleMinMax.Max != 0 {
+		if upgradingChildScaleTo <= 0 && originalScaleMinMax != nil && originalScaleMinMax.Max != nil && *originalScaleMinMax.Max != 0 {
 			upgradingChildScaleTo = 1
 		}
 

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -327,11 +327,15 @@ func scaleDownUpgradingMonoVertex(
 	upgradingMonoVertexDef *unstructured.Unstructured,
 ) error {
 	// Update the scale values of the Upgrading Child, but first save the original scale values
-	originalScaleMinMax, err := progressive.ExtractScaleMinMaxAsJSONString(upgradingMonoVertexDef.Object, []string{"spec", "scale"})
+	originalScaleMinMaxString, err := progressive.ExtractScaleMinMaxAsJSONString(upgradingMonoVertexDef.Object, []string{"spec", "scale"})
+	if err != nil {
+		return fmt.Errorf("cannot extract the scale min and max values from the upgrading monovertex as string: %w", err)
+	}
+	monoVertexRollout.Status.ProgressiveStatus.UpgradingMonoVertexStatus.OriginalScaleMinMax = originalScaleMinMaxString
+	originalScaleMinMax, err := progressive.ExtractScaleMinMax(upgradingMonoVertexDef.Object, []string{"spec", "scale"})
 	if err != nil {
 		return fmt.Errorf("cannot extract the scale min and max values from the upgrading monovertex: %w", err)
 	}
-	monoVertexRollout.Status.ProgressiveStatus.UpgradingMonoVertexStatus.OriginalScaleMinMax = originalScaleMinMax
 
 	if monoVertexRollout.Status.ProgressiveStatus.PromotedMonoVertexStatus == nil {
 		return errors.New("unable to perform pre-upgrade operations because the rollout does not have promotedChildStatus set")
@@ -346,7 +350,9 @@ func scaleDownUpgradingMonoVertex(
 		// which is necessary when performing the health check for "ready replicas >= desired replicas"
 		// 2. that the total number of Pods (between the 2 monovertices) before and during upgrade remains the same
 		upgradingChildScaleTo := scaleValue.Initial - scaleValue.ScaleTo
-		if upgradingChildScaleTo <= 0 { // if for some reason the Initial value was 0, we don't want to set our Pods to 0
+		// if for some reason there were no Pods running in the promoted MonoVertex at the time (i.e. maybe some failure) and the Max was not set to 0 explicitly,
+		// then we don't want to set our Pods to 0 so set to 1 at least
+		if upgradingChildScaleTo <= 0 && originalScaleMinMax.Max != nil && *originalScaleMinMax.Max != 0 {
 			upgradingChildScaleTo = 1
 		}
 

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -407,19 +407,9 @@ func createScaledDownUpgradingPipelineDef(
 			// if for some reason there were no Pods running in the promoted Pipeline's vertex at the time (i.e. maybe some failure) and the Max was not set to 0 explicitly,
 			// then we don't want to set our Pods to 0 so set to 1 at least
 			upgradingVertexScaleTo = scaleValue.Initial - scaleValue.ScaleTo
-
 			maxZero := originalScaleMinMax != nil && originalScaleMinMax.Max != nil && *originalScaleMinMax.Max == 0
 			if upgradingVertexScaleTo <= 0 && !maxZero {
-				fmt.Printf("deletethis: scaling vertex %s of pipeline %s to 1\n", vertexName, upgradingPipelineDef.GetName())
 				upgradingVertexScaleTo = 1
-			} else {
-				fmt.Printf("deletethis: NOT scaling vertex %s of pipeline %s to 1, originalScaleMinMax=%+v\n", vertexName, upgradingPipelineDef.GetName(), originalScaleMinMax)
-				if originalScaleMinMax != nil {
-					fmt.Printf("deletethis: NOT scaling vertex %s of pipeline %s to 1, *originalScaleMinMax=%+v\n", vertexName, upgradingPipelineDef.GetName(), *originalScaleMinMax)
-					if originalScaleMinMax.Max != nil {
-						fmt.Printf("deletethis: NOT scaling vertex %s of pipeline %s to 1, *originalScaleMinMax.Max=%+v\n", vertexName, upgradingPipelineDef.GetName(), originalScaleMinMax.Max)
-					}
-				}
 			}
 			numaLogger.WithValues("vertex", vertexName).Debugf("scaling upgrading pipeline vertex to min=max=%d", upgradingVertexScaleTo)
 		}

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -407,7 +407,7 @@ func createScaledDownUpgradingPipelineDef(
 			// if for some reason there were no Pods running in the promoted Pipeline's vertex at the time (i.e. maybe some failure) and the Max was not set to 0 explicitly,
 			// then we don't want to set our Pods to 0 so set to 1 at least
 			upgradingVertexScaleTo = scaleValue.Initial - scaleValue.ScaleTo
-			if upgradingVertexScaleTo <= 0 && originalScaleMinMax.Max != nil && *originalScaleMinMax.Max != 0 {
+			if upgradingVertexScaleTo <= 0 && originalScaleMinMax != nil && originalScaleMinMax.Max != nil && *originalScaleMinMax.Max != 0 {
 				upgradingVertexScaleTo = 1
 			}
 			numaLogger.WithValues("vertex", vertexName).Debugf("scaling upgrading pipeline vertex to min=max=%d", upgradingVertexScaleTo)

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -407,8 +407,19 @@ func createScaledDownUpgradingPipelineDef(
 			// if for some reason there were no Pods running in the promoted Pipeline's vertex at the time (i.e. maybe some failure) and the Max was not set to 0 explicitly,
 			// then we don't want to set our Pods to 0 so set to 1 at least
 			upgradingVertexScaleTo = scaleValue.Initial - scaleValue.ScaleTo
-			if upgradingVertexScaleTo <= 0 && originalScaleMinMax != nil && originalScaleMinMax.Max != nil && *originalScaleMinMax.Max != 0 {
+
+			maxZero := originalScaleMinMax != nil && originalScaleMinMax.Max != nil && *originalScaleMinMax.Max == 0
+			if upgradingVertexScaleTo <= 0 && !maxZero {
+				fmt.Printf("deletethis: scaling vertex %s of pipeline %s to 1\n", vertexName, upgradingPipelineDef.GetName())
 				upgradingVertexScaleTo = 1
+			} else {
+				fmt.Printf("deletethis: NOT scaling vertex %s of pipeline %s to 1, originalScaleMinMax=%+v\n", vertexName, upgradingPipelineDef.GetName(), originalScaleMinMax)
+				if originalScaleMinMax != nil {
+					fmt.Printf("deletethis: NOT scaling vertex %s of pipeline %s to 1, *originalScaleMinMax=%+v\n", vertexName, upgradingPipelineDef.GetName(), *originalScaleMinMax)
+					if originalScaleMinMax.Max != nil {
+						fmt.Printf("deletethis: NOT scaling vertex %s of pipeline %s to 1, *originalScaleMinMax.Max=%+v\n", vertexName, upgradingPipelineDef.GetName(), originalScaleMinMax.Max)
+					}
+				}
 			}
 			numaLogger.WithValues("vertex", vertexName).Debugf("scaling upgrading pipeline vertex to min=max=%d", upgradingVertexScaleTo)
 		}

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -390,6 +390,10 @@ func createScaledDownUpgradingPipelineDef(
 	for index, vertex := range vertexDefinitions {
 		vertexAsMap := vertex.(map[string]interface{})
 		vertexName := vertexAsMap["name"].(string)
+		originalScaleMinMax, err := progressive.ExtractScaleMinMax(vertexAsMap, []string{"scale"})
+		if err != nil {
+			return fmt.Errorf("cannot extract the scale min and max values from the upgrading pipeline vertex %s: %w", vertexName, err)
+		}
 		scaleValue, vertexFound := pipelineRollout.Status.ProgressiveStatus.PromotedPipelineStatus.ScaleValues[vertexName]
 		var upgradingVertexScaleTo int64
 		if !vertexFound {
@@ -400,8 +404,10 @@ func createScaledDownUpgradingPipelineDef(
 			numaLogger.WithValues("vertex", vertexName).Debugf("vertex not found previously; scaling upgrading pipeline vertex to min=max=%d", upgradingVertexScaleTo)
 		} else {
 			// nominal case: found the same vertex from the "promoted" pipeline: set min and max to the number of Pods that were removed from the "promoted" one
+			// if for some reason there were no Pods running in the promoted Pipeline's vertex at the time (i.e. maybe some failure) and the Max was not set to 0 explicitly,
+			// then we don't want to set our Pods to 0 so set to 1 at least
 			upgradingVertexScaleTo = scaleValue.Initial - scaleValue.ScaleTo
-			if upgradingVertexScaleTo <= 0 { // if for some reason the Initial value was 0, we don't want to set our Pods to 0
+			if upgradingVertexScaleTo <= 0 && originalScaleMinMax.Max != nil && *originalScaleMinMax.Max != 0 {
 				upgradingVertexScaleTo = 1
 			}
 			numaLogger.WithValues("vertex", vertexName).Debugf("scaling upgrading pipeline vertex to min=max=%d", upgradingVertexScaleTo)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Modifications

Code was setting the upgrading child to 1 pods if the `Initial` was 0. This code was added for the purpose of handling the case of a "promoted" child which was supposed to have more than 0 Pods but some failure was causing only 0 Pods to exist.

We need to also account for the case in which the user really does intend for min=max=0.


### Verification

Tested both PipelineRollout and MonoVertexRollout using min and max set to 0 in the spec.

For PipelineRollout, I tried a 3 vertex Pipeline with scale set to min=max=0 for one Vertex, `scale` not set for another, and `scale` set but `min` and `max` not set for another. Observed that only the Vertex with min=max=0 was actually scaled to 0 in the new Pipeline. 

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
