### PR TITLE
chore: increase timeouts on codegen and unit tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,6 +93,14 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Archive unit test code coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unit-tests-coverage
+          path: coverage.out
+          retention-days: 7
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -189,6 +197,14 @@ jobs:
           POD_NAME=$(kubectl get pods -n numaplane-system -l app.kubernetes.io/name=controller-manager -o jsonpath="{.items[0].metadata.name}")
           kubectl cp $POD_NAME:/coverage -n numaplane-system tests/e2e/output/resources/coverage/
 
+      - name: Archive code coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-${{matrix.strategy}}-${{matrix.case}}
+          path: |
+            tests/e2e/output/resources/coverage/
+          retention-days: 7
 
       - name: Archive resource changes
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,14 +93,6 @@ jobs:
       - name: Test
         run: make test
 
-      - name: Archive unit test code coverage
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: unit-tests-coverage
-          path: coverage.out
-          retention-days: 7
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -197,14 +189,6 @@ jobs:
           POD_NAME=$(kubectl get pods -n numaplane-system -l app.kubernetes.io/name=controller-manager -o jsonpath="{.items[0].metadata.name}")
           kubectl cp $POD_NAME:/coverage -n numaplane-system tests/e2e/output/resources/coverage/
 
-      - name: Archive code coverage
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: coverage-${{matrix.strategy}}-${{matrix.case}}
-          path: |
-            tests/e2e/output/resources/coverage/
-          retention-days: 7
 
       - name: Archive resource changes
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
   codegen:
     name: Codegen
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -333,6 +333,7 @@ func processUpgradingChild(
 	existingPromotedChildDef, existingUpgradingChildDef *unstructured.Unstructured,
 	c client.Client,
 ) (bool, time.Duration, error) {
+
 	numaLogger := logger.FromContext(ctx)
 
 	assessmentSchedule, err := getChildStatusAssessmentSchedule(ctx, rolloutObject)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

CI was timing out for Unit Tests and Codegen.

### Verification

Ran CI multiple times

### Backward incompatibilities

N/A
