### PR TITLE
feat: if we aren't doing full progressive then we don't need to do force draining

### DIFF
--- a/internal/controller/pipelinerollout/pipelinerollout_recycle.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_recycle.go
@@ -78,9 +78,9 @@ func (r *PipelineRolloutReconciler) Recycle(
 	numaLogger.WithValues("reason", upgradeStateReason).Debug("Recycling Pipeline")
 
 	if requiresPause {
-		if (pipelineRollout.Spec.Strategy != nil && pipelineRollout.Spec.Strategy.Progressive.ForcePromote) || r.ProgressiveUnsupported(ctx, pipelineRollout) {
-			// these are cases in which we don't care about data loss, so we can just delete the pipeline without draining
-			numaLogger.Debug("PipelineRollout strategy indicates no concern for data loss so Pipeline will be deleted without draining")
+		if pipelineRollout.Spec.Strategy != nil && pipelineRollout.Spec.Strategy.Progressive.ForcePromote {
+			// this is a case in which user likely doesn't care about data loss (and also we have no idea if the "promoted" pipeline is any good), so we can just delete the pipeline without draining
+			numaLogger.Debug("PipelineRollout strategy implies no concern for data loss so Pipeline will be deleted without draining")
 			requiresPause = false
 		}
 	}


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

If the user's strategy is set to skip the assessment of Progressive rollout, then we really have no idea whether a "promoted" pipeline is good for force draining. The fact that they have this strategy also indicates that they don't care about data loss. 


### Verification

Verified that with ForcePromote strategy set to true, we skip draining and just delete the resource.

### Backward incompatibilities

N/A
