### PR TITLE
fix: Add info logger while removing metrics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -150,7 +150,7 @@ func main() {
 	}
 
 	// initialize the custom metrics with the global prometheus registry
-	customMetrics := metrics.RegisterCustomMetrics()
+	customMetrics := metrics.RegisterCustomMetrics(numaLogger)
 	newRawConfig := metrics.AddMetricsTransportWrapper(customMetrics, mgr.GetConfig())
 
 	if err := kubernetes.StartConfigMapWatcher(ctx, newRawConfig); err != nil {

--- a/internal/controller/ginkgo_suite_test.go
+++ b/internal/controller/ginkgo_suite_test.go
@@ -130,7 +130,7 @@ var _ = BeforeSuite(func() {
 
 	// other tests may call this, but it fails if called more than once
 	if ctlrcommon.TestCustomMetrics == nil {
-		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics()
+		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics(numaLogger)
 	}
 
 	Expect(kubernetes.SetClientSets(k8sManager.GetConfig())).To(Succeed())

--- a/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller_test.go
@@ -77,7 +77,7 @@ func Test_reconcile_isbservicerollout_PPND(t *testing.T) {
 	config.GetConfigManagerInstance().UpdateUSDEConfig(usdeConfig)
 
 	if ctlrcommon.TestCustomMetrics == nil {
-		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics()
+		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics(numaLogger)
 	}
 
 	recorder := record.NewFakeRecorder(64)
@@ -327,6 +327,8 @@ func Test_reconcile_isbservicerollout_PPND(t *testing.T) {
 }
 
 func Test_reconcile_isbservicerollout_Progressive(t *testing.T) {
+	numaLogger := logger.New()
+	numaLogger.SetLevel(4)
 	restConfig, numaflowClientSet, client, k8sClientSet, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
 	assert.Nil(t, kubernetes.SetClientSets(restConfig))
@@ -347,7 +349,7 @@ func Test_reconcile_isbservicerollout_Progressive(t *testing.T) {
 
 	// other tests may call this, but it fails if called more than once
 	if ctlrcommon.TestCustomMetrics == nil {
-		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics()
+		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics(numaLogger)
 	}
 
 	recorder := record.NewFakeRecorder(64)

--- a/internal/controller/monovertexrollout/monovertexrollout_controller_test.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller_test.go
@@ -321,7 +321,8 @@ func createMonoVertex(phase numaflowv1.MonoVertexPhase, status numaflowv1.Status
 
 // process an existing monoVertex's progressive upgrade and check that AnalysisRun with correct spec is created
 func Test_processExistingMonoVertex_AnalysisRunGeneration(t *testing.T) {
-
+	numaLogger := logger.New()
+	numaLogger.SetLevel(4)
 	restConfig, numaflowClientSet, client, _, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
 	assert.Nil(t, kubernetes.SetClientSets(restConfig))
@@ -336,7 +337,7 @@ func Test_processExistingMonoVertex_AnalysisRunGeneration(t *testing.T) {
 	ctx := context.Background()
 
 	if ctlrcommon.TestCustomMetrics == nil {
-		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics()
+		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics(numaLogger)
 	}
 
 	recorder := record.NewFakeRecorder(64)
@@ -481,6 +482,8 @@ func Test_processExistingMonoVertex_AnalysisRunGeneration(t *testing.T) {
 
 // process an existing monoVertex in this test, the user preferred strategy is Progressive
 func Test_processExistingMonoVertex_Progressive(t *testing.T) {
+	numaLogger := logger.New()
+	numaLogger.SetLevel(4)
 	restConfig, numaflowClientSet, client, _, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
 	assert.Nil(t, kubernetes.SetClientSets(restConfig))
@@ -496,7 +499,7 @@ func Test_processExistingMonoVertex_Progressive(t *testing.T) {
 
 	// other tests may call this, but it fails if called more than once
 	if ctlrcommon.TestCustomMetrics == nil {
-		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics()
+		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics(numaLogger)
 	}
 
 	recorder := record.NewFakeRecorder(64)

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller_test.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller_test.go
@@ -77,7 +77,7 @@ func Test_reconcile_NumaflowControllerRollout_PPND(t *testing.T) {
 
 	// other tests may call this, but it fails if called more than once
 	if ctlrcommon.TestCustomMetrics == nil {
-		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics()
+		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics(numaLogger)
 	}
 
 	recorder := record.NewFakeRecorder(64)

--- a/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/numaproj/numaplane/internal/controller/ppnd"
 	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
+	"github.com/numaproj/numaplane/internal/util/logger"
 	"github.com/numaproj/numaplane/internal/util/metrics"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 	commontest "github.com/numaproj/numaplane/tests/common"
@@ -816,6 +817,8 @@ func withInterstepBufferService(origPipelineSpec numaflowv1.PipelineSpec, isbsvc
 // process an existing pipeline
 // in this test, the user preferred strategy is PPND
 func Test_processExistingPipeline_PPND(t *testing.T) {
+	numaLogger := logger.New()
+	numaLogger.SetLevel(4)
 	restConfig, numaflowClientSet, client, _, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
 	assert.Nil(t, kubernetes.SetClientSets(restConfig))
@@ -837,7 +840,7 @@ func Test_processExistingPipeline_PPND(t *testing.T) {
 
 	// other tests may call this, but it fails if called more than once
 	if ctlrcommon.TestCustomMetrics == nil {
-		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics()
+		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics(numaLogger)
 	}
 
 	recorder := record.NewFakeRecorder(64)
@@ -1083,6 +1086,8 @@ func Test_processExistingPipeline_PPND(t *testing.T) {
 
 // process an existing pipeline in this test, the user preferred strategy is Progressive
 func Test_processExistingPipeline_Progressive(t *testing.T) {
+	numaLogger := logger.New()
+	numaLogger.SetLevel(4)
 	restConfig, numaflowClientSet, client, _, err := commontest.PrepareK8SEnvironment()
 	assert.Nil(t, err)
 	assert.Nil(t, kubernetes.SetClientSets(restConfig))
@@ -1103,7 +1108,7 @@ func Test_processExistingPipeline_Progressive(t *testing.T) {
 
 	// other tests may call this, but it fails if called more than once
 	if ctlrcommon.TestCustomMetrics == nil {
-		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics()
+		ctlrcommon.TestCustomMetrics = metrics.RegisterCustomMetrics(numaLogger)
 	}
 
 	recorder := record.NewFakeRecorder(64)

--- a/internal/sync/cache_test.go
+++ b/internal/sync/cache_test.go
@@ -21,6 +21,7 @@ import (
 	testcore "k8s.io/client-go/testing"
 	"sigs.k8s.io/yaml"
 
+	"github.com/numaproj/numaplane/internal/util/logger"
 	"github.com/numaproj/numaplane/internal/util/metrics"
 )
 
@@ -75,8 +76,10 @@ func newCluster(t *testing.T, objs ...runtime.Object) clustercache.ClusterCache 
 }
 
 func newFakeLivStateCache(t *testing.T, objs ...runtime.Object) LiveStateCache {
+	numaLogger := logger.New()
+	numaLogger.SetLevel(4)
 	cluster := newCluster(t, objs...)
-	customMetrics := metrics.RegisterCustomMetrics()
+	customMetrics := metrics.RegisterCustomMetrics(numaLogger)
 	clusterCache := newLiveStateCache(cluster, customMetrics)
 	cluster.Invalidate(clustercache.SetPopulateResourceInfoHandler(clusterCache.PopulateResourceInfo))
 	return clusterCache

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -7,10 +7,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
+	"github.com/numaproj/numaplane/internal/util/logger"
 	apiv1 "github.com/numaproj/numaplane/pkg/apis/numaplane/v1alpha1"
 )
 
 type CustomMetrics struct {
+	// NumaLogger is used to log messages related to metrics.
+	NumaLogger *logger.NumaLogger
 	// PipelinesRolloutHealth is the gauge for the health of pipelines.
 	PipelinesRolloutHealth *prometheus.GaugeVec
 	// PipelineRolloutsRunning is the gauge for the number of running PipelineRollouts.
@@ -319,7 +322,7 @@ var (
 )
 
 // RegisterCustomMetrics registers the custom metrics to the existing global prometheus registry for pipelines, ISB service and numaflow controller
-func RegisterCustomMetrics() *CustomMetrics {
+func RegisterCustomMetrics(numaLogger *logger.NumaLogger) *CustomMetrics {
 	metrics.Registry.MustRegister(
 		pipelinesRolloutHealth, pipelineRolloutsRunning, pipelineROSyncs, pipelineROSyncErrors, pipelineRolloutQueueLength,
 		isbServicesRolloutHealth, isbServiceRolloutsRunning, isbServiceROSyncs, isbServiceROSyncErrors,
@@ -330,6 +333,7 @@ func RegisterCustomMetrics() *CustomMetrics {
 		kubeResourceCache, clusterCacheError, pipelinePausedSeconds, pipelinePausingSeconds, isbServicePausedSeconds)
 
 	return &CustomMetrics{
+		NumaLogger:                                numaLogger,
 		PipelinesRolloutHealth:                    pipelinesRolloutHealth,
 		PipelineRolloutsRunning:                   pipelineRolloutsRunning,
 		PipelineROCounterMap:                      make(map[string]map[string]struct{}),
@@ -448,6 +452,7 @@ func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase s
 
 // DeletePipelineRolloutHealth deletes the pipeline rollout health metric
 func (m *CustomMetrics) DeletePipelineRolloutHealth(namespace, name string) {
+	m.NumaLogger.Infof("Deleting pipeline rollout health for %s/%s", namespace, name)
 	for _, phase := range phases {
 		m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase)
 	}
@@ -466,6 +471,7 @@ func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhas
 
 // DeleteISBServicesRolloutHealth deletes the ISB service rollout health metric
 func (m *CustomMetrics) DeleteISBServicesRolloutHealth(namespace, name string) {
+	m.NumaLogger.Infof("Deleting pipeline rollout health for %s/%s", namespace, name)
 	for _, phase := range phases {
 		m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase)
 	}
@@ -484,6 +490,7 @@ func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPha
 
 // DeleteMonoVerticesRolloutHealth deletes the monovertex rollout health metric
 func (m *CustomMetrics) DeleteMonoVerticesRolloutHealth(namespace, name string) {
+	m.NumaLogger.Infof("Deleting monovertex rollout health for %s/%s", namespace, name)
 	for _, phase := range phases {
 		m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase)
 	}
@@ -502,6 +509,7 @@ func (m *CustomMetrics) SetNumaflowControllerRolloutsHealth(namespace, name, cur
 
 // DeleteNumaflowControllerRolloutsHealth deletes the numaflow controller rollout health metric
 func (m *CustomMetrics) DeleteNumaflowControllerRolloutsHealth(namespace, name string) {
+	m.NumaLogger.Infof("Deleting numaflow controller rollout health for %s/%s", namespace, name)
 	for _, phase := range phases {
 		m.NumaflowControllerRolloutsHealth.DeleteLabelValues(namespace, name, phase)
 	}
@@ -520,6 +528,7 @@ func (m *CustomMetrics) SetNumaflowControllersHealth(namespace, name, currentPha
 
 // DeleteNumaflowControllersHealth deletes the numaflow controller health metric
 func (m *CustomMetrics) DeleteNumaflowControllersHealth(namespace, name string) {
+	m.NumaLogger.Infof("Deleting numaflow controller health for %s/%s", namespace, name)
 	for _, phase := range phases {
 		m.NumaflowControllersHealth.DeleteLabelValues(namespace, name, phase)
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Modifications

- Added the info log while deleting the metrics durning deletion of  pipelineRO, monovertexRO, .....

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification
- Verified in local k8s cluster

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
