### PR TITLE
fix: prevent Failed NumaflowController from putting Pipelines in paused state

### DIFF
--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller.go
@@ -480,8 +480,8 @@ func (r *NumaflowControllerRolloutReconciler) isNumaflowControllerReconciled(ctx
 		return false, "", fmt.Errorf("failed to convert NumaflowController Status: %+v, %v", numaflowController, err)
 	}
 
-	// Assume NumaflowController is progressing unless otherwise specified in the condition
-	ncProgressing := true
+	// Check if NumaflowController is still progressing
+	ncProgressing := false
 	healthyChildCond := nfcStatus.GetCondition(apiv1.ConditionChildResourceHealthy)
 	if healthyChildCond != nil {
 		ncProgressing = healthyChildCond.Reason == apiv1.ProgressingReasonString


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Background

The NumaflowControllerRollout pauses Pipelines if it's still in the middle of updating, to prevent data loss.

How does it check if it's still updating?:
1. It checks `observedGeneration` of NumaflowController
2. It checks whether the Healthy condition of NumaflowController says false due to "Progressing"

### Modifications

If the ChildHealthy condition is not even present at all in NumaflowController, I'm changing the code to **not** consider this as still updating. 

The issue is that if the NumaflowController has just been created for the first time and is failed, the ChildHealthy Condition is not present at all. We don't want to be pausing pipelines then. (If we do, then as soon as the pipeline gets created, it will be in a paused state.)




### Verification

Did 2 tests:
1. tested the case of a new failed NumaflowController - this is the case I was trying to address - now Pipelines no longer stay paused in this case
2. tested the nominal case of changing an existing version of NumaflowControllerRollout and observed the Pipeline pauses as expected; also did `kubectl get numaflowcontroller -o yaml --watch` to observe this sequence of changes:
- generation > observedGeneration
- generation == observedGeneration; healthy condition = False: Progressing
- generation == observedGeneration; healthy condition = True

### Backward incompatibilities

N/A
