### PR TITLE
feat: Incorporate conditions as point tags into Health Metrics

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -2868,6 +2868,10 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -196,7 +196,13 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 		// Set the health of the ISBServiceRollout only if it is not being deleted.
 		if isbServiceRollout.DeletionTimestamp.IsZero() {
 			numaLogger.Debugf("Reconcilation finished for ISBServiceRollout %s/%s, setting phase metrics: %s", isbServiceRollout.Namespace, isbServiceRollout.Name, isbServiceRollout.Status.Phase)
-			r.customMetrics.SetISBServicesRolloutHealth(isbServiceRollout.Namespace, isbServiceRollout.Name, string(isbServiceRollout.Status.Phase))
+			r.customMetrics.SetISBServicesRolloutHealth(
+				isbServiceRollout.Namespace,
+				isbServiceRollout.Name,
+				string(isbServiceRollout.Status.Phase),
+				!apiv1.GetConditionValue(isbServiceRollout.Status.Conditions, apiv1.ConditionChildResourceHealthy),
+				!apiv1.GetConditionValue(isbServiceRollout.Status.Conditions, apiv1.ConditionProgressiveUpgradeSucceeded),
+			)
 		}
 	}()
 

--- a/internal/controller/isbservicerollout/isbservicerollout_controller.go
+++ b/internal/controller/isbservicerollout/isbservicerollout_controller.go
@@ -196,12 +196,14 @@ func (r *ISBServiceRolloutReconciler) reconcile(ctx context.Context, isbServiceR
 		// Set the health of the ISBServiceRollout only if it is not being deleted.
 		if isbServiceRollout.DeletionTimestamp.IsZero() {
 			numaLogger.Debugf("Reconcilation finished for ISBServiceRollout %s/%s, setting phase metrics: %s", isbServiceRollout.Namespace, isbServiceRollout.Name, isbServiceRollout.Status.Phase)
+			promotedChildHealth := apiv1.GetConditionValue(isbServiceRollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+			progressiveSuccess := apiv1.GetConditionValue(isbServiceRollout.Status.Conditions, apiv1.ConditionProgressiveUpgradeSucceeded)
 			r.customMetrics.SetISBServicesRolloutHealth(
 				isbServiceRollout.Namespace,
 				isbServiceRollout.Name,
 				string(isbServiceRollout.Status.Phase),
-				!apiv1.GetConditionValue(isbServiceRollout.Status.Conditions, apiv1.ConditionChildResourceHealthy),
-				!apiv1.GetConditionValue(isbServiceRollout.Status.Conditions, apiv1.ConditionProgressiveUpgradeSucceeded),
+				promotedChildHealth != nil && !*promotedChildHealth,
+				progressiveSuccess != nil && !*progressiveSuccess,
 			)
 		}
 	}()

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -194,12 +194,14 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 		// Set the health of the monoVertexRollout only if it is not being deleted.
 		if monoVertexRollout.DeletionTimestamp.IsZero() {
 			numaLogger.Debugf("Reconcilation finished for monoVertexRollout %s/%s, setting phase metrics: %s", monoVertexRollout.Namespace, monoVertexRollout.Name, monoVertexRollout.Status.Phase)
+			promotedChildHealth := apiv1.GetConditionValue(monoVertexRollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+			progressiveSuccess := apiv1.GetConditionValue(monoVertexRollout.Status.Conditions, apiv1.ConditionProgressiveUpgradeSucceeded)
 			r.customMetrics.SetMonoVerticesRolloutHealth(
 				monoVertexRollout.Namespace,
 				monoVertexRollout.Name,
 				string(monoVertexRollout.Status.Phase),
-				!apiv1.GetConditionValue(monoVertexRollout.Status.Conditions, apiv1.ConditionChildResourceHealthy),
-				!apiv1.GetConditionValue(monoVertexRollout.Status.Conditions, apiv1.ConditionProgressiveUpgradeSucceeded),
+				promotedChildHealth != nil && !*promotedChildHealth,
+				progressiveSuccess != nil && !*progressiveSuccess,
 			)
 		}
 	}()

--- a/internal/controller/monovertexrollout/monovertexrollout_controller.go
+++ b/internal/controller/monovertexrollout/monovertexrollout_controller.go
@@ -194,7 +194,13 @@ func (r *MonoVertexRolloutReconciler) reconcile(ctx context.Context, monoVertexR
 		// Set the health of the monoVertexRollout only if it is not being deleted.
 		if monoVertexRollout.DeletionTimestamp.IsZero() {
 			numaLogger.Debugf("Reconcilation finished for monoVertexRollout %s/%s, setting phase metrics: %s", monoVertexRollout.Namespace, monoVertexRollout.Name, monoVertexRollout.Status.Phase)
-			r.customMetrics.SetMonoVerticesRolloutHealth(monoVertexRollout.Namespace, monoVertexRollout.Name, string(monoVertexRollout.Status.Phase))
+			r.customMetrics.SetMonoVerticesRolloutHealth(
+				monoVertexRollout.Namespace,
+				monoVertexRollout.Name,
+				string(monoVertexRollout.Status.Phase),
+				!apiv1.GetConditionValue(monoVertexRollout.Status.Conditions, apiv1.ConditionChildResourceHealthy),
+				!apiv1.GetConditionValue(monoVertexRollout.Status.Conditions, apiv1.ConditionProgressiveUpgradeSucceeded),
+			)
 		}
 	}()
 

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -223,11 +223,12 @@ func (r *NumaflowControllerReconciler) reconcile(
 		// Set the health of the controller only if it is not being deleted.
 		if controller.DeletionTimestamp.IsZero() {
 			numaLogger.Debugf("Reconcilation finished for controller %s/%s, setting phase metrics: %s", controller.Namespace, controller.Name, controller.Status.Phase)
+			promotedChildHealth := apiv1.GetConditionValue(controller.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 			r.customMetrics.SetNumaflowControllersHealth(
 				controller.Namespace,
 				controller.Name,
 				string(controller.Status.Phase),
-				apiv1.GetConditionValue(controller.Status.Conditions, apiv1.ConditionChildResourceHealthy),
+				promotedChildHealth != nil && *promotedChildHealth,
 			)
 		}
 	}()

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -223,7 +223,12 @@ func (r *NumaflowControllerReconciler) reconcile(
 		// Set the health of the controller only if it is not being deleted.
 		if controller.DeletionTimestamp.IsZero() {
 			numaLogger.Debugf("Reconcilation finished for controller %s/%s, setting phase metrics: %s", controller.Namespace, controller.Name, controller.Status.Phase)
-			r.customMetrics.SetNumaflowControllersHealth(controller.Namespace, controller.Name, string(controller.Status.Phase))
+			r.customMetrics.SetNumaflowControllersHealth(
+				controller.Namespace,
+				controller.Name,
+				string(controller.Status.Phase),
+				apiv1.GetConditionValue(controller.Status.Conditions, apiv1.ConditionChildResourceHealthy),
+			)
 		}
 	}()
 

--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -223,12 +223,12 @@ func (r *NumaflowControllerReconciler) reconcile(
 		// Set the health of the controller only if it is not being deleted.
 		if controller.DeletionTimestamp.IsZero() {
 			numaLogger.Debugf("Reconcilation finished for controller %s/%s, setting phase metrics: %s", controller.Namespace, controller.Name, controller.Status.Phase)
-			promotedChildHealth := apiv1.GetConditionValue(controller.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+			childHealth := apiv1.GetConditionValue(controller.Status.Conditions, apiv1.ConditionChildResourceHealthy)
 			r.customMetrics.SetNumaflowControllersHealth(
 				controller.Namespace,
 				controller.Name,
 				string(controller.Status.Phase),
-				promotedChildHealth != nil && *promotedChildHealth,
+				childHealth != nil && *childHealth,
 			)
 		}
 	}()

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -352,7 +352,13 @@ func (r *PipelineRolloutReconciler) reconcile(
 		// Set the health of the pipelineRollout only if it is not being deleted.
 		if pipelineRollout.DeletionTimestamp.IsZero() {
 			numaLogger.Debugf("Reconcilation finished for pipelineRollout %s/%s, setting phase metrics: %s", pipelineRollout.Namespace, pipelineRollout.Name, pipelineRollout.Status.Phase)
-			r.customMetrics.SetPipelineRolloutHealth(pipelineRollout.Namespace, pipelineRollout.Name, string(pipelineRollout.Status.Phase))
+			r.customMetrics.SetPipelineRolloutHealth(
+				pipelineRollout.Namespace,
+				pipelineRollout.Name,
+				string(pipelineRollout.Status.Phase),
+				!apiv1.GetConditionValue(pipelineRollout.Status.Conditions, apiv1.ConditionChildResourceHealthy),
+				!apiv1.GetConditionValue(pipelineRollout.Status.Conditions, apiv1.ConditionProgressiveUpgradeSucceeded),
+			)
 		}
 	}()
 

--- a/internal/controller/pipelinerollout/pipelinerollout_controller.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_controller.go
@@ -352,12 +352,14 @@ func (r *PipelineRolloutReconciler) reconcile(
 		// Set the health of the pipelineRollout only if it is not being deleted.
 		if pipelineRollout.DeletionTimestamp.IsZero() {
 			numaLogger.Debugf("Reconcilation finished for pipelineRollout %s/%s, setting phase metrics: %s", pipelineRollout.Namespace, pipelineRollout.Name, pipelineRollout.Status.Phase)
+			promotedChildHealth := apiv1.GetConditionValue(pipelineRollout.Status.Conditions, apiv1.ConditionChildResourceHealthy)
+			progressiveSuccess := apiv1.GetConditionValue(pipelineRollout.Status.Conditions, apiv1.ConditionProgressiveUpgradeSucceeded)
 			r.customMetrics.SetPipelineRolloutHealth(
 				pipelineRollout.Namespace,
 				pipelineRollout.Name,
 				string(pipelineRollout.Status.Phase),
-				!apiv1.GetConditionValue(pipelineRollout.Status.Conditions, apiv1.ConditionChildResourceHealthy),
-				!apiv1.GetConditionValue(pipelineRollout.Status.Conditions, apiv1.ConditionProgressiveUpgradeSucceeded),
+				promotedChildHealth != nil && !*promotedChildHealth,
+				progressiveSuccess != nil && !*progressiveSuccess,
 			)
 		}
 	}()

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -126,6 +126,8 @@ const (
 	LabelForcedSuccess             = "forcedSuccess"
 	LabelResourceHealthSuccess     = "resourceHealthSuccess"
 	LabelCompleted                 = "completed"
+	LabelPromotedChildHealthy      = "promotedChildHealthy"
+	LabelProgressiveSuccess        = "progressiveSuccess"
 )
 
 var (
@@ -145,9 +147,9 @@ var (
 	// pipelinesRolloutHealth indicates whether the pipeline rollouts are healthy (from k8s resource perspective).
 	pipelinesRolloutHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "numaplane_pipeline_rollout_health",
-		Help:        "A metric to indicate whether the pipeline rollout is healthy. '1' means healthy, '0' means unhealthy",
+		Help:        "A metric to indicate whether the pipeline rollout is healthy. '1' means healthy, '0' means unhealthy.",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelPipeline, LabelPhase})
+	}, []string{LabelNamespace, LabelPipeline, LabelPhase, LabelPromotedChildHealthy, LabelProgressiveSuccess})
 
 	// isbServicesRolloutHealth indicates whether the ISB service rollouts are healthy (from k8s resource perspective).
 	isbServicesRolloutHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -528,13 +530,20 @@ func (m *CustomMetrics) DecMonoVertexRollouts(name, namespace string) {
 	}
 }
 
