### PR TITLE
chore: constrain number of e2e jobs that can run at the same time, to create fairness with other PRs 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,6 +113,7 @@ jobs:
     # We already have a timeout in "go test" call: we don't also need this
     #timeout-minutes: 35 # If we start getting error in CI as "The operation was canceled", we need to increase this value.
     strategy:
+      max-parallel: 15
       fail-fast: false
       matrix:
         strategy: ["pause-and-drain", "progressive", "no-strategy"]


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Modifications

Background: Currently we are not paying for Github, which means that all PRs in all repos within the **numaproj** org are restricted to 20 workers in the CI. 

This change makes it so that if a PR is running either within numaplane repo, or within the same Github org (e.g. numaflow repo), we can create fairness by restricting the number of e2e jobs that run in parallel and enable another PR to run its CI at that time. Note that **numaflow** repo will set this same value to 15.

Note: There is a trade off that even when no other PR is running, this restriction will be in place - only 15 e2e jobs will be able to run simultaneously, which will create a longer end-to-end time. Therefore, the ideal solution will be to upgrade to a paid version of Github.


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? (not a showstopper but something to prepare for) -->
