### PR TITLE
Metric deletion logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Numaplane is a control plane for installing, managing and running numaflow resou
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.
 
-
 ### To build Numaplane image and run it on your local cluster with latest manifests
 
 `make start`

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -454,7 +454,8 @@ func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase s
 func (m *CustomMetrics) DeletePipelineRolloutHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting pipeline rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase)
+		deleted := m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase)
+		m.NumaLogger.WithValues("phase", phase, "deleted", deleted).Debugf("Result of deletion of pipeline rollout health metrics for %s/%s", namespace, name)
 	}
 }
 
@@ -471,9 +472,10 @@ func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhas
 
 // DeleteISBServicesRolloutHealth deletes the ISB service rollout health metric
 func (m *CustomMetrics) DeleteISBServicesRolloutHealth(namespace, name string) {
-	m.NumaLogger.Infof("Deleting pipeline rollout health metrics for %s/%s", namespace, name)
+	m.NumaLogger.Infof("Deleting isbsvc rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase)
+		deleted := m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase)
+		m.NumaLogger.WithValues("phase", phase, "deleted", deleted).Debugf("Result of deletion of isbsvc rollout health metrics for %s/%s", namespace, name)
 	}
 }
 
@@ -492,7 +494,8 @@ func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPha
 func (m *CustomMetrics) DeleteMonoVerticesRolloutHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting monovertex rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase)
+		deleted := m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase)
+		m.NumaLogger.WithValues("phase", phase, "deleted", deleted).Debugf("Result of deletion of monovertex rollout health metrics for %s/%s", namespace, name)
 	}
 }
 
@@ -511,7 +514,8 @@ func (m *CustomMetrics) SetNumaflowControllerRolloutsHealth(namespace, name, cur
 func (m *CustomMetrics) DeleteNumaflowControllerRolloutsHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting numaflow controller rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		m.NumaflowControllerRolloutsHealth.DeleteLabelValues(namespace, name, phase)
+		deleted := m.NumaflowControllerRolloutsHealth.DeleteLabelValues(namespace, name, phase)
+		m.NumaLogger.WithValues("phase", phase, "deleted", deleted).Debugf("Result of deletion of numaflow controller rollout health metrics for %s/%s", namespace, name)
 	}
 }
 
@@ -530,6 +534,7 @@ func (m *CustomMetrics) SetNumaflowControllersHealth(namespace, name, currentPha
 func (m *CustomMetrics) DeleteNumaflowControllersHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting numaflow controller health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		m.NumaflowControllersHealth.DeleteLabelValues(namespace, name, phase)
+		deleted := m.NumaflowControllersHealth.DeleteLabelValues(namespace, name, phase)
+		m.NumaLogger.WithValues("phase", phase, "deleted", deleted).Debugf("Result of deletion of numaflow controller health metrics for %s/%s", namespace, name)
 	}
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

Add logging to better understand what's happening in the case that we're still seeing a metric in Wavefront despite a deletion of it. 

### Verification

This is what I observed when deleting the NumaflowControllerRollout:
```
{"level":"debug","phase":"Pending","deleted":true,"logger":"numaplane.controller-manager","caller":"metrics/metrics.go:518","ts":"2025-09-22T21:22:03.207345777Z","msg":"Result of deletion of numaflow controller rollout health metrics for example-namespace/numaflow-controller"}
{"level":"debug","phase":"Deployed","deleted":true,"logger":"numaplane.controller-manager","caller":"metrics/metrics.go:518","ts":"2025-09-22T21:22:03.207348277Z","msg":"Result of deletion of numaflow controller rollout health metrics for example-namespace/numaflow-controller"}
{"level":"debug","phase":"Failed","deleted":true,"logger":"numaplane.controller-manager","caller":"metrics/metrics.go:518","ts":"2025-09-22T21:22:03.207351068Z","msg":"Result of deletion of numaflow controller rollout health metrics for example-namespace/numaflow-controller"}
```

### Backward incompatibilities

n/a