-// SetPipelineRolloutHealth sets the health of the pipeline rollout
-func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase string) {
+// SetPipelineRolloutHealth sets the health of the pipeline rollout.
+func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase string, promotedChildHealthy, progressiveSuccess bool) {
+	pchStr := strconv.FormatBool(promotedChildHealthy)
+	psStr := strconv.FormatBool(progressiveSuccess)
 	for _, phase := range phases {
-		if phase == currentPhase {
-			m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase).Set(1)
-		} else {
-			m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase).Set(0)
+		for _, pch := range []string{"true", "false"} {
+			for _, ps := range []string{"true", "false"} {
+				if phase == currentPhase && pch == pchStr && ps == psStr {
+					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(1)
+				} else {
+					// clear out any other time series for this particular PipelineRollout
+					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(0)
+				}
+			}
 		}
 	}
 }
@@ -543,8 +552,12 @@ func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase s
 func (m *CustomMetrics) DeletePipelineRolloutHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting pipeline rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		deleted := m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase)
-		m.NumaLogger.WithValues("phase", phase, "deleted", deleted).Debugf("Result of deletion of pipeline rollout health metrics for %s/%s", namespace, name)
+		for _, pch := range []string{"true", "false"} {
+			for _, ps := range []string{"true", "false"} {
+				deleted := m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase, pch, ps)
+				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, pch, LabelProgressiveSuccess, ps, "deleted", deleted).Debugf("Result of deletion of pipeline rollout health metrics for %s/%s", namespace, name)
+			}
+		}
 	}
 }
 

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -154,9 +154,9 @@ var (
 	// isbServicesRolloutHealth indicates whether the ISB service rollouts are healthy (from k8s resource perspective).
 	isbServicesRolloutHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "numaplane_isb_services_rollout_health",
-		Help:        "A metric to indicate whether the isb services rollout is healthy. '1' means healthy, '0' means unhealthy",
+		Help:        "A metric to indicate whether the ISB service rollout is healthy. '1' means healthy, '0' means unhealthy",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelISBService, LabelPhase})
+	}, []string{LabelNamespace, LabelISBService, LabelPhase, LabelPromotedChildHealthy, LabelProgressiveSuccess})
 
 	// monoVerticesRolloutHealth indicates whether the mono vertices are healthy (from k8s resource perspective).
 	monoVerticesRolloutHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -561,13 +561,20 @@ func (m *CustomMetrics) DeletePipelineRolloutHealth(namespace, name string) {
 	}
 }
 
