### PR TITLE
chore: update NumaflowControllerRollout name validation

### DIFF
--- a/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
@@ -178,7 +178,7 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: The metadata name must start with 'numaflow-controller'
-          rule: matches(self.metadata.name, '^numaflow-controller.*')
+          rule: self.metadata.name.matches('^numaflow-controller.*')
     served: true
     storage: true
     subresources:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1157,7 +1157,7 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: The metadata name must start with 'numaflow-controller'
-          rule: matches(self.metadata.name, '^numaflow-controller.*')
+          rule: self.metadata.name.matches('^numaflow-controller.*')
     served: true
     storage: true
     subresources:

--- a/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
@@ -44,7 +44,7 @@ type NumaflowControllerRolloutStatus struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:validation:XValidation:rule="matches(self.metadata.name, '^numaflow-controller.*')",message="The metadata name must start with 'numaflow-controller'"
+// +kubebuilder:validation:XValidation:rule="self.metadata.name.matches('^numaflow-controller.*')",message="The metadata name must start with 'numaflow-controller'"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.controller.version",description="The desired Numaflow Controller version"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### Modifications

The XValidation rule used the global form `matches(self.metadata.name, ...)`,
which is unavailable in older cel-go versions shipped with the kube-apiserver
and fails CRD installation with "no matching overload for 'matches' applied
to '(string, string)'". Switch to the universally supported receiver form
`self.metadata.name.matches(...)`.

This was an error I would see consistently when running make-start locally and would need to edit the rule.

### Verification

Running `make start` locally.

### Backward (and forward) incompatibilities
 
 N/A
