### PR TITLE
fix: remove log objects due to potential for dropped log lines; correctly handle error

### DIFF
--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -131,9 +131,6 @@ type ProgressiveConfig struct {
 
 	// timeout duration which AnalysisRuns cannot continue to run after
 	AnalysisRunTimeout string `json:"analysisRunTimeout" mapstructure:"analysisRunTimeout"`
-
-	// when set to true, adds the rollout, promoted, and upgrading objects to all the log messages during progressive upgrade
-	LogObjects bool `json:"logObjects" mapstructure:"logObjects"`
 }
 
 // DefaultAssessmentSchedule defines a default schedule for each Kind


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

1. Error was not being properly returned from caller - fixed
2. The `logObjects` configuration setting in the ConfigMap was logging the entire rollout object and the entire promoted child, which was causing many log lines to be so big that they were getting dropped. I considered whether to keep something getting logged, but I don't see anything that we really need. 


### Verification

CI

### Backward incompatibilities

N/A
