### PR TITLE
fix: Add two analysis template for monovertex and failure tests for pipeline

### DIFF
--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -598,3 +598,12 @@ func VerifyISBServiceProgressiveSuccess(isbsvcRolloutName string, promotedISBSvc
 	VerifyISBServiceRolloutProgressiveStatus(isbsvcRolloutName, promotedISBSvcName, upgradingISBSvcName, apiv1.AssessmentResultSuccess)
 	VerifyISBServiceRolloutProgressiveCondition(isbsvcRolloutName, metav1.ConditionTrue)
 }
+
+func UpdateISBService(isbServiceRolloutName string, spec numaflowv1.InterStepBufferServiceSpec) {
+	rawSpec, err := json.Marshal(spec)
+	Expect(err).ShouldNot(HaveOccurred())
+	UpdateISBServiceRolloutInK8S(isbServiceRolloutName, func(isbSvcRollout apiv1.ISBServiceRollout) (apiv1.ISBServiceRollout, error) {
+		isbSvcRollout.Spec.InterStepBufferService.Spec.Raw = rawSpec
+		return isbSvcRollout, nil
+	})
+}

--- a/tests/e2e/pipeline.go
+++ b/tests/e2e/pipeline.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"k8s.io/utils/ptr"
 	"reflect"
 	"time"
 
+	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -16,9 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
-
-	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
 
 	"github.com/numaproj/numaplane/internal/common"
 	"github.com/numaproj/numaplane/internal/controller/config"

