### PR TITLE
fix: don't do progressive on metadata change anymore

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_isbservicerollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_isbservicerollout.yaml
@@ -8,10 +8,6 @@ spec:
     progressive:
       assessmentSchedule: "0,60,10"
   interStepBufferService:
-    #uncomment for Progressive rollout to set Numaflow Controller instance:
-    #metadata:
-    #  annotations:
-    #    numaflow.numaproj.io/instance: "0"
     spec:
       # Example from https://github.com/numaproj/numaflow/blob/main/examples/0-isbsvc-jetstream.yaml
       jetstream:

--- a/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_monovertexrollout.yaml
@@ -26,10 +26,6 @@ spec:
           # todo: add more fields here...
 
   monoVertex:
-    #uncomment for Progressive rollout to set Numaflow Controller instance:
-    #metadata:
-    #  annotations:
-    #    numaflow.numaproj.io/instance: "0"
     spec:
       scale:
         min: 2

--- a/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
@@ -26,10 +26,6 @@ spec:
             name: '{{.pipeline-name}}-{{.vertex-name}}'
           # todo: add more fields here...
   pipeline:
-    #uncomment for Progressive rollout to set Numaflow Controller instance:
-    #metadata:
-    #  annotations:
-    #    numaflow.numaproj.io/instance: "0"
     spec:
       interStepBufferServiceName: my-isbsvc
       vertices:

--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -127,13 +127,8 @@ func (r *ISBServiceRolloutReconciler) CheckForDifferences(ctx context.Context, f
 	specsEqual := util.CompareStructNumTypeAgnostic(from.Object["spec"], to.Object["spec"])
 	numaLogger.Debugf("specsEqual: %t, from=%v, to=%v\n",
 		specsEqual, from, to)
-	// compare Labels and Annotations, excluding any that Numaplane itself applies
-	labelsEqual := util.CompareMapsWithExceptions(from.GetLabels(), to.GetLabels(), common.KeyNumaplanePrefix)
-	numaLogger.Debugf("labelsEqual (excluding Numaplane labels): %t, from Labels=%v, to Labels=%v", labelsEqual, from.GetLabels(), to.GetLabels())
-	annotationsEqual := util.CompareMapsWithExceptions(from.GetAnnotations(), to.GetAnnotations(), common.KeyNumaplanePrefix)
-	numaLogger.Debugf("annotationsEqual (excluding Numaplane annotations): %t, from Annotations=%v, to Annotations=%v", annotationsEqual, from.GetAnnotations(), to.GetAnnotations())
 
-	return !specsEqual || !labelsEqual || !annotationsEqual, nil
+	return !specsEqual, nil
 }
 
 func (r *ISBServiceRolloutReconciler) ProcessPromotedChildPreUpgrade(

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -146,13 +146,8 @@ func (r *MonoVertexRolloutReconciler) CheckForDifferences(ctx context.Context, f
 	specsEqual := util.CompareStructNumTypeAgnostic(fromNew, toNew)
 	numaLogger.Debugf("specsEqual: %t, fromNew=%v, toNew=%v\n",
 		specsEqual, fromNew, toNew)
-	// compare Labels and Annotations, excluding any that Numaplane itself applies
-	labelsEqual := util.CompareMapsWithExceptions(from.GetLabels(), to.GetLabels(), common.KeyNumaplanePrefix)
-	numaLogger.Debugf("labelsEqual (excluding Numaplane labels): %t, from Labels=%v, to Labels=%v", labelsEqual, from.GetLabels(), to.GetLabels())
-	annotationsEqual := util.CompareMapsWithExceptions(from.GetAnnotations(), to.GetAnnotations(), common.KeyNumaplanePrefix)
-	numaLogger.Debugf("annotationsEqual (excluding Numaplane annotations): %t, from Annotations=%v, to Annotations=%v", annotationsEqual, from.GetAnnotations(), to.GetAnnotations())
 
-	return !specsEqual || !labelsEqual || !annotationsEqual, nil
+	return !specsEqual, nil
 
 }
 

--- a/internal/controller/pipelinerollout/pipelinerollout_progressive.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_progressive.go
@@ -177,13 +177,8 @@ func (r *PipelineRolloutReconciler) CheckForDifferences(ctx context.Context, fro
 	specsEqual := util.CompareStructNumTypeAgnostic(fromCopy.Object["spec"], toCopy.Object["spec"])
 	numaLogger.Debugf("specsEqual: %t, from=%v, to=%v\n",
 		specsEqual, fromCopy.Object["spec"], toCopy.Object["spec"])
-	// compare Labels and Annotations, excluding any that Numaplane itself applies
-	labelsEqual := util.CompareMapsWithExceptions(from.GetLabels(), to.GetLabels(), common.KeyNumaplanePrefix)
-	numaLogger.Debugf("labelsEqual (excluding Numaplane labels): %t, from Labels=%v, to Labels=%v", labelsEqual, from.GetLabels(), to.GetLabels())
-	annotationsEqual := util.CompareMapsWithExceptions(from.GetAnnotations(), to.GetAnnotations(), common.KeyNumaplanePrefix)
-	numaLogger.Debugf("annotationsEqual (excluding Numaplane annotations): %t, from Annotations=%v, to Annotations=%v", annotationsEqual, from.GetAnnotations(), to.GetAnnotations())
 
-	return !specsEqual || !labelsEqual || !annotationsEqual, nil
+	return !specsEqual, nil
 }
 
 /*


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

Back when we showed how we could do Progressive upgrade when the `numaflow.numaproj.io/instance` Annotation changed, we made it so that an Annotation or a Label could cause a Progressive upgrade. 

Unfortunately, the code that came out of this which determines if there's a difference between one spec and another is looking for labels and annotations. This caused us to consider the annotation that Numaflow adds for "pause-timestamp" is a key difference, which it's not. If you set desiredPhase=Paused in the Rollout and then make a progressive change, this check actually results in getting into a cycle of repeatedly trying to create and then delete new pipelines. 

### Verification

Once I removed this code, I tried creating a PipelineRollout with desiredPhase=Paused. Then I updated the pipeline topology and observed that it did the right thing: created one new "upgrading" Pipeline, assessed it as successfully, and deleted the original Pipeline.

### Backward incompatibilities

n/a
