### PR TITLE
feat: Add metrics to track drain successes and incomplete drains

### DIFF
--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -118,7 +118,7 @@ var (
 	isbServiceLock sync.Mutex
 	monoVertexLock sync.Mutex
 
-	LabelValueDrainResult_PipelineFailed LabelValueDrainResult = "Failed"
+	LabelValueDrainResult_PipelineFailed LabelValueDrainResult = "PipelineFailed"
 	LabelValueDrainResult_NeverDrained   LabelValueDrainResult = "DrainIncomplete"
 	LabelValueDrainResult_StandardDrain  LabelValueDrainResult = "StandardDrain"
 	LabelValueDrainResult_ForceDrain     LabelValueDrainResult = "ForceDrain"

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -108,7 +108,7 @@ const (
 	LabelPauseType                 = "pause_type"
 	LabelPipelineRollout           = "pipelineRollout"
 	LabelDrainComplete             = "drainComplete"
-	LabelIncompleteReason          = "incompleteReason"
+	LabelDrainResult               = "drainResult"
 )
 
 var (
@@ -204,7 +204,7 @@ var (
 		Name:        "progressive_pipeline_drains",
 		Help:        "The total number of pipelines drained as part of Progressive Rollout recycling",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelPipelineRollout, LabelPipeline, LabelDrainComplete, LabelIncompleteReason})
+	}, []string{LabelNamespace, LabelPipelineRollout, LabelPipeline, LabelDrainComplete, LabelDrainResult})
 
 	// isbServiceRolloutsRunning is the gauge for the number of running ISBServiceRollouts.
 	isbServiceRolloutsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #880 

### Modifications

Adding a new Counter metric `PipelineDrains` to keep track of pipelines which did and did not successfully drain fully (i.e. `drainedOnPause==true`).

My main goals were:
1. Be able to alert on a pipeline drain failure (i.e. if the total count of `PipelineDrains{"drainComplete"="false"}` increases).
2. Be able to know immediately which pipeline it was that failed.


### Verification

I ran the CI test and saw this when port forwarding the numaplane port 8080:

```
# HELP progressive_pipeline_drains The total number of pipelines drained as part of Progressive Rollout recycling
# TYPE progressive_pipeline_drains counter
progressive_pipeline_drains{drainComplete="true",incompleteReason="ForceDrain",intuit_alert="true",namespace="numaplane-system",pipeline="test-pipeline-rollout-1",pipelineRollout="test-pipeline-rollout"} 1
progressive_pipeline_drains{drainComplete="true",incompleteReason="ForceDrain",intuit_alert="true",namespace="numaplane-system",pipeline="test-pipeline-rollout-2",pipelineRollout="test-pipeline-rollout"} 1
progressive_pipeline_drains{drainComplete="true",incompleteReason="ForceDrain",intuit_alert="true",namespace="numaplane-system",pipeline="test-pipeline-rollout-3",pipelineRollout="test-pipeline-rollout"} 1
progressive_pipeline_drains{drainComplete="true",incompleteReason="ForceDrain",intuit_alert="true",namespace="numaplane-system",pipeline="test-pipeline-rollout-4",pipelineRollout="test-pipeline-rollout"} 1
progressive_pipeline_drains{drainComplete="true",incompleteReason="StandardDrain",intuit_alert="true",namespace="numaplane-system",pipeline="test-pipeline-rollout-0",pipelineRollout="test-pipeline-rollout"} 1
```

### Backward incompatibilities

N/A
