### PR TITLE
chore: for now, if we're using an HPA, we automatically force promote

### DIFF
--- a/internal/controller/isbservicerollout/isbservicerollout_progressive.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_progressive.go
@@ -226,3 +226,8 @@ func (r *ISBServiceRolloutReconciler) ProcessUpgradingChildPreRecycle(
 ) error {
 	return nil
 }
+
+func (r *ISBServiceRolloutReconciler) ProgressiveUnsupported(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject) bool {
+
+	return false
+}

--- a/internal/controller/monovertexrollout/monovertexrollout_progressive.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_progressive.go
@@ -727,3 +727,19 @@ func scaleDefinitionToPatchString(scaleDefinition *apiv1.ScaleDefinition) string
 	}
 	return scaleValue
 }
+
+func (r *MonoVertexRolloutReconciler) ProgressiveUnsupported(ctx context.Context, rolloutObject progressive.ProgressiveRolloutObject) bool {
+	numaLogger := logger.FromContext(ctx)
+
+	// Temporary: we cannot support Progressive rollout assessment for HPA: See issue https://github.com/numaproj/numaplane/issues/868
+	monoVertexRollout := rolloutObject.(*apiv1.MonoVertexRollout)
+	for _, rider := range monoVertexRollout.Spec.Riders {
+		gvk := rider.Definition.Object.GetObjectKind().GroupVersionKind()
+		if gvk.Group == "autoscaling" && gvk.Kind == "HorizontalPodAutoscaler" {
+			numaLogger.Debug("MonoVertexRollout %s/%s contains HPA Rider: Full Progressive Rollout is unsupported")
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/controller/progressive/progressive.go
+++ b/internal/controller/progressive/progressive.go
@@ -87,6 +87,9 @@ type progressiveController interface {
 
 	// ProcessUpgradingChildPreRecycle performs operations on the upgrading child prior to its being recycled
 	ProcessUpgradingChildPreRecycle(ctx context.Context, rolloutObject ProgressiveRolloutObject, upgradingChildDef *unstructured.Unstructured, c client.Client) error
+
+	// ProgressiveUnsupported checks to see if Full Progressive Rollout (with assessment) is unsupported for this Rollout
+	ProgressiveUnsupported(ctx context.Context, rolloutObject ProgressiveRolloutObject) bool
 }
 
 // ProgressiveRolloutObject describes a Rollout instance that supports progressive upgrade
@@ -352,7 +355,7 @@ func processUpgradingChild(
 	}
 
 	// check for Force Promote set in Progressive strategy to force success logic OR if upgrading child has force-promote label
-	if rolloutObject.GetProgressiveStrategy().ForcePromote || forcePromote {
+	if rolloutObject.GetProgressiveStrategy().ForcePromote || forcePromote || controller.ProgressiveUnsupported(ctx, rolloutObject) {
 		childStatus.ForcedSuccess = true
 
 		done, err := declareSuccess(ctx, rolloutObject, controller, existingPromotedChildDef, existingUpgradingChildDef, childStatus, c)

--- a/pkg/client/clientset/versioned/typed/numaplane/v1alpha1/numaplane_client.go
+++ b/pkg/client/clientset/versioned/typed/numaplane/v1alpha1/numaplane_client.go
@@ -34,7 +34,7 @@ type NumaplaneV1alpha1Interface interface {
 	PipelineRolloutsGetter
 }
 
-// NumaplaneV1alpha1Client is used to interact with features provided by the numaplane group.
+// NumaplaneV1alpha1Client is used to interact with features provided by the numaplane.numaproj.io group.
 type NumaplaneV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -51,7 +51,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=numaplane, Version=v1alpha1
+	// Group=numaplane.numaproj.io, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("isbservicerollouts"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Numaplane().V1alpha1().ISBServiceRollouts().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("monovertexrollouts"):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Modifications

<!-- TODO: Say what changes you made (including any design decisions) -->


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
