### PR TITLE
fix: default timeout for Consistently() check should be much shorter 

### DIFF
--- a/tests/e2e/analysistemplate.go
+++ b/tests/e2e/analysistemplate.go
@@ -57,7 +57,7 @@ func DeleteAnalysisTemplate(name string) {
 			return false
 		}
 		return true
-	}).WithTimeout(TestTimeout).Should(BeFalse(), "The AnalysisTemplate should have been deleted but it was found.")
+	}).WithTimeout(DefaultTestTimeout).Should(BeFalse(), "The AnalysisTemplate should have been deleted but it was found.")
 }
 
 func VerifyAnalysisRunStatus(metricName, name string, expectedStatus argov1alpha1.AnalysisPhase) {

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -50,8 +50,9 @@ var (
 	// Note: this timeout needs to be large enough for:
 	//  - progressive child resource healthiness assessment (2 minutes until assessment start time + 1 minute until end time)
 	//  - time for isbsvc to be created plus pipeline to become healthy afterward
-	TestTimeout         = 6 * time.Minute
-	TestPollingInterval = 10 * time.Millisecond
+	DefaultTestTimeout            = 6 * time.Minute
+	DefaultConsistentCheckTimeout = 15 * time.Second // the default time for checks using "Consistently"
+	TestPollingInterval           = 10 * time.Millisecond
 
 	pipelineRolloutClient           planepkg.PipelineRolloutInterface
 	isbServiceRolloutClient         planepkg.ISBServiceRolloutInterface
@@ -145,7 +146,7 @@ func verifyPodsRunning(namespace string, numPods int, labelSelector string) {
 			return true
 		}
 		return false
-	}).WithTimeout(TestTimeout).Should(BeTrue())
+	}).WithTimeout(DefaultTestTimeout).Should(BeTrue())
 
 }
 
@@ -210,7 +211,7 @@ func VerifyVerticesPodsRunning(namespace, rolloutChildName string, specVertices 
 			}
 
 			return true
-		}).WithTimeout(TestTimeout).Should(BeTrue())
+		}).WithTimeout(DefaultTestTimeout).Should(BeTrue())
 	}
 }
 
@@ -472,14 +473,14 @@ func VerifyResourceExists(gvr schema.GroupVersionResource, name string) {
 			return false
 		}
 		return true
-	}).WithTimeout(TestTimeout).Should(BeTrue())
+	}).WithTimeout(DefaultTestTimeout).Should(BeTrue())
 }
 
 func VerifyResourceDoesntExist(gvr schema.GroupVersionResource, name string) {
 	CheckEventually(fmt.Sprintf("verifying GVR %+v of name=%s doesn't exist", gvr, name), func() bool {
 		resource, _ := GetResource(gvr, Namespace, name)
 		return resource == nil
-	}).WithTimeout(TestTimeout).Should(BeTrue())
+	}).WithTimeout(DefaultTestTimeout).Should(BeTrue())
 }
 
 func GetResource(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
@@ -701,14 +702,14 @@ func setupOutputDir() {
 // You can override the default timeout and polling interval by using WithTimeout and WithPolling methods
 func CheckEventually(testDescription string, actualOrCtx interface{}) AsyncAssertion {
 	By(testDescription)
-	return Eventually(actualOrCtx, TestTimeout, TestPollingInterval)
+	return Eventually(actualOrCtx, DefaultTestTimeout, TestPollingInterval)
 }
 
 // CheckConsistently is wrappers around Ginkgo's Consistently
 // You can override the default timeout and polling interval by using WithTimeout and WithPolling methods
 func CheckConsistently(testDescription string, actualOrCtx interface{}) AsyncAssertion {
 	By(testDescription)
-	return Consistently(actualOrCtx, TestTimeout, TestPollingInterval)
+	return Consistently(actualOrCtx, DefaultConsistentCheckTimeout, TestPollingInterval)
 }
 
 func VerifyVerticesScale(actualVertexScaleMap map[string]numaflowv1.Scale, expectedVertexScaleMap map[string]numaflowv1.Scale) bool {

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -349,7 +349,7 @@ func DeleteISBServiceRollout(name string) {
 			return false
 		}
 		return true
-	}).WithTimeout(TestTimeout).Should(BeFalse(), "The ISBServiceRollout should have been deleted but it was found.")
+	}).WithTimeout(DefaultTestTimeout).Should(BeFalse(), "The ISBServiceRollout should have been deleted but it was found.")
 
 	CheckEventually("Verifying ISBService deletion", func() bool {
 		list, err := dynamicClient.Resource(GetGVRForISBService()).Namespace(Namespace).List(ctx, metav1.ListOptions{})
@@ -360,7 +360,7 @@ func DeleteISBServiceRollout(name string) {
 			return true
 		}
 		return false
-	}).WithTimeout(TestTimeout).Should(BeTrue(), "The ISBService should have been deleted but it was found.")
+	}).WithTimeout(DefaultTestTimeout).Should(BeTrue(), "The ISBService should have been deleted but it was found.")
 }
 
 // pipelineRolloutNames is an array of pipelinerollout names that are checked to see if it is pausing or not after update
@@ -561,5 +561,5 @@ func VerifyISBServiceDeletion(isbsvcName string) {
 		}
 
 		return pipeline == nil
-	}).WithTimeout(TestTimeout).Should(BeTrue(), fmt.Sprintf("The InterstepBufferService %s/%s should have been deleted but it was found.", Namespace, isbsvcName))
+	}).WithTimeout(DefaultTestTimeout).Should(BeTrue(), fmt.Sprintf("The InterstepBufferService %s/%s should have been deleted but it was found.", Namespace, isbsvcName))
 }

