### PR TITLE
chore: Feature flag to ignore AnalysisRun result

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
@@ -6,11 +6,11 @@ metadata:
 spec:
   strategy:
     progressive:
-      assessmentSchedule: "60,60,10"
+      assessmentSchedule: "120,60,10"
     analysis:
       args:
       templates:
-      - templateName: mvtx-template
+      - templateName: mvtx-acknowledged-messages
         clusterScope: false
   riders:
     - definition:
@@ -41,8 +41,47 @@ spec:
             image: quay.io/numaio/numaflow-go/source-simple-source:stable
         transformer:
           container:
-            image: docker.intuit.com/quay-rmt/numaio/numaflow-rs/source-transformer-now:stable
+            image: quay.io/numaio/numaflow-rs/source-transformer-now:stable
       sink:
         udsink:
           container:
             image: quay.io/numaio/numaflow-go/sink-log:stable
+            #image: quay.io/numaio/numaflow-go/sink-log-failure:stable # use to fail the AnalysisRun
+---
+
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: mvtx-acknowledged-messages
+  labels:
+    used_by: numaplane
+spec:
+  args:
+    - name: upgrading-monovertex-name
+    - name: monovertex-namespace
+    - name: interval
+      value: 10s
+    - name: success-limit
+      value: "3" # if we do this check too early and the prometheus metric doesn't know about the read count yet, it could
+                        # succeed when it shouldn't
+    - name: failure-limit 
+      value: "3" # if we do this check too early and the read has occurred but not the ack, it could fail when it shouldn't
+  metrics:
+  - name: acknowledged-messages
+    consecutiveSuccessLimit: '{{args.success-limit}}'
+    failureLimit: '{{args.failure-limit}}'
+    interval: '{{args.interval}}'
+    provider:
+      prometheus:
+        address: http://prometheus.addon-metricset-ns.svc.cluster.local:9090/
+        query: |
+          (
+            absent(sum(numaflow_monovtx_read_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}))
+            OR
+            sum(numaflow_monovtx_read_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}) == 0
+          )
+          OR
+          (
+            sum(numaflow_monovtx_ack_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}) > 0
+          )
+    successCondition: len(result) > 0 && result[0] > 0

--- a/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   strategy:
     progressive:
-      assessmentSchedule: "60,60,10"
+      assessmentSchedule: "120,60,10"
     analysis:
       args:
       templates:

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -103,6 +103,10 @@ type GlobalConfig struct {
 	// FeatureFlagDisallowProgressiveForNonMonoVertex is a TEMPORARY feature flag to disable progressive upgrades for resources other than MonoVertex
 	FeatureFlagDisallowProgressiveForNonMonoVertex bool `json:"featureFlagDisallowProgressiveForNonMonoVertex" mapstructure:"featureFlagDisallowProgressiveForNonMonoVertex"`
 
+	// TODO: remove when no longer needed
+	// FeatureFlagIgnoreAnalysisResult is a TEMPORARY feature flag to ignore the result of an AnalysisRun
+	FeatureFlagIgnoreAnalysisResult bool `json:"featureFlagIgnoreAnalysisResult" mapstructure:"featureFlagIgnoreAnalysisResult"`
+
 	// List of permitted Kinds for Riders
 	PermittedRiders string `json:"permittedRiders" mapstructure:"permittedRiders"`
 }

--- a/internal/controller/progressive/analysis.go
+++ b/internal/controller/progressive/analysis.go
@@ -215,6 +215,7 @@ func AssessAnalysisStatus(
 		return apiv1.AssessmentResultUnknown, "", fmt.Errorf("error getting the global config: %v", err)
 	}
 	if globalConfig.FeatureFlagIgnoreAnalysisResult {
+		numaLogger.Debugf("Feature flag set to ignore AnalysisRun")
 		return apiv1.AssessmentResultSuccess, "", nil
 	}
 

--- a/internal/controller/progressive/analysis.go
+++ b/internal/controller/progressive/analysis.go
@@ -29,6 +29,7 @@ import (
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/numaproj/numaplane/internal/controller/config"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -208,6 +209,16 @@ func AssessAnalysisStatus(
 	analysisStatus *apiv1.AnalysisStatus) (apiv1.AssessmentResult, string, error) {
 	numaLogger := logger.FromContext(ctx)
 
+	// check for feature flag to skip checking the AnalysisRun
+	globalConfig, err := config.GetConfigManagerInstance().GetConfig()
+	if err != nil {
+		return apiv1.AssessmentResultUnknown, "", fmt.Errorf("error getting the global config: %v", err)
+	}
+	if globalConfig.FeatureFlagIgnoreAnalysisResult {
+		return apiv1.AssessmentResultSuccess, "", nil
+	}
+
+	// make sure we haven't gone past the max time allowed for an AnalysisRun
 	analysisRunTimeout, err := getAnalysisRunTimeout(ctx)
 	if err != nil {
 		return apiv1.AssessmentResultUnknown, "", err


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

This adds a feature flag for ignoring the result of the AnalysisRun as part of the assessment of either Pipeline or MonoVertex.

I've also updated our sample MonoVertexRollout to use the AnalysisTemplate we're using on clusters.


### Verification

Did two tests: once with the feature flag turned on and once with it turned off. Verified that the result was ignored in the former case and not in the latter.

### Backward incompatibilities

N/A
