### PR TITLE
chore: reduce some very noisy logging; add some other logging

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -212,6 +212,7 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 			if requeue {
 				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 			}
+			numaLogger.Info("Removing Finalizer from ISBServiceRollout")
 			controllerutil.RemoveFinalizer(isbServiceRollout, common.FinalizerName)
 		}
 		// generate metrics for ISB Service deletion.

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -204,6 +204,8 @@ func (r *NumaflowControllerRolloutReconciler) reconcile(
 			r.recorder.Eventf(nfcRollout, corev1.EventTypeNormal, "Deleting", "Deleting NumaflowControllerRollout")
 			if controllerutil.ContainsFinalizer(nfcRollout, common.FinalizerName) {
 				ppnd.GetPauseModule().DeletePauseRequest(controllerKey)
+
+				numaLogger.Info("Removing Finalizer from NumaflowControllerRollout")
 				controllerutil.RemoveFinalizer(nfcRollout, common.FinalizerName)
 			}
 

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -357,6 +357,7 @@ func (r *PipelineRolloutReconciler) reconcile(
 			if requeue {
 				return 5 * time.Second, nil, nil
 			}
+			numaLogger.Info("Removing Finalizer from PipelineRollout")
 			controllerutil.RemoveFinalizer(pipelineRollout, common.FinalizerName)
 		}
 		// generate the metrics for the Pipeline deletion.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

When I was looking at splunk logs, there were some logs that were too noisy and others that I wished I saw but didn't exist.

Specifically, the usde was logging every [field](https://github.com/numaproj/numaplane/blob/main/config/manager/usde-config.yaml#L9-L118) described in the usde-config.yaml file that it checked. I removed that and replaced with a single line to indicate if a particular field is deemed to require an update. 

I also added some logging to indicate when the finalizers of the various numaplane resources are removed.


### Verification

Did a local progressive test to verify the USDE log change. Deleted a rollout and verified the line for removing the finalizer showed.

### Backward incompatibilities

N/A