--- a/tests/e2e/monovertex.go
+++ b/tests/e2e/monovertex.go
@@ -373,7 +373,7 @@ func DeleteMonoVertexRollout(name string) {
 			return false
 		}
 		return true
-	}).WithTimeout(TestTimeout).Should(BeFalse(), "The MonoVertexRollout should have been deleted but it was found.")
+	}).WithTimeout(DefaultTestTimeout).Should(BeFalse(), "The MonoVertexRollout should have been deleted but it was found.")
 
 	CheckEventually("Verifying MonoVertex deletion", func() bool {
 		list, err := dynamicClient.Resource(GetGVRForMonoVertex()).Namespace(Namespace).List(ctx, metav1.ListOptions{})
@@ -384,7 +384,7 @@ func DeleteMonoVertexRollout(name string) {
 			return true
 		}
 		return false
-	}).WithTimeout(TestTimeout).Should(BeTrue(), "The MonoVertex should have been deleted but it was found.")
+	}).WithTimeout(DefaultTestTimeout).Should(BeTrue(), "The MonoVertex should have been deleted but it was found.")
 }
 
 func VerifyMonoVertexDeletion(name string) {
@@ -395,7 +395,7 @@ func VerifyMonoVertexDeletion(name string) {
 		}
 
 		return monovertex == nil
-	}).WithTimeout(TestTimeout).Should(BeTrue(), fmt.Sprintf("The MonoVertex %s/%s should have been deleted but it was found.", Namespace, name))
+	}).WithTimeout(DefaultTestTimeout).Should(BeTrue(), fmt.Sprintf("The MonoVertex %s/%s should have been deleted but it was found.", Namespace, name))
 }
 
 func UpdateMonoVertexRollout(name string, newSpec numaflowv1.MonoVertexSpec, expectedFinalPhase numaflowv1.MonoVertexPhase, verifySpecFunc func(numaflowv1.MonoVertexSpec) bool,

--- a/tests/e2e/numaflowcontroller.go
+++ b/tests/e2e/numaflowcontroller.go
@@ -201,7 +201,7 @@ func DeleteNumaflowControllerRollout() {
 			return false
 		}
 		return true
-	}).WithTimeout(TestTimeout).Should(BeFalse(), "The NumaflowControllerRollout should have been deleted but it was found.")
+	}).WithTimeout(DefaultTestTimeout).Should(BeFalse(), "The NumaflowControllerRollout should have been deleted but it was found.")
 
 	CheckEventually("Verifying Numaflow Controller deletion", func() bool {
 		_, err := kubeClient.AppsV1().Deployments(Namespace).Get(ctx, numaflowControllerRolloutName, metav1.GetOptions{})
@@ -212,7 +212,7 @@ func DeleteNumaflowControllerRollout() {
 			return false
 		}
 		return true
-	}).WithTimeout(TestTimeout).Should(BeFalse(), "The deployment should have been deleted but it was found.")
+	}).WithTimeout(DefaultTestTimeout).Should(BeFalse(), "The deployment should have been deleted but it was found.")
 }
 
 // UpdateNumaflowControllerRollout updates the NumaflowControllerRollout and its dependent PipelineRollouts.

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -469,7 +469,7 @@ func DeletePipelineRollout(name string) {
 			return false
 		}
 		return true
-	}).WithTimeout(TestTimeout).Should(BeFalse(), "The PipelineRollout should have been deleted but it was found.")
+	}).WithTimeout(DefaultTestTimeout).Should(BeFalse(), "The PipelineRollout should have been deleted but it was found.")
 
 	CheckEventually("Verifying Pipeline deletion", func() bool {
 		// ensures deletion of single pipeline
@@ -482,7 +482,7 @@ func DeletePipelineRollout(name string) {
 			return true
 		}
 		return false
-	}).WithTimeout(TestTimeout).Should(BeTrue(), "The Pipeline should have been deleted but it was found.")
+	}).WithTimeout(DefaultTestTimeout).Should(BeTrue(), "The Pipeline should have been deleted but it was found.")
 }
 
 // update PipelineRollout and verify correct process
@@ -598,7 +598,7 @@ func VerifyPipelineDeletion(pipelineName string) {
 		}
 
 		return pipeline == nil
-	}).WithTimeout(TestTimeout).Should(BeTrue(), fmt.Sprintf("The Pipeline %s/%s should have been deleted but it was found.", Namespace, pipelineName))
+	}).WithTimeout(DefaultTestTimeout).Should(BeTrue(), fmt.Sprintf("The Pipeline %s/%s should have been deleted but it was found.", Namespace, pipelineName))
 }
 
 func CreateInitialPipelineRollout(pipelineRolloutName, currentPromotedISBService string, initialPipelineSpec numaflowv1.PipelineSpec, defaultStrategy apiv1.PipelineTypeRolloutStrategy) {

--- a/tests/e2e/progressive.go
+++ b/tests/e2e/progressive.go
@@ -265,7 +265,7 @@ func VerifyMonoVertexPromotedScale(namespace, monoVertexRolloutName string, expe
 		}
 
 		return VerifyVerticesScale(actualMonoVertexScaleMap, expectedMonoVertexScaleMap)
-	}).WithTimeout(TestTimeout).Should(BeTrue())
+	}).WithTimeout(DefaultTestTimeout).Should(BeTrue())
 }
 
 // Make sure Upgrading Pipeline has min=max equal to difference between Initial and ScaleTo in promoted status


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

I noticed a couple of places where I was calling `CheckConsistently()`, and unfortunately if you forget to override the default test timeout, it sets it to 6 minutes. I want to make the default much shorter.

This reduces the pipeline-progressive test from 32 minutes to 21 :) 

### Verification

e2e still passes, observed the Consistently check took only 15 seconds

### Backward incompatibilities

n/a