-// SetISBServicesRolloutHealth sets the health of the ISB service rollout
-func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhase string) {
+// SetISBServicesRolloutHealth sets the health of the ISB service rollout.
+func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhase string, promotedChildHealthy, progressiveSuccess bool) {
+	pchStr := strconv.FormatBool(promotedChildHealthy)
+	psStr := strconv.FormatBool(progressiveSuccess)
 	for _, phase := range phases {
-		if phase == currentPhase {
-			m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase).Set(1)
-		} else {
-			m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase).Set(0)
+		for _, pch := range []string{"true", "false"} {
+			for _, ps := range []string{"true", "false"} {
+				if phase == currentPhase && pch == pchStr && ps == psStr {
+					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(1)
+				} else {
+					// clear out older time series for this particular ISBServiceRollout
+					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(0)
+				}
+			}
 		}
 	}
 }
@@ -576,8 +583,12 @@ func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhas
 func (m *CustomMetrics) DeleteISBServicesRolloutHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting isbsvc rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		deleted := m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase)
-		m.NumaLogger.WithValues("phase", phase, "deleted", deleted).Debugf("Result of deletion of isbsvc rollout health metrics for %s/%s", namespace, name)
+		for _, pch := range []string{"true", "false"} {
+			for _, ps := range []string{"true", "false"} {
+				deleted := m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase, pch, ps)
+				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, pch, LabelProgressiveSuccess, ps, "deleted", deleted).Debugf("Result of deletion of isbsvc rollout health metrics for %s/%s", namespace, name)
+			}
+		}
 	}
 }
 

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -541,6 +541,7 @@ func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase s
 				if phase == currentPhase && promotedChildFailure == promotedChildFailureStr && progressiveFailure == progressiveFailureStr {
 					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(1)
 				} else {
+					// clear out any other time series for this particular PipelineRollout
 					m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure)
 				}
 			}
@@ -571,6 +572,7 @@ func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhas
 				if phase == currentPhase && promotedChildFailure == promotedChildFailureStr && progressiveFailure == progressiveFailureStr {
 					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(1)
 				} else {
+					// clear out older time series for this particular ISBServiceRollout
 					m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure)
 				}
 			}
