### PR TITLE
fix: logging needs to reference the right name of the resource

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
@@ -73,7 +73,7 @@ spec:
     interval: '{{args.interval}}'
     provider:
       prometheus:
-        address: http://prometheus.addon-metricset-ns.svc.cluster.local:9090/
+        address: http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090
         query: |
           (
             absent(sum(numaflow_monovtx_read_total{namespace="{{args.monovertex-namespace}}", mvtx_name="{{args.upgrading-monovertex-name}}"}))

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -486,7 +486,6 @@ func checkForUpgradeReplacement(
 		}
 
 		if differentFromPromoted {
-			numaLogger.WithValues("old child", existingUpgradingChildDef.GetName(), "new child", newUpgradingChildDef.GetName()).Debug("replacing 'upgrading' child")
 
 			// recycle the old one
 			reason := common.LabelValueProgressiveReplaced
@@ -502,6 +501,7 @@ func checkForUpgradeReplacement(
 			if err != nil {
 				return false, false, err
 			}
+			numaLogger.WithValues("old child", existingUpgradingChildDef.GetName(), "new child", newUpgradingChildDef.GetName()).Debug("replacing 'upgrading' child")
 			if needRequeue {
 				return true, false, nil
 			}

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -501,7 +501,9 @@ func checkForUpgradeReplacement(
 			if err != nil {
 				return false, false, err
 			}
-			numaLogger.WithValues("old child", existingUpgradingChildDef.GetName(), "new child", newUpgradingChildDef.GetName()).Debug("replacing 'upgrading' child")
+			if newUpgradingChildDef != nil {
+				numaLogger.WithValues("old child", existingUpgradingChildDef.GetName(), "new child", newUpgradingChildDef.GetName()).Debug("replacing 'upgrading' child")
+			}
 			if needRequeue {
 				return true, false, nil
 			}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

I noticed this log line wasn't showing the correct name of the upgrading child. The issue is the location of the log line. 


### Verification

Verified log line while executing.

### Backward incompatibilities

N/A
