### PR TITLE
fix: Prune NumaflowController resource which is removed in latest update

### DIFF
--- a/config/crd/bases/numaplane.numaproj.io_numaflowcontrollers.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_numaflowcontrollers.yaml
@@ -133,6 +133,8 @@ spec:
                   - type
                   type: object
                 type: array
+              lastAppliedVersion:
+                type: string
               lastFailureTime:
                 description: LastFailureTime records the timestamp of the Last Failure
                   (PhaseFailed)

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1262,6 +1262,8 @@ spec:
                   - type
                   type: object
                 type: array
+              lastAppliedVersion:
+                type: string
               lastFailureTime:
                 description: LastFailureTime records the timestamp of the Last Failure
                   (PhaseFailed)

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -241,7 +241,7 @@ func (r *NumaflowControllerReconciler) reconcile(
 		return ctrl.Result{}, err
 	}
 
-	// Generate the manifest for the NumaflowController based on the version specified in the controller spec. Which is used for
+	// Generate the manifest for the NumaflowController based on the version specified in the controller spec, Which is used for
 	// creating the Deployment and other resources.
 	newVersion := controller.Spec.Version
 	newVersionTargetObjs, err := determineTargetObjects(controller, newVersion, namespace)
@@ -262,7 +262,7 @@ func (r *NumaflowControllerReconciler) reconcile(
 
 	oldVersionTargetObjs, err := determineTargetObjects(controller, oldVersion, namespace)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("unable to determine the target objects for the old version %s: %w", oldVersion, err)
+		numaLogger.Warnf("unable to determine the target objects for the old version %s: %v", oldVersion, err)
 	}
 	numaLogger.Debugf("found %d target objects associated with NumaflowController version %s", len(oldVersionTargetObjs), oldVersion)
 

--- a/pkg/apis/numaplane/v1alpha1/numaflowcontroller_types.go
+++ b/pkg/apis/numaplane/v1alpha1/numaflowcontroller_types.go
@@ -31,7 +31,8 @@ type NumaflowControllerSpec struct {
 
 // NumaflowControllerStatus defines the observed state of NumaflowController
 type NumaflowControllerStatus struct {
-	Status `json:",inline"`
+	Status             `json:",inline"`
+	LastAppliedVersion string `json:"lastAppliedVersion,omitempty"`
 }
 
 // +genclient


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/783

### Modifications
- Handle case for pruning resource when it's deleted in new version
  - Add `LastAppliedVersion` in CRD status field
  - `LastAppliedVersion` is set each time after successful reconciliation.
- It won't fix existing issue as `LastAppliedVersion` is unknown.

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification
Verified in local k8s cluster with below scenatios
- Deployed `NumaflowController` v1.4.2` which has the `numaflow-server`, then deployed `NumaflowController` v1.4.3 which doesn't have `numaflow-server`.

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities
Yes

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