--- a/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
+++ b/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
@@ -34,9 +34,10 @@ import (
 )
 
 const (
-	monoVertexRolloutName = "test-monovertex-analysis-rollout"
-	analysisTemplateName  = "test-monovertex-template"
-	analysisRunName       = "monovertex-" + monoVertexRolloutName
+	monoVertexRolloutName   = "test-monovertex-analysis-rollout"
+	analysisTemplateNameOne = "test-monovertex-template-1"
+	analysisTemplateNameTwo = "test-monovertex-template-2"
+	analysisRunName         = "monovertex-" + monoVertexRolloutName
 )
 
 var (
@@ -56,7 +57,11 @@ var (
 			Analysis: apiv1.Analysis{
 				Templates: []argov1alpha1.AnalysisTemplateRef{
 					{
-						TemplateName: analysisTemplateName,
+						TemplateName: analysisTemplateNameOne,
+						ClusterScope: false,
+					},
+					{
+						TemplateName: analysisTemplateNameTwo,
 						ClusterScope: false,
 					},
 				},
@@ -86,7 +91,7 @@ var (
 	initialAnalysisTemplateSpec = argov1alpha1.AnalysisTemplateSpec{
 		Metrics: []argov1alpha1.Metric{
 			{
-				Name:                    "mvtx-example",
+				Name:                    "mvtx-example-1",
 				FailureLimit:            ptr.To(intstrutil.FromInt32(3)),
 				Interval:                "60s",
 				ConsecutiveSuccessLimit: ptr.To(intstrutil.FromInt32(3)),
@@ -134,7 +139,14 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 	})
 
 	It("Should validate MonoVertex upgrade using Analysis template for Progressive strategy - Success case", func() {
-		CreateAnalysisTemplate(analysisTemplateName, Namespace, initialAnalysisTemplateSpec)
+		CreateAnalysisTemplate(analysisTemplateNameOne, Namespace, initialAnalysisTemplateSpec)
+
+		// Update the initial AnalysisTemplateSpec to use a different metric name and success condition
+		updatedAnalysisTemplateSpec := initialAnalysisTemplateSpec.DeepCopy()
+		updatedAnalysisTemplateSpec.Metrics[0].Name = "mvtx-example-2"
+		updatedAnalysisTemplateSpec.Metrics[0].SuccessCondition = "len(result) > 0"
+		CreateAnalysisTemplate(analysisTemplateNameTwo, Namespace, *updatedAnalysisTemplateSpec)
+
 		CreateInitialMonoVertexRollout(monoVertexRolloutName, initialMonoVertexSpec, &defaultStrategy)
 
 		updatedMonoVertexSpec := UpdateMonoVertexRolloutForSuccess(monoVertexRolloutName, validUDTransformerImage, initialMonoVertexSpec, udTransformer)
@@ -144,14 +156,21 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 		// Verify the previously promoted monovertex was deleted
 		VerifyMonoVertexDeletion(GetInstanceName(monoVertexRolloutName, 0))
 
-		VerifyAnalysisRunStatus("mvtx-example", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseSuccessful)
+		VerifyAnalysisRunStatus("mvtx-example-1", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseSuccessful)
+		VerifyAnalysisRunStatus("mvtx-example-2", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseSuccessful)
 
 		DeleteMonoVertexRollout(monoVertexRolloutName)
-		DeleteAnalysisTemplate(analysisTemplateName)
+		DeleteAnalysisTemplate(analysisTemplateNameOne)
+		DeleteAnalysisTemplate(analysisTemplateNameTwo)
 	})
 
 	It("Should validate MonoVertex upgrade using Analysis template for Progressive strategy - Failure case", func() {
-		CreateAnalysisTemplate(analysisTemplateName, Namespace, initialAnalysisTemplateSpec)
+		CreateAnalysisTemplate(analysisTemplateNameOne, Namespace, initialAnalysisTemplateSpec)
+		// Update the initial AnalysisTemplateSpec to use a different metric name and success condition
+		updatedAnalysisTemplate := initialAnalysisTemplateSpec.DeepCopy()
+		updatedAnalysisTemplate.Metrics[0].Name = "mvtx-example-2"
+		updatedAnalysisTemplate.Metrics[0].SuccessCondition = "result[0] == 0"
+		CreateAnalysisTemplate(analysisTemplateNameTwo, Namespace, *updatedAnalysisTemplate)
 
 		// Update the initial MonoVertexSpec to use a bad image for the sink
 		initialMonoVertexSpec.Sink.AbstractSink.Blackhole = nil
@@ -162,10 +181,12 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 		VerifyMonoVertexProgressiveFailure(monoVertexRolloutName, monoVertexScaleMinMaxJSONString, updatedMonoVertexSpec, monoVertexScaleTo, false)
 
 		// Verify the AnalysisRun status is Failed
-		VerifyAnalysisRunStatus("mvtx-example", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseError)
+		VerifyAnalysisRunStatus("mvtx-example-1", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseError)
+		VerifyAnalysisRunStatus("mvtx-example-2", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseError)
 
 		DeleteMonoVertexRollout(monoVertexRolloutName)
-		DeleteAnalysisTemplate(analysisTemplateName)
+		DeleteAnalysisTemplate(analysisTemplateNameOne)
+		DeleteAnalysisTemplate(analysisTemplateNameTwo)
 	})
 
 	It("Should delete all remaining rollout objects", func() {

--- a/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
+++ b/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
@@ -166,10 +166,12 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 
 	It("Should validate MonoVertex upgrade using Analysis template for Progressive strategy - Failure case", func() {
 		CreateAnalysisTemplate(analysisTemplateNameOne, Namespace, initialAnalysisTemplateSpec)
-		// Update the initial AnalysisTemplateSpec to use a different metric name and success condition
+		// Update a fake query to cause a success status
 		updatedAnalysisTemplate := initialAnalysisTemplateSpec.DeepCopy()
 		updatedAnalysisTemplate.Metrics[0].Name = "mvtx-example-2"
-		updatedAnalysisTemplate.Metrics[0].SuccessCondition = "result[0] == 0"
+		updatedAnalysisTemplate.Metrics[0].SuccessCondition = "true"
+		updatedAnalysisTemplate.Metrics[0].Provider.Prometheus.Query = "vector(1)"
+
 		CreateAnalysisTemplate(analysisTemplateNameTwo, Namespace, *updatedAnalysisTemplate)
 
 		// Update the initial MonoVertexSpec to use a bad image for the sink
@@ -182,7 +184,7 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 
 		// Verify the AnalysisRun status is Failed
 		VerifyAnalysisRunStatus("mvtx-example-1", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseError)
-		VerifyAnalysisRunStatus("mvtx-example-2", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseError)
+		VerifyAnalysisRunStatus("mvtx-example-2", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseSuccessful)
 
 		DeleteMonoVertexRollout(monoVertexRolloutName)
 		DeleteAnalysisTemplate(analysisTemplateNameOne)

--- a/tests/e2e/progressive-pipeline-e2e/pipeline_test.go
+++ b/tests/e2e/progressive-pipeline-e2e/pipeline_test.go
@@ -280,7 +280,7 @@ var _ = Describe("Progressive Pipeline and ISBService E2E", Serial, func() {
 		By("Updating the ISBService to cause a Progressive change - Valid change")
 		updatedISBServiceSpec := initialISBServiceSpec.DeepCopy()
 		updatedISBServiceSpec.JetStream.Version = UpdatedJetstreamVersion
-		updateISBService(*updatedISBServiceSpec)
+		UpdateISBService(isbServiceRolloutName, *updatedISBServiceSpec)
 
 		// Since forcePromote=true, both Pipeline and ISBService should be promoted successfully
 		// even though the pipeline change was invalid ("badcat" function)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/750

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

- Use two analysis template for MonoVertex analysis tests for success and failure case.
- Add failure test case for pipeline analysis e2e 

### Verification
- Verified in local k8s cluster

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
