### PR TITLE
remove analysistemplate reference from pipelinerollout sample

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
@@ -9,9 +9,9 @@ spec:
       assessmentSchedule: "120,60,10"
     analysis:
       args:
-      templates:
-      - templateName: pipeline-template
-        clusterScope: false
+      #templates:
+      #- templateName: pipeline-template
+      #  clusterScope: false
   riders:
     - perVertex: true
       definition:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

Had an accidental commit to this sample in a previous PR. I don't want to reference an AnalysisTemplate that somebody probably won't have that's using it.


### Verification

n/a

### Backward incompatibilities

n/a
