### PR TITLE
fix: log error for AnalysisRuns controller watch

### DIFF
--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -42,6 +42,7 @@ import (
 
 	argorolloutsv1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	numaflowv1 "github.com/numaproj/numaflow/pkg/apis/numaflow/v1alpha1"
+
 	"github.com/numaproj/numaplane/internal/common"
 	ctlrcommon "github.com/numaproj/numaplane/internal/controller/common"
 	"github.com/numaproj/numaplane/internal/controller/common/numaflowtypes"
@@ -440,7 +441,7 @@ func (r *MonoVertexRolloutReconciler) SetupWithManager(ctx context.Context, mgr 
 						if err != nil {
 							numaLogger.WithValues(
 								"AnalysisRun", fmt.Sprintf("%s:%s", analysisRun.Namespace, analysisRun.Name),
-								"MonoVertex", fmt.Sprintf("%s:%s", analysisRun.Namespace, analysisRunOwner.Name)).Warnf("Unable to get MonoVertex owner of AnalysisRun")
+								"MonoVertex", fmt.Sprintf("%s:%s", analysisRun.Namespace, analysisRunOwner.Name)).Warnf("Unable to get MonoVertex owner of AnalysisRun, err: %v", err)
 							continue
 						}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Part of: https://github.com/numaproj/numaplane/issues/798

### Modifications

- Add error log for AnalysisRuns controller watch

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