@@ -601,6 +603,7 @@ func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPha
 				if phase == currentPhase && promotedChildFailure == promotedChildFailureStr && progressiveFailure == progressiveFailureStr {
 					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(1)
 				} else {
+					// clear out older time series for this particular MonoVertexRollout
 					m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure)
 				}
 			}
@@ -627,6 +630,7 @@ func (m *CustomMetrics) SetNumaflowControllerRolloutsHealth(namespace, name, cur
 		if phase == currentPhase {
 			m.NumaflowControllerRolloutsHealth.WithLabelValues(namespace, name, phase).Set(1)
 		} else {
+			// clear out older time series for this particular NumaflowControllerRollout
 			m.NumaflowControllerRolloutsHealth.DeleteLabelValues(namespace, name, phase)
 		}
 	}
@@ -686,6 +690,7 @@ func (m *CustomMetrics) SetNumaflowControllersHealth(namespace, name, currentPha
 			if phase == currentPhase && childHealthy == childHealthyStr {
 				m.NumaflowControllersHealth.WithLabelValues(namespace, name, phase, childHealthy).Set(1)
 			} else {
+				// clear out older time series for this particular NumaflowController
 				m.NumaflowControllersHealth.DeleteLabelValues(namespace, name, phase, childHealthy)
 			}
 		}

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -541,8 +541,7 @@ func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase s
 				if phase == currentPhase && promotedChildFailure == promotedChildFailureStr && progressiveFailure == progressiveFailureStr {
 					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(1)
 				} else {
-					// clear out any other time series for this particular PipelineRollout
-					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(0)
+					m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure)
 				}
 			}
 		}
@@ -572,8 +571,7 @@ func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhas
 				if phase == currentPhase && promotedChildFailure == promotedChildFailureStr && progressiveFailure == progressiveFailureStr {
 					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(1)
 				} else {
-					// clear out older time series for this particular ISBServiceRollout
-					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(0)
+					m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure)
 				}
 			}
 		}
@@ -603,8 +601,7 @@ func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPha
 				if phase == currentPhase && promotedChildFailure == promotedChildFailureStr && progressiveFailure == progressiveFailureStr {
 					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(1)
 				} else {
-					// clear out older time series for this particular MonoVertexRollout
-					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(0)
+					m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure)
 				}
 			}
 		}
@@ -630,7 +627,7 @@ func (m *CustomMetrics) SetNumaflowControllerRolloutsHealth(namespace, name, cur
 		if phase == currentPhase {
 			m.NumaflowControllerRolloutsHealth.WithLabelValues(namespace, name, phase).Set(1)
 		} else {
-			m.NumaflowControllerRolloutsHealth.WithLabelValues(namespace, name, phase).Set(0)
+			m.NumaflowControllerRolloutsHealth.DeleteLabelValues(namespace, name, phase)
 		}
 	}
 }
@@ -689,8 +686,7 @@ func (m *CustomMetrics) SetNumaflowControllersHealth(namespace, name, currentPha
 			if phase == currentPhase && childHealthy == childHealthyStr {
 				m.NumaflowControllersHealth.WithLabelValues(namespace, name, phase, childHealthy).Set(1)
 			} else {
-				// clear out older time series for this particular NumaflowController
-				m.NumaflowControllersHealth.WithLabelValues(namespace, name, phase, childHealthy).Set(0)
+				m.NumaflowControllersHealth.DeleteLabelValues(namespace, name, phase, childHealthy)
 			}
 		}
 	}

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -128,6 +128,7 @@ const (
 	LabelCompleted                 = "completed"
 	LabelPromotedChildHealthy      = "promotedChildHealthy"
 	LabelProgressiveSuccess        = "progressiveSuccess"
+	LabelChildHealthy              = "childHealthy"
 )
 
 var (
@@ -170,7 +171,7 @@ var (
 		Name:        "numaflow_controller_health",
 		Help:        "A metric to indicate whether the NumaflowController is healthy. '1' means healthy, '0' means unhealthy",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelNumaflowController, LabelPhase})
