### PR TITLE
feat: update RBAC/configMap to allow HPA as Rider kind

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -2478,6 +2478,12 @@ rules:
   - verticalpodautoscalers
   verbs:
   - '*'
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -2582,7 +2588,7 @@ data:
         - kind: InterstepBufferService
           schedule: "0,0,10"
       analysisRunTimeout: 1200
-    permittedRiders: "group=autoscaling.k8s.io,kind=VerticalPodAutoscaler"
+    permittedRiders: "group=autoscaling.k8s.io,kind=VerticalPodAutoscaler;group=autoscaling,kind=HorizontalPodAutoscaler"
 kind: ConfigMap
 metadata:
   name: numaplane-controller-config

--- a/config/manager/controller-config.yaml
+++ b/config/manager/controller-config.yaml
@@ -19,4 +19,4 @@ data:
         - kind: InterstepBufferService
           schedule: "0,0,10"
       analysisRunTimeout: 1200
-    permittedRiders: "group=autoscaling.k8s.io,kind=VerticalPodAutoscaler"
+    permittedRiders: "group=autoscaling.k8s.io,kind=VerticalPodAutoscaler;group=autoscaling,kind=HorizontalPodAutoscaler"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -76,3 +76,7 @@ rules:
     resources:
       - verticalpodautoscalers
     verbs: ["*"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["*"]

--- a/tests/manifests/default/config.yaml
+++ b/tests/manifests/default/config.yaml
@@ -15,4 +15,4 @@ progressive:
     - kind: InterstepBufferService
       schedule: "0,0,10"
   analysisRunTimeout: "1200"
-permittedRiders: "group=autoscaling.k8s.io,kind=VerticalPodAutoscaler;group=,kind=ConfigMap"
+permittedRiders: "group=autoscaling.k8s.io,kind=VerticalPodAutoscaler;group=,kind=ConfigMap;group=autoscaling,kind=HorizontalPodAutoscaler"

--- a/tests/manifests/e2e/special-cases/no-strategy/controller-config.yaml
+++ b/tests/manifests/e2e/special-cases/no-strategy/controller-config.yaml
@@ -19,4 +19,4 @@ data:
         - kind: InterstepBufferService
           schedule: "0,0,10"
       analysisRunTimeout: "1200"
-    permittedRiders: "group=autoscaling.k8s.io,kind=VerticalPodAutoscaler;group=,kind=ConfigMap"
+    permittedRiders: "group=autoscaling.k8s.io,kind=VerticalPodAutoscaler;group=,kind=ConfigMap;group=autoscaling,kind=HorizontalPodAutoscaler"

--- a/tests/manifests/e2e/special-cases/pause-and-drain/controller-config.yaml
+++ b/tests/manifests/e2e/special-cases/pause-and-drain/controller-config.yaml
@@ -8,4 +8,4 @@ data:
     logLevel: DEBUG
     includedResources: "group=apps,kind=Deployment;group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
     defaultUpgradeStrategy: "pause-and-drain"
-    permittedRiders: "group=autoscaling.k8s.io,kind=VerticalPodAutoscaler;group=,kind=ConfigMap"
+    permittedRiders: "group=autoscaling.k8s.io,kind=VerticalPodAutoscaler;group=,kind=ConfigMap;group=autoscaling,kind=HorizontalPodAutoscaler"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->

Adds `HorizontalPodAutoscaler` as allowed Kind for Rider. Updates `numaplane-role` to include HPA to be able to create them.

### Verification

Tested locally with MonoVertexRollout spec below.

```
apiVersion: numaplane.numaproj.io/v1alpha1
kind: MonoVertexRollout
metadata:
  name: my-monovertex
  namespace: example-namespace
spec:
  # replicas: 1
  strategy:
    progressive:
      assessmentSchedule: "120,60,10"
    analysis:
      args:
      templates:
      - templateName: mvtx-acknowledged-messages
        clusterScope: false
  riders:
    - definition:    
        apiVersion: autoscaling/v2
        kind: HorizontalPodAutoscaler
        metadata:
          name: my-mvtx-hpa
        spec:
          minReplicas: 1
          maxReplicas: 3
          metrics:
          - type: Resource
            resource:
              name: cpu
              target:
                type: Utilization
                averageUtilization: 50
          scaleTargetRef:
            apiVersion: numaflow.numaproj.io/v1alpha1
            kind: MonoVertex
            name: '{{.monovertex-name}}'

  monoVertex:
    #uncomment for Progressive rollout to set Numaflow Controller instance:
    #metadata:
    #  annotations:
    #    numaflow.numaproj.io/instance: "0"
    spec:
      scale:
        min: 0
        max: 3
        lookbackSeconds: 60
      source:
        udsource:
          container:
            image: quay.io/numaio/numaflow-go/source-simple-source:stable
        transformer:
          container:
            image: quay.io/numaio/numaflow-rs/source-transformer-now:stable
      sink:
        udsink:
          container:
            # image: quay.io/numaio/numaflow-go/sink-log:stable
            image: quay.io/numaio/numaflow-java/simple-sink:stable
            #image: quay.io/numaio/numaflow-go/sink-log-failure:stable # use to fail the AnalysisRun
```

### Backward incompatibilities

If Numaplane is not updated on the cluster and user adds a MonoVertexRollout with an HPA Rider, the rollout will automatically fail since it is not an allowed Kind. Othewise existing rollouts will function the same.
