### PR TITLE
fix: Rename analysis template name for pipeline and monovertex

### DIFF
--- a/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
+++ b/tests/e2e/progressive-analysis-monovertex-e2e/analysis_monovertex_test.go
@@ -32,10 +32,12 @@ import (
 )
 
 const (
-	monoVertexRolloutName   = "test-monovertex-analysis-rollout"
-	analysisTemplateNameOne = "test-monovertex-template-1"
-	analysisTemplateNameTwo = "test-monovertex-template-2"
-	analysisRunName         = "monovertex-" + monoVertexRolloutName
+	monoVertexRolloutName          = "test-monovertex-analysis-rollout"
+	analysisTemplateNameSuccessOne = "test-monovertex-template-success-1"
+	analysisTemplateNameSuccessTwo = "test-monovertex-template-success-2"
+	analysisTemplateNameFailureOne = "test-monovertex-template-failure-1"
+	analysisTemplateNameFailureTwo = "test-monovertex-template-failure-2"
+	analysisRunName                = "monovertex-" + monoVertexRolloutName
 )
 
 var (
@@ -47,7 +49,7 @@ var (
 	monoVertexScaleMinMaxJSONString = fmt.Sprintf("{\"max\":%d,\"min\":%d}", monoVertexScaleMax, monoVertexScaleMin)
 	monovertexSinkBadImage          = "quay.io/numaio/numaflow-go/sink-log-failure:stable"
 
-	defaultStrategy = apiv1.PipelineTypeRolloutStrategy{
+	defaultStrategyForSuccessCase = apiv1.PipelineTypeRolloutStrategy{
 		PipelineTypeProgressiveStrategy: apiv1.PipelineTypeProgressiveStrategy{
 			Progressive: apiv1.ProgressiveStrategy{
 				AssessmentSchedule: "60,180,30,10",
@@ -55,11 +57,31 @@ var (
 			Analysis: apiv1.Analysis{
 				Templates: []argov1alpha1.AnalysisTemplateRef{
 					{
-						TemplateName: analysisTemplateNameOne,
+						TemplateName: analysisTemplateNameSuccessOne,
 						ClusterScope: false,
 					},
 					{
-						TemplateName: analysisTemplateNameTwo,
+						TemplateName: analysisTemplateNameSuccessTwo,
+						ClusterScope: false,
+					},
+				},
+			},
+		},
+	}
+
+	defaultStrategyForFailureCase = apiv1.PipelineTypeRolloutStrategy{
+		PipelineTypeProgressiveStrategy: apiv1.PipelineTypeProgressiveStrategy{
+			Progressive: apiv1.ProgressiveStrategy{
+				AssessmentSchedule: "60,180,30,10",
+			},
+			Analysis: apiv1.Analysis{
+				Templates: []argov1alpha1.AnalysisTemplateRef{
+					{
+						TemplateName: analysisTemplateNameFailureOne,
+						ClusterScope: false,
+					},
+					{
+						TemplateName: analysisTemplateNameFailureTwo,
 						ClusterScope: false,
 					},
 				},
@@ -137,15 +159,15 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 	})
 
 	It("Should validate MonoVertex upgrade using Analysis template for Progressive strategy - Success case", func() {
-		CreateAnalysisTemplate(analysisTemplateNameOne, Namespace, initialAnalysisTemplateSpec)
+		CreateAnalysisTemplate(analysisTemplateNameSuccessOne, Namespace, initialAnalysisTemplateSpec)
 
 		// Update the initial AnalysisTemplateSpec to use a different metric name and success condition
 		updatedAnalysisTemplateSpec := initialAnalysisTemplateSpec.DeepCopy()
 		updatedAnalysisTemplateSpec.Metrics[0].Name = "mvtx-example-2"
 		updatedAnalysisTemplateSpec.Metrics[0].SuccessCondition = "len(result) > 0"
-		CreateAnalysisTemplate(analysisTemplateNameTwo, Namespace, *updatedAnalysisTemplateSpec)
+		CreateAnalysisTemplate(analysisTemplateNameSuccessTwo, Namespace, *updatedAnalysisTemplateSpec)
 
-		CreateInitialMonoVertexRollout(monoVertexRolloutName, initialMonoVertexSpec, &defaultStrategy)
+		CreateInitialMonoVertexRollout(monoVertexRolloutName, initialMonoVertexSpec, &defaultStrategyForSuccessCase)
 
 		updatedMonoVertexSpec := UpdateMonoVertexRolloutForSuccess(monoVertexRolloutName, validUDTransformerImage, initialMonoVertexSpec, udTransformer)
 		VerifyMonoVertexProgressiveSuccess(monoVertexRolloutName, monoVertexScaleMinMaxJSONString, monoVertexScaleTo, updatedMonoVertexSpec,
@@ -158,25 +180,25 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 		VerifyAnalysisRunStatus("mvtx-example-2", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseSuccessful)
 
 		DeleteMonoVertexRollout(monoVertexRolloutName)
-		DeleteAnalysisTemplate(analysisTemplateNameOne)
-		DeleteAnalysisTemplate(analysisTemplateNameTwo)
+		DeleteAnalysisTemplate(analysisTemplateNameSuccessOne)
+		DeleteAnalysisTemplate(analysisTemplateNameSuccessTwo)
 	})
 
 	It("Should validate MonoVertex upgrade using Analysis template for Progressive strategy - Failure case", func() {
-		CreateAnalysisTemplate(analysisTemplateNameOne, Namespace, initialAnalysisTemplateSpec)
+		CreateAnalysisTemplate(analysisTemplateNameFailureOne, Namespace, initialAnalysisTemplateSpec)
 		// Update a fake query to cause a success status
 		updatedAnalysisTemplate := initialAnalysisTemplateSpec.DeepCopy()
 		updatedAnalysisTemplate.Metrics[0].Name = "mvtx-example-2"
 		updatedAnalysisTemplate.Metrics[0].SuccessCondition = "true"
 		updatedAnalysisTemplate.Metrics[0].Provider.Prometheus.Query = "vector(1)"
 
-		CreateAnalysisTemplate(analysisTemplateNameTwo, Namespace, *updatedAnalysisTemplate)
+		CreateAnalysisTemplate(analysisTemplateNameFailureTwo, Namespace, *updatedAnalysisTemplate)
 
 		// Update the initial MonoVertexSpec to use a bad image for the sink
 		updatedInitialMonoVertexSpec := initialMonoVertexSpec.DeepCopy()
 		updatedInitialMonoVertexSpec.Sink.AbstractSink.Blackhole = nil
 		updatedInitialMonoVertexSpec.Sink.AbstractSink.UDSink = &numaflowv1.UDSink{Container: &numaflowv1.Container{Image: monovertexSinkBadImage}}
-		CreateInitialMonoVertexRollout(monoVertexRolloutName, *updatedInitialMonoVertexSpec, &defaultStrategy)
+		CreateInitialMonoVertexRollout(monoVertexRolloutName, *updatedInitialMonoVertexSpec, &defaultStrategyForFailureCase)
 
 		updatedMonoVertexSpec := UpdateMonoVertexRolloutForSuccess(monoVertexRolloutName, validUDTransformerImage, *updatedInitialMonoVertexSpec, udTransformer)
 		VerifyMonoVertexProgressiveFailure(monoVertexRolloutName, monoVertexScaleMinMaxJSONString, updatedMonoVertexSpec, monoVertexScaleTo, false)
@@ -186,8 +208,8 @@ var _ = Describe("Progressive MonoVertex E2E", Serial, func() {
 		VerifyAnalysisRunStatus("mvtx-example-2", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseSuccessful)
 
 		DeleteMonoVertexRollout(monoVertexRolloutName)
-		DeleteAnalysisTemplate(analysisTemplateNameOne)
-		DeleteAnalysisTemplate(analysisTemplateNameTwo)
+		DeleteAnalysisTemplate(analysisTemplateNameFailureOne)
+		DeleteAnalysisTemplate(analysisTemplateNameFailureTwo)
 	})
 
 	It("Should delete all remaining rollout objects", func() {

--- a/tests/e2e/progressive-analysis-pipeline-e2e/analysis_pipeline_test.go
+++ b/tests/e2e/progressive-analysis-pipeline-e2e/analysis_pipeline_test.go
@@ -35,17 +35,16 @@ import (
 )
 
 const (
-	pipelineRolloutName     = "test-pipeline-rollout"
-	isbServiceRolloutName   = "test-isbservice-rollout"
-	initialJetstreamVersion = "2.10.17"
-	invalidJetstreamVersion = "0.0.0"
-	validJetstreamVersion   = "2.10.11"
-	analysisTemplateName    = "test-pipeline-template"
-	analysisRunName         = "pipeline-" + pipelineRolloutName
+	pipelineRolloutName         = "test-pipeline-rollout"
+	isbServiceRolloutName       = "test-isbservice-rollout"
+	initialJetstreamVersion     = "2.10.17"
+	analysisTemplateNameSuccess = "test-pipeline-template-success"
+	analysisTemplateNameFailure = "test-pipeline-template-failure"
+	analysisRunName             = "pipeline-" + pipelineRolloutName
 )
 
 var (
-	defaultStrategy = apiv1.PipelineStrategy{
+	defaultStrategyForSuccessCase = apiv1.PipelineStrategy{
 		PipelineTypeRolloutStrategy: apiv1.PipelineTypeRolloutStrategy{
 			PipelineTypeProgressiveStrategy: apiv1.PipelineTypeProgressiveStrategy{
 				Progressive: apiv1.ProgressiveStrategy{
@@ -54,7 +53,25 @@ var (
 				Analysis: apiv1.Analysis{
 					Templates: []argov1alpha1.AnalysisTemplateRef{
 						{
-							TemplateName: analysisTemplateName,
+							TemplateName: analysisTemplateNameSuccess,
+							ClusterScope: false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	defaultStrategyForFailureCase = apiv1.PipelineStrategy{
+		PipelineTypeRolloutStrategy: apiv1.PipelineTypeRolloutStrategy{
+			PipelineTypeProgressiveStrategy: apiv1.PipelineTypeProgressiveStrategy{
+				Progressive: apiv1.ProgressiveStrategy{
+					AssessmentSchedule: "60,300,30,10",
+				},
+				Analysis: apiv1.Analysis{
+					Templates: []argov1alpha1.AnalysisTemplateRef{
+						{
+							TemplateName: analysisTemplateNameFailure,
 							ClusterScope: false,
 						},
 					},
@@ -198,8 +215,8 @@ var _ = Describe("Progressive Pipeline and ISBService E2E", Serial, func() {
 	})
 
 	It("Should validate Pipeline and ISBService upgrade using Progressive strategy - Successful analysis", func() {
-		CreateAnalysisTemplate(analysisTemplateName, Namespace, initialAnalysisTemplateSpec)
-		CreateInitialPipelineRollout(pipelineRolloutName, GetInstanceName(isbServiceRolloutName, 0), initialPipelineSpec, defaultStrategy)
+		CreateAnalysisTemplate(analysisTemplateNameSuccess, Namespace, initialAnalysisTemplateSpec)
+		CreateInitialPipelineRollout(pipelineRolloutName, GetInstanceName(isbServiceRolloutName, 0), initialPipelineSpec, defaultStrategyForSuccessCase)
 
 		By("Updating the Pipeline Topology to cause a Progressive change - Successful case")
 		UpdatePipeline(pipelineRolloutName, updatedPipelineSpec)
@@ -209,14 +226,14 @@ var _ = Describe("Progressive Pipeline and ISBService E2E", Serial, func() {
 		VerifyPipelineDeletion(GetInstanceName(pipelineRolloutName, 0))
 
 		DeletePipelineRollout(pipelineRolloutName)
-		DeleteAnalysisTemplate(analysisTemplateName)
+		DeleteAnalysisTemplate(analysisTemplateNameSuccess)
 	})
 
 	It("Should validate Pipeline upgrade using Progressive strategy - failure analysis", func() {
 		updatedAnalysisTemplateSpec := initialAnalysisTemplateSpec.DeepCopy()
 		updatedAnalysisTemplateSpec.Metrics[0].SuccessCondition = "result[0] > 0"
-		CreateAnalysisTemplate(analysisTemplateName, Namespace, *updatedAnalysisTemplateSpec)
-		CreateInitialPipelineRollout(pipelineRolloutName, GetInstanceName(isbServiceRolloutName, 0), initialPipelineSpec, defaultStrategy)
+		CreateAnalysisTemplate(analysisTemplateNameFailure, Namespace, *updatedAnalysisTemplateSpec)
+		CreateInitialPipelineRollout(pipelineRolloutName, GetInstanceName(isbServiceRolloutName, 0), initialPipelineSpec, defaultStrategyForFailureCase)
 
 		By("Updating the Pipeline Topology to cause a Progressive change")
 		UpdatePipeline(pipelineRolloutName, updatedPipelineSpec)
@@ -225,7 +242,7 @@ var _ = Describe("Progressive Pipeline and ISBService E2E", Serial, func() {
 		VerifyAnalysisRunStatus("pipeline-example", GetInstanceName(analysisRunName, 1), argov1alpha1.AnalysisPhaseError)
 
 		DeletePipelineRollout(pipelineRolloutName)
-		DeleteAnalysisTemplate(analysisTemplateName)
+		DeleteAnalysisTemplate(analysisTemplateNameFailure)
 	})
 
 	It("Should delete all remaining rollout objects", func() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes https://github.com/numaproj/numaplane/issues/826

### Modifications
- Rename analysis template name for pipeline and monovertex, which will help to debug failure test cases easily 

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification
- Verified in local K8s cluster

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