+	}, []string{LabelNamespace, LabelNumaflowController, LabelPhase, LabelChildHealthy})
 
 	// numaflowControllerRolloutsHealth indicates whether the numaflow controller rollouts are healthy (from k8s resource perspective)
 	numaflowControllerRolloutsHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -532,16 +533,16 @@ func (m *CustomMetrics) DecMonoVertexRollouts(name, namespace string) {
 
 // SetPipelineRolloutHealth sets the health of the pipeline rollout.
 func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase string, promotedChildHealthy, progressiveSuccess bool) {
-	pchStr := strconv.FormatBool(promotedChildHealthy)
-	psStr := strconv.FormatBool(progressiveSuccess)
+	promotedChildHealthyStr := strconv.FormatBool(promotedChildHealthy)
+	progressiveSuccessStr := strconv.FormatBool(progressiveSuccess)
 	for _, phase := range phases {
-		for _, pch := range []string{"true", "false"} {
-			for _, ps := range []string{"true", "false"} {
-				if phase == currentPhase && pch == pchStr && ps == psStr {
-					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(1)
+		for _, promotedChildHealthy := range []string{"true", "false"} {
+			for _, progressiveSuccess := range []string{"true", "false"} {
+				if phase == currentPhase && promotedChildHealthy == promotedChildHealthyStr && progressiveSuccess == progressiveSuccessStr {
+					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(1)
 				} else {
 					// clear out any other time series for this particular PipelineRollout
-					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(0)
+					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(0)
 				}
 			}
 		}
@@ -552,10 +553,10 @@ func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase s
 func (m *CustomMetrics) DeletePipelineRolloutHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting pipeline rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		for _, pch := range []string{"true", "false"} {
-			for _, ps := range []string{"true", "false"} {
-				deleted := m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase, pch, ps)
-				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, pch, LabelProgressiveSuccess, ps, "deleted", deleted).Debugf("Result of deletion of pipeline rollout health metrics for %s/%s", namespace, name)
+		for _, promotedChildHealthy := range []string{"true", "false"} {
+			for _, progressiveSuccess := range []string{"true", "false"} {
+				deleted := m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess)
+				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, promotedChildHealthy, LabelProgressiveSuccess, progressiveSuccess, "deleted", deleted).Debugf("Result of deletion of pipeline rollout health metrics for %s/%s", namespace, name)
 			}
 		}
 	}
@@ -563,16 +564,16 @@ func (m *CustomMetrics) DeletePipelineRolloutHealth(namespace, name string) {
 
 // SetISBServicesRolloutHealth sets the health of the ISB service rollout.
 func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhase string, promotedChildHealthy, progressiveSuccess bool) {
-	pchStr := strconv.FormatBool(promotedChildHealthy)
-	psStr := strconv.FormatBool(progressiveSuccess)
+	promotedChildHealthyStr := strconv.FormatBool(promotedChildHealthy)
+	progressiveSuccessStr := strconv.FormatBool(progressiveSuccess)
 	for _, phase := range phases {
-		for _, pch := range []string{"true", "false"} {
-			for _, ps := range []string{"true", "false"} {
-				if phase == currentPhase && pch == pchStr && ps == psStr {
-					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(1)
+		for _, promotedChildHealthy := range []string{"true", "false"} {
+			for _, progressiveSuccess := range []string{"true", "false"} {
+				if phase == currentPhase && promotedChildHealthy == promotedChildHealthyStr && progressiveSuccess == progressiveSuccessStr {
+					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(1)
 				} else {
 					// clear out older time series for this particular ISBServiceRollout
-					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(0)
+					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(0)
 				}
 			}
 		}
@@ -583,10 +584,10 @@ func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhas
 func (m *CustomMetrics) DeleteISBServicesRolloutHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting isbsvc rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		for _, pch := range []string{"true", "false"} {
-			for _, ps := range []string{"true", "false"} {
-				deleted := m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase, pch, ps)
-				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, pch, LabelProgressiveSuccess, ps, "deleted", deleted).Debugf("Result of deletion of isbsvc rollout health metrics for %s/%s", namespace, name)
+		for _, promotedChildHealthy := range []string{"true", "false"} {
+			for _, progressiveSuccess := range []string{"true", "false"} {
+				deleted := m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess)
+				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, promotedChildHealthy, LabelProgressiveSuccess, progressiveSuccess, "deleted", deleted).Debugf("Result of deletion of isbsvc rollout health metrics for %s/%s", namespace, name)
 			}
 		}
 	}
@@ -594,16 +595,16 @@ func (m *CustomMetrics) DeleteISBServicesRolloutHealth(namespace, name string) {
 
 // SetMonoVerticesRolloutHealth sets the health of the monovertex rollout.
 func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPhase string, promotedChildHealthy, progressiveSuccess bool) {
-	pchStr := strconv.FormatBool(promotedChildHealthy)
-	psStr := strconv.FormatBool(progressiveSuccess)
+	promotedChildHealthyStr := strconv.FormatBool(promotedChildHealthy)
+	progressiveSuccessStr := strconv.FormatBool(progressiveSuccess)
 	for _, phase := range phases {
-		for _, pch := range []string{"true", "false"} {
-			for _, ps := range []string{"true", "false"} {
-				if phase == currentPhase && pch == pchStr && ps == psStr {
-					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(1)
+		for _, promotedChildHealthy := range []string{"true", "false"} {
+			for _, progressiveSuccess := range []string{"true", "false"} {
+				if phase == currentPhase && promotedChildHealthy == promotedChildHealthyStr && progressiveSuccess == progressiveSuccessStr {
+					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(1)
 				} else {
 					// clear out older time series for this particular MonoVertexRollout
-					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(0)
+					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(0)
 				}
 			}
 		}
@@ -614,10 +615,10 @@ func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPha
 func (m *CustomMetrics) DeleteMonoVerticesRolloutHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting monovertex rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		for _, pch := range []string{"true", "false"} {
-			for _, ps := range []string{"true", "false"} {
-				deleted := m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase, pch, ps)
-				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, pch, LabelProgressiveSuccess, ps, "deleted", deleted).Debugf("Result of deletion of monovertex rollout health metrics for %s/%s", namespace, name)
+		for _, promotedChildHealthy := range []string{"true", "false"} {
+			for _, progressiveSuccess := range []string{"true", "false"} {
+				deleted := m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess)
+				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, promotedChildHealthy, LabelProgressiveSuccess, progressiveSuccess, "deleted", deleted).Debugf("Result of deletion of monovertex rollout health metrics for %s/%s", namespace, name)
 			}
 		}
 	}
@@ -680,13 +681,17 @@ func (m *CustomMetrics) DeleteNumaflowControllerRolloutRunning(name, namespace, 
 	m.NumaflowControllerRolloutsRunning.DeleteLabelValues(name, namespace, version)
 }
 
-// SetNumaflowControllersHealth sets the health of the numaflow controller
-func (m *CustomMetrics) SetNumaflowControllersHealth(namespace, name, currentPhase string) {
+// SetNumaflowControllersHealth sets the health of the numaflow controller.
+func (m *CustomMetrics) SetNumaflowControllersHealth(namespace, name, currentPhase string, childHealthy bool) {
+	childHealthyStr := strconv.FormatBool(childHealthy)
 	for _, phase := range phases {
-		if phase == currentPhase {
-			m.NumaflowControllersHealth.WithLabelValues(namespace, name, phase).Set(1)
-		} else {
-			m.NumaflowControllersHealth.WithLabelValues(namespace, name, phase).Set(0)
+		for _, childHealthy := range []string{"true", "false"} {
+			if phase == currentPhase && childHealthy == childHealthyStr {
+				m.NumaflowControllersHealth.WithLabelValues(namespace, name, phase, childHealthy).Set(1)
+			} else {
+				// clear out older time series for this particular NumaflowController
+				m.NumaflowControllersHealth.WithLabelValues(namespace, name, phase, childHealthy).Set(0)
+			}
 		}
 	}
 }
@@ -695,8 +700,10 @@ func (m *CustomMetrics) SetNumaflowControllersHealth(namespace, name, currentPha
 func (m *CustomMetrics) DeleteNumaflowControllersHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting numaflow controller health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		deleted := m.NumaflowControllersHealth.DeleteLabelValues(namespace, name, phase)
-		m.NumaLogger.WithValues("phase", phase, "deleted", deleted).Debugf("Result of deletion of numaflow controller health metrics for %s/%s", namespace, name)
+		for _, childHealthy := range []string{"true", "false"} {
+			deleted := m.NumaflowControllersHealth.DeleteLabelValues(namespace, name, phase, childHealthy)
+			m.NumaLogger.WithValues("phase", phase, LabelChildHealthy, childHealthy, "deleted", deleted).Debugf("Result of deletion of numaflow controller health metrics for %s/%s", namespace, name)
+		}
 	}
 }
 

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -163,7 +163,7 @@ var (
 		Name:        "numaplane_monovertex_rollout_health",
 		Help:        "A metric to indicate whether the MonoVertex is healthy. '1' means healthy, '0' means unhealthy",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelMonoVertex, LabelPhase})
+	}, []string{LabelNamespace, LabelMonoVertex, LabelPhase, LabelPromotedChildHealthy, LabelProgressiveSuccess})
 
 	// numaflowControllersHealth indicates whether the NumaflowControllers are healthy (from k8s resource perspective)
 	numaflowControllersHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -581,13 +581,20 @@ func (m *CustomMetrics) DeleteISBServicesRolloutHealth(namespace, name string) {
 	}
 }
 
-// SetMonoVerticesRolloutHealth sets the health of the monovertex rollout
-func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPhase string) {
+// SetMonoVerticesRolloutHealth sets the health of the monovertex rollout.
+func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPhase string, promotedChildHealthy, progressiveSuccess bool) {
+	pchStr := strconv.FormatBool(promotedChildHealthy)
+	psStr := strconv.FormatBool(progressiveSuccess)
 	for _, phase := range phases {
-		if phase == currentPhase {
-			m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase).Set(1)
-		} else {
-			m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase).Set(0)
+		for _, pch := range []string{"true", "false"} {
+			for _, ps := range []string{"true", "false"} {
+				if phase == currentPhase && pch == pchStr && ps == psStr {
+					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(1)
+				} else {
+					// clear out older time series for this particular MonoVertexRollout
+					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, pch, ps).Set(0)
+				}
+			}
 		}
 	}
 }
