### PR TITLE
fix: Prune NumaflowController resource which are removed in latest version

### DIFF
--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -254,6 +254,8 @@ func (r *NumaflowControllerReconciler) reconcile(
 		return ctrl.Result{}, fmt.Errorf("unable to determine existing managed resources in cluster: %w", err)
 	}
 
+	numaLogger.Debugf("found %d existing managed resources in cluster associated with Numaplane API", len(existingClusterResources))
+
 	// apply controller - this handles syncing in the cases in which our Controller  isn't updating
 	// (note that the cases above in which it is updating have a 'return' statement):
 	// - new Controller


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/783 
Fixes https://github.com/numaproj/numaplane/issues/787

### Modifications
- Handle case for pruning resource when it's deleted in new version
  - List all the resources in cluster whose owner reference API Version is `numaplane`
  - Then compute the diff with upcoming resource and remove if any.


<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification
Verified in local k8s cluster with below scenatios

Case: 1
- Deployed `NumaflowController` v1.4.2 which has the `numaflow-server`, then deployed `NumaflowController` v1.4.3 which doesn't have `numaflow-server`. As expected `numaflow-server` is removed.
Case: 2
- Cluster is running `numaflow-server` which is not in current manifest due to bug in `Numaplane-controller`, Then updated the `numaplane-controller` with the fix image, as expected `numaflow-server` is removed.

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
