### PR TITLE
fix: remove unneeded check for promotedDifference, which prevents doing an upgrade when rollout spec == promoted spec

### DIFF
--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -154,21 +154,14 @@ func ProcessResource(
 	}
 
 	// if there's a difference between the desired spec and the current "promoted" child, and there isn't already an "upgrading" definition, then create one and return
-	if promotedDifference && currentUpgradingChildDef == nil {
-		// Create it
-		if currentUpgradingChildDef == nil {
-			_, needRequeue, err := startUpgradeProcess(ctx, rolloutObject, existingPromotedChild, controller, c)
-			if needRequeue {
-				return false, common.DefaultRequeueDelay, err
-			} else {
-				return false, 0, err
-			}
-		}
-	}
-
-	// nothing to do (either there's nothing to upgrade, or we just created an "upgrading" child, and it's too early to start reconciling it)
 	if currentUpgradingChildDef == nil {
-		return true, 0, err
+		// Create it
+		_, needRequeue, err := startUpgradeProcess(ctx, rolloutObject, existingPromotedChild, controller, c)
+		if needRequeue {
+			return false, common.DefaultRequeueDelay, err
+		} else {
+			return false, 0, err
+		}
 	}
 
 	// There's already an Upgrading child, now process it


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