@@ -596,8 +603,12 @@ func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPha
 func (m *CustomMetrics) DeleteMonoVerticesRolloutHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting monovertex rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		deleted := m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase)
-		m.NumaLogger.WithValues("phase", phase, "deleted", deleted).Debugf("Result of deletion of monovertex rollout health metrics for %s/%s", namespace, name)
+		for _, pch := range []string{"true", "false"} {
+			for _, ps := range []string{"true", "false"} {
+				deleted := m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase, pch, ps)
+				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, pch, LabelProgressiveSuccess, ps, "deleted", deleted).Debugf("Result of deletion of monovertex rollout health metrics for %s/%s", namespace, name)
+			}
+		}
 	}
 }
 

--- a/internal/util/metrics/metrics.go
+++ b/internal/util/metrics/metrics.go
@@ -126,8 +126,8 @@ const (
 	LabelForcedSuccess             = "forcedSuccess"
 	LabelResourceHealthSuccess     = "resourceHealthSuccess"
 	LabelCompleted                 = "completed"
-	LabelPromotedChildHealthy      = "promotedChildHealthy"
-	LabelProgressiveSuccess        = "progressiveSuccess"
+	LabelPromotedChildFailure      = "promotedChildFailure"
+	LabelProgressiveFailure        = "progressiveFailure"
 	LabelChildHealthy              = "childHealthy"
 )
 
@@ -150,21 +150,21 @@ var (
 		Name:        "numaplane_pipeline_rollout_health",
 		Help:        "A metric to indicate whether the pipeline rollout is healthy. '1' means healthy, '0' means unhealthy.",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelPipeline, LabelPhase, LabelPromotedChildHealthy, LabelProgressiveSuccess})
+	}, []string{LabelNamespace, LabelPipeline, LabelPhase, LabelPromotedChildFailure, LabelProgressiveFailure})
 
 	// isbServicesRolloutHealth indicates whether the ISB service rollouts are healthy (from k8s resource perspective).
 	isbServicesRolloutHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "numaplane_isb_services_rollout_health",
 		Help:        "A metric to indicate whether the ISB service rollout is healthy. '1' means healthy, '0' means unhealthy",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelISBService, LabelPhase, LabelPromotedChildHealthy, LabelProgressiveSuccess})
