### PR TITLE
chore: update prometheus query in AT test to reflect what we're using

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ endif
 prometheus:
 ifeq ($(PROMETHEUS_REQUIRED), true)
 	$(KUBECTL) apply -f $(TEST_MANIFEST_DIR_DEFAULT)/prometheus-ns.yaml
-	helm upgrade --install prometheus $(PROMETHEUS_CHART) -n prometheus --set prometheus.resourcesPreset=small --set prometheus.logLevel=debug --hide-notes
+	helm upgrade --install prometheus $(PROMETHEUS_CHART) -n prometheus --set prometheus.resourcesPreset=small --set prometheus.logLevel=debug --hide-notes 
 endif
 
 ##@ Deployment

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -29,7 +29,9 @@ import (
 	"k8s.io/client-go/dynamic"
 	clientgo "k8s.io/client-go/kubernetes"
 
-	argov1alpha1 "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/typed/rollouts/v1alpha1"
+	argoclientsetv1alpha1 "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/typed/rollouts/v1alpha1"
+
+	argorolloutv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/controller/config"
@@ -58,8 +60,8 @@ var (
 	numaflowControllerRolloutClient planepkg.NumaflowControllerRolloutInterface
 	numaflowControllerClient        planepkg.NumaflowControllerInterface
 	monoVertexRolloutClient         planepkg.MonoVertexRolloutInterface
-	argoAnalysisTemplateClient      argov1alpha1.AnalysisTemplateInterface
-	argoAnalysisRunClient           argov1alpha1.AnalysisRunInterface
+	argoAnalysisTemplateClient      argoclientsetv1alpha1.AnalysisTemplateInterface
+	argoAnalysisRunClient           argoclientsetv1alpha1.AnalysisRunInterface
 	kubeClient                      clientgo.Interface
 
 	wg     sync.WaitGroup
@@ -101,8 +103,9 @@ const (
 	PodLogsNumaflowControllerOutputPath  = "../output/logs/numaflowcontrollerrollouts"
 	PodLogsNumaplaneControllerOutputPath = "../output/logs/numaplanecontroller"
 
-	NumaplaneAPIVersion = "numaplane.numaproj.io/v1alpha1"
-	NumaflowAPIVersion  = "numaflow.numaproj.io/v1alpha1"
+	NumaplaneAPIVersion    = "numaplane.numaproj.io/v1alpha1"
+	NumaflowAPIVersion     = "numaflow.numaproj.io/v1alpha1"
+	ArgoRolloutsAPIVersion = "argoproj.io/v1alpha1"
 
 	NumaplaneLabel = "app.kubernetes.io/part-of=numaplane"
 	NumaflowLabel  = "app.kubernetes.io/part-of=numaflow"
@@ -385,6 +388,27 @@ func watchResourceType(getWatchFunc func() (watch.Interface, error), processEven
 
 }
 
+func watchAnalysisRun() {
+
+	watchResourceType(func() (watch.Interface, error) {
+		watcher, err := argoAnalysisRunClient.Watch(context.Background(), metav1.ListOptions{})
+		return watcher, err
+	}, func(o runtime.Object) Output {
+		if analysisRun, ok := o.(*argorolloutv1alpha1.AnalysisRun); ok {
+			analysisRun.ManagedFields = nil
+			return Output{
+				APIVersion: ArgoRolloutsAPIVersion,
+				Kind:       "AnalysisRun",
+				Metadata:   analysisRun.ObjectMeta,
+				Spec:       analysisRun.Spec,
+				Status:     analysisRun.Status,
+			}
+		}
+		return Output{}
+	})
+
+}
+
 // helper func to write `kubectl get -o yaml` output to file
 func writeToFile(resource Output) error {
 
@@ -531,6 +555,11 @@ func getUpgradeStrategy() config.USDEUserStrategy {
 	}
 }
 
+func startCommonWatches() {
+	wg.Add(1)
+	go watchAnalysisRun()
+}
+
 func BeforeSuiteSetup() {
 	var err error
 	// make output directory to store temporary outputs; if it's there from before delete it
@@ -592,11 +621,11 @@ func BeforeSuiteSetup() {
 	Expect(numaflowControllerClient).NotTo(BeNil())
 	Expect(err).NotTo(HaveOccurred())
 
-	argoAnalysisTemplateClient = argov1alpha1.NewForConfigOrDie(cfg).AnalysisTemplates(Namespace)
+	argoAnalysisTemplateClient = argoclientsetv1alpha1.NewForConfigOrDie(cfg).AnalysisTemplates(Namespace)
 	Expect(argoAnalysisTemplateClient).NotTo(BeNil())
 	Expect(err).NotTo(HaveOccurred())
 
-	argoAnalysisRunClient = argov1alpha1.NewForConfigOrDie(cfg).AnalysisRuns(Namespace)
+	argoAnalysisRunClient = argoclientsetv1alpha1.NewForConfigOrDie(cfg).AnalysisRuns(Namespace)
 	Expect(argoAnalysisRunClient).NotTo(BeNil())
 	Expect(err).NotTo(HaveOccurred())
 
@@ -612,6 +641,8 @@ func BeforeSuiteSetup() {
 
 		wg.Add(1)
 		go watchPods()
+
+		startCommonWatches()
 
 		startNumaflowControllerRolloutWatches()
 

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -438,6 +438,15 @@ func writeToFile(resource Output) error {
 		fileName = filepath.Join(ResourceChangesNumaflowControllerOutputPath, "numaflowcontroller.yaml")
 	case "NumaflowControllerRollout":
 		fileName = filepath.Join(ResourceChangesNumaflowControllerOutputPath, "numaflowcontroller_rollout.yaml")
+	case "AnalysisRun":
+		if len(resource.Metadata.OwnerReferences) > 0 {
+			switch resource.Metadata.OwnerReferences[0].Kind {
+			case "Monovertex":
+				fileName = filepath.Join(ResourceChangesMonoVertexOutputPath, "analysisrun.yaml")
+			case "Pipeline":
+				fileName = filepath.Join(ResourceChangesPipelineOutputPath, "analysisrun.yaml")
+			}
+		}
 	case "Pod":
 		switch resource.Metadata.Labels["app.kubernetes.io/component"] {
 		case "controller-manager":

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -441,7 +441,7 @@ func writeToFile(resource Output) error {
 	case "AnalysisRun":
 		if len(resource.Metadata.OwnerReferences) > 0 {
 			switch resource.Metadata.OwnerReferences[0].Kind {
-			case "Monovertex":
+			case "MonoVertex":
 				fileName = filepath.Join(ResourceChangesMonoVertexOutputPath, "analysisrun.yaml")
 			case "Pipeline":
 				fileName = filepath.Join(ResourceChangesPipelineOutputPath, "analysisrun.yaml")

--- a/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
+++ b/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
@@ -93,7 +93,16 @@ var (
 				Provider: argov1alpha1.MetricProvider{
 					Prometheus: &argov1alpha1.PrometheusMetric{
 						Address: "http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:{{args.prometheus-port}}",
-						Query:   "(vector(1) and on() (sum(monovtx_read_total{namespace=\"{{args.monovertex-namespace}}\", mvtx_name=\"{{args.upgrading-monovertex-name}}\"}) == 0)) or (vector(1) and on() (sum(monovtx_ack_total{namespace=\"{{args.monovertex-namespace}}\", mvtx_name=\"{{args.upgrading-monovertex-name}}\"}) > 0)) or vector(0)",
+						Query: `
+(
+  absent(sum(numaflow_monovtx_read_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}))
+  OR
+  sum(numaflow_monovtx_read_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}) == 0
+)
+OR
+(
+  sum(numaflow_monovtx_ack_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}) > 0
+)`,
 					},
 				},
 				SuccessCondition: "result[0] > 0",

--- a/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
+++ b/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
@@ -96,13 +96,13 @@ var (
 						Address: "http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:{{args.prometheus-port}}",
 						Query: `
 (
-  absent(sum(numaflow_monovtx_read_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}))
+  absent(sum(monovtx_read_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}))
   OR
-  sum(numaflow_monovtx_read_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}) == 0
+  sum(monovtx_read_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}) == 0
 )
 OR
 (
-  sum(numaflow_monovtx_ack_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}) > 0
+  sum(monovtx_ack_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}) > 0
 )`,
 					},
 				},

--- a/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
+++ b/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
@@ -72,8 +72,7 @@ var (
 		Source: &numaflowv1.Source{
 			UDSource: &numaflowv1.UDSource{
 				Container: &numaflowv1.Container{
-					//Image: "quay.io/numaio/numaflow-rs/simple-source:stable",
-					Image: "quay.io/numaio/numaflow-go/source-simple-source:stable",
+					Image: "quay.io/numaio/numaflow-rs/simple-source:stable",
 				},
 			},
 		},

--- a/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
+++ b/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 		CreateNumaflowControllerRollout(PrimaryNumaflowControllerVersion)
 	})
 
-	/*It("Should validate MonoVertex upgrade using Analysis template for Progressive strategy - Success case", func() {
+	It("Should validate MonoVertex upgrade using Analysis template for Progressive strategy - Success case", func() {
 		CreateAnalysisTemplate(analysisTemplateName, Namespace, initialAnalysisTemplateSpec)
 		CreateInitialMonoVertexRollout(monoVertexRolloutName, initialMonoVertexSpec, &defaultStrategy)
 
@@ -149,7 +149,7 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 
 		DeleteMonoVertexRollout(monoVertexRolloutName)
 		DeleteAnalysisTemplate(analysisTemplateName)
-	})*/
+	})
 
 	It("Should validate MonoVertex upgrade using Analysis template for Progressive strategy - Failure case", func() {
 		CreateAnalysisTemplate(analysisTemplateName, Namespace, initialAnalysisTemplateSpec)
@@ -163,7 +163,7 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 		VerifyMonoVertexProgressiveFailure(monoVertexRolloutName, monoVertexScaleMinMaxJSONString, updatedMonoVertexSpec, monoVertexScaleTo, false)
 
 		// Verify the AnalysisRun status is Failed
-		VerifyAnalysisRunStatus("mvtx-example", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseFailed)
+		VerifyAnalysisRunStatus("mvtx-example", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseError)
 
 		DeleteMonoVertexRollout(monoVertexRolloutName)
 		DeleteAnalysisTemplate(analysisTemplateName)

--- a/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
+++ b/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
@@ -72,7 +72,8 @@ var (
 		Source: &numaflowv1.Source{
 			UDSource: &numaflowv1.UDSource{
 				Container: &numaflowv1.Container{
-					Image: "quay.io/numaio/numaflow-rs/simple-source:stable",
+					//Image: "quay.io/numaio/numaflow-rs/simple-source:stable",
+					Image: "quay.io/numaio/numaflow-go/source-simple-source:stable",
 				},
 			},
 		},
@@ -133,7 +134,7 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 		CreateNumaflowControllerRollout(PrimaryNumaflowControllerVersion)
 	})
 
-	It("Should validate MonoVertex upgrade using Analysis template for Progressive strategy - Success case", func() {
+	/*It("Should validate MonoVertex upgrade using Analysis template for Progressive strategy - Success case", func() {
 		CreateAnalysisTemplate(analysisTemplateName, Namespace, initialAnalysisTemplateSpec)
 		CreateInitialMonoVertexRollout(monoVertexRolloutName, initialMonoVertexSpec, &defaultStrategy)
 
@@ -148,7 +149,7 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 
 		DeleteMonoVertexRollout(monoVertexRolloutName)
 		DeleteAnalysisTemplate(analysisTemplateName)
-	})
+	})*/
 
 	It("Should validate MonoVertex upgrade using Analysis template for Progressive strategy - Failure case", func() {
 		CreateAnalysisTemplate(analysisTemplateName, Namespace, initialAnalysisTemplateSpec)

--- a/tests/manifests/default/prometheus-monitors.yaml
+++ b/tests/manifests/default/prometheus-monitors.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: numaflow
   name: numaflow-pipeline-metrics
+  namespace: prometheus
 spec:
   namespaceSelector:
     any: true
@@ -31,6 +32,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: numaflow
   name: numaflow-mono-vertex-metrics
+  namespace: prometheus
 spec:
   namespaceSelector:
     any: true

--- a/tests/manifests/default/prometheus-monitors.yaml
+++ b/tests/manifests/default/prometheus-monitors.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/part-of: numaflow
   name: numaflow-pipeline-metrics
-  namespace: prometheus
 spec:
   namespaceSelector:
     any: true
@@ -32,7 +31,6 @@ metadata:
   labels:
     app.kubernetes.io/part-of: numaflow
   name: numaflow-mono-vertex-metrics
-  namespace: prometheus
 spec:
   namespaceSelector:
     any: true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

1. Updated prometheus query to match the one we're applying to clusters
2. Added "AnalysisRun" to the list of artifacts that are saved when running e2e

### Verification

n/a

### Backward incompatibilities

n/a
