### PR TITLE
chore: default upgrade strategy should be progressive

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -2645,7 +2645,7 @@ data:
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
-    defaultUpgradeStrategy: "pause-and-drain"
+    defaultUpgradeStrategy: "progressive"
     progressive:
       defaultAssessmentSchedule:
         - kind: Pipeline

--- a/config/manager/controller-config.yaml
+++ b/config/manager/controller-config.yaml
@@ -9,7 +9,7 @@ data:
     includedResources: "group=apps,kind=Deployment;\
     group=,kind=ConfigMap;group=,kind=ServiceAccount;group=,kind=Secret;group=,kind=Service;\
     group=rbac.authorization.k8s.io,kind=RoleBinding;group=rbac.authorization.k8s.io,kind=Role"
-    defaultUpgradeStrategy: "pause-and-drain"
+    defaultUpgradeStrategy: "progressive"
     progressive:
       defaultAssessmentSchedule:
         - kind: Pipeline


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

It doesn't really matter but I think the default upgrade strategy should be "progressive".


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