+	}, []string{LabelNamespace, LabelISBService, LabelPhase, LabelPromotedChildFailure, LabelProgressiveFailure})
 
 	// monoVerticesRolloutHealth indicates whether the mono vertices are healthy (from k8s resource perspective).
 	monoVerticesRolloutHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "numaplane_monovertex_rollout_health",
 		Help:        "A metric to indicate whether the MonoVertex is healthy. '1' means healthy, '0' means unhealthy",
 		ConstLabels: defaultLabels,
-	}, []string{LabelNamespace, LabelMonoVertex, LabelPhase, LabelPromotedChildHealthy, LabelProgressiveSuccess})
+	}, []string{LabelNamespace, LabelMonoVertex, LabelPhase, LabelPromotedChildFailure, LabelProgressiveFailure})
 
 	// numaflowControllersHealth indicates whether the NumaflowControllers are healthy (from k8s resource perspective)
 	numaflowControllersHealth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -532,17 +532,17 @@ func (m *CustomMetrics) DecMonoVertexRollouts(name, namespace string) {
 }
 
 // SetPipelineRolloutHealth sets the health of the pipeline rollout.
-func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase string, promotedChildHealthy, progressiveSuccess bool) {
-	promotedChildHealthyStr := strconv.FormatBool(promotedChildHealthy)
-	progressiveSuccessStr := strconv.FormatBool(progressiveSuccess)
+func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase string, promotedChildFailure, progressiveFailure bool) {
+	promotedChildFailureStr := strconv.FormatBool(promotedChildFailure)
+	progressiveFailureStr := strconv.FormatBool(progressiveFailure)
 	for _, phase := range phases {
-		for _, promotedChildHealthy := range []string{"true", "false"} {
-			for _, progressiveSuccess := range []string{"true", "false"} {
-				if phase == currentPhase && promotedChildHealthy == promotedChildHealthyStr && progressiveSuccess == progressiveSuccessStr {
-					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(1)
+		for _, promotedChildFailure := range []string{"true", "false"} {
+			for _, progressiveFailure := range []string{"true", "false"} {
+				if phase == currentPhase && promotedChildFailure == promotedChildFailureStr && progressiveFailure == progressiveFailureStr {
+					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(1)
 				} else {
 					// clear out any other time series for this particular PipelineRollout
-					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(0)
+					m.PipelinesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(0)
 				}
 			}
 		}
@@ -553,27 +553,27 @@ func (m *CustomMetrics) SetPipelineRolloutHealth(namespace, name, currentPhase s
 func (m *CustomMetrics) DeletePipelineRolloutHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting pipeline rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		for _, promotedChildHealthy := range []string{"true", "false"} {
-			for _, progressiveSuccess := range []string{"true", "false"} {
-				deleted := m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess)
-				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, promotedChildHealthy, LabelProgressiveSuccess, progressiveSuccess, "deleted", deleted).Debugf("Result of deletion of pipeline rollout health metrics for %s/%s", namespace, name)
+		for _, promotedChildFailure := range []string{"true", "false"} {
+			for _, progressiveFailure := range []string{"true", "false"} {
+				deleted := m.PipelinesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure)
+				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildFailure, promotedChildFailure, LabelProgressiveFailure, progressiveFailure, "deleted", deleted).Debugf("Result of deletion of pipeline rollout health metrics for %s/%s", namespace, name)
 			}
 		}
 	}
 }
 
 // SetISBServicesRolloutHealth sets the health of the ISB service rollout.
-func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhase string, promotedChildHealthy, progressiveSuccess bool) {
-	promotedChildHealthyStr := strconv.FormatBool(promotedChildHealthy)
-	progressiveSuccessStr := strconv.FormatBool(progressiveSuccess)
+func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhase string, promotedChildFailure, progressiveFailure bool) {
+	promotedChildFailureStr := strconv.FormatBool(promotedChildFailure)
+	progressiveFailureStr := strconv.FormatBool(progressiveFailure)
 	for _, phase := range phases {
-		for _, promotedChildHealthy := range []string{"true", "false"} {
-			for _, progressiveSuccess := range []string{"true", "false"} {
-				if phase == currentPhase && promotedChildHealthy == promotedChildHealthyStr && progressiveSuccess == progressiveSuccessStr {
-					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(1)
+		for _, promotedChildFailure := range []string{"true", "false"} {
+			for _, progressiveFailure := range []string{"true", "false"} {
+				if phase == currentPhase && promotedChildFailure == promotedChildFailureStr && progressiveFailure == progressiveFailureStr {
+					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(1)
 				} else {
 					// clear out older time series for this particular ISBServiceRollout
-					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(0)
+					m.ISBServicesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(0)
 				}
 			}
 		}
@@ -584,27 +584,27 @@ func (m *CustomMetrics) SetISBServicesRolloutHealth(namespace, name, currentPhas
 func (m *CustomMetrics) DeleteISBServicesRolloutHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting isbsvc rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		for _, promotedChildHealthy := range []string{"true", "false"} {
-			for _, progressiveSuccess := range []string{"true", "false"} {
-				deleted := m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess)
-				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, promotedChildHealthy, LabelProgressiveSuccess, progressiveSuccess, "deleted", deleted).Debugf("Result of deletion of isbsvc rollout health metrics for %s/%s", namespace, name)
+		for _, promotedChildFailure := range []string{"true", "false"} {
+			for _, progressiveFailure := range []string{"true", "false"} {
+				deleted := m.ISBServicesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure)
+				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildFailure, promotedChildFailure, LabelProgressiveFailure, progressiveFailure, "deleted", deleted).Debugf("Result of deletion of isbsvc rollout health metrics for %s/%s", namespace, name)
 			}
 		}
 	}
 }
 
 // SetMonoVerticesRolloutHealth sets the health of the monovertex rollout.
-func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPhase string, promotedChildHealthy, progressiveSuccess bool) {
-	promotedChildHealthyStr := strconv.FormatBool(promotedChildHealthy)
-	progressiveSuccessStr := strconv.FormatBool(progressiveSuccess)
+func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPhase string, promotedChildFailure, progressiveFailure bool) {
+	promotedChildFailureStr := strconv.FormatBool(promotedChildFailure)
+	progressiveFailureStr := strconv.FormatBool(progressiveFailure)
 	for _, phase := range phases {
-		for _, promotedChildHealthy := range []string{"true", "false"} {
-			for _, progressiveSuccess := range []string{"true", "false"} {
-				if phase == currentPhase && promotedChildHealthy == promotedChildHealthyStr && progressiveSuccess == progressiveSuccessStr {
-					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(1)
+		for _, promotedChildFailure := range []string{"true", "false"} {
+			for _, progressiveFailure := range []string{"true", "false"} {
+				if phase == currentPhase && promotedChildFailure == promotedChildFailureStr && progressiveFailure == progressiveFailureStr {
+					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(1)
 				} else {
 					// clear out older time series for this particular MonoVertexRollout
-					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess).Set(0)
+					m.MonoVerticesRolloutHealth.WithLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure).Set(0)
 				}
 			}
 		}
@@ -615,10 +615,10 @@ func (m *CustomMetrics) SetMonoVerticesRolloutHealth(namespace, name, currentPha
 func (m *CustomMetrics) DeleteMonoVerticesRolloutHealth(namespace, name string) {
 	m.NumaLogger.Infof("Deleting monovertex rollout health metrics for %s/%s", namespace, name)
 	for _, phase := range phases {
-		for _, promotedChildHealthy := range []string{"true", "false"} {
-			for _, progressiveSuccess := range []string{"true", "false"} {
-				deleted := m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildHealthy, progressiveSuccess)
-				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildHealthy, promotedChildHealthy, LabelProgressiveSuccess, progressiveSuccess, "deleted", deleted).Debugf("Result of deletion of monovertex rollout health metrics for %s/%s", namespace, name)
+		for _, promotedChildFailure := range []string{"true", "false"} {
+			for _, progressiveFailure := range []string{"true", "false"} {
+				deleted := m.MonoVerticesRolloutHealth.DeleteLabelValues(namespace, name, phase, promotedChildFailure, progressiveFailure)
+				m.NumaLogger.WithValues("phase", phase, LabelPromotedChildFailure, promotedChildFailure, LabelProgressiveFailure, progressiveFailure, "deleted", deleted).Debugf("Result of deletion of monovertex rollout health metrics for %s/%s", namespace, name)
 			}
 		}
 	}

--- a/pkg/apis/numaplane/v1alpha1/status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/status_types.go
@@ -152,6 +152,16 @@ func (s *Status) GetCondition(t ConditionType) *metav1.Condition {
 	return nil
 }
 
+// GetConditionValue reports whether t is present with Status True in conditions.
+func GetConditionValue(conditions []metav1.Condition, t ConditionType) bool {
+	for i := range conditions {
+		if conditions[i].Type == string(t) && conditions[i].Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
 // Init sets certain Status parameters to a default initial state
 func (status *Status) Init(generation int64) {
 	status.SetObservedGeneration(generation)

--- a/pkg/apis/numaplane/v1alpha1/status_types.go
+++ b/pkg/apis/numaplane/v1alpha1/status_types.go
@@ -152,14 +152,15 @@ func (s *Status) GetCondition(t ConditionType) *metav1.Condition {
 	return nil
 }
 
-// GetConditionValue reports whether t is present with Status True in conditions.
-func GetConditionValue(conditions []metav1.Condition, t ConditionType) bool {
+// GetConditionValue reports whether condition t is True. nil means no condition of that type exists.
+func GetConditionValue(conditions []metav1.Condition, t ConditionType) *bool {
 	for i := range conditions {
-		if conditions[i].Type == string(t) && conditions[i].Status == metav1.ConditionTrue {
-			return true
+		if conditions[i].Type == string(t) {
+			v := conditions[i].Status == metav1.ConditionTrue
+			return &v
 		}
 	}
-	return false
+	return nil
 }
 
 // Init sets certain Status parameters to a default initial state


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

Our existing rollout health metrics aren't all that useful. They just look at the "phase" of the rollout. In order to make them more meaningful, I thought to incorporate the underlying children health using the Conditions _ChildResourcesHealthy_ and _ProgressiveUpgradeSucceeded_ as point tags. Then we can show them in our Wavefront Table Plot. 


### Verification

Created each of the 4 rollouts and confirmed the metric in Prometheus UI. Did a progressive rollout to result in failure for both PipelineRollout and MonoVertexRollout. Confirmed the old metric was replaced with a new one which had the "progressiveFailed" point tag set true. 

Deleted each Rollout. Confirmed that the metric was deleted. 

### Backward (and forward) incompatibilities

N/A

When we release this, a new Numaplane pod will come up and advertise just the new metrics with the new point tags. We will update our charts to show columns for the new point tags. If we go back to before this change was released, the columns should simply be empty, which is fine.

