### PR TITLE
fix: update USDE to include all of the built-in sources and sinks

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -2698,9 +2698,10 @@ data:
         includeSubfields: true
       - path: spec.vertices.source.transformer.builtin
         includeSubfields: true
-      - path: spec.vertices.sink.log
       - path: spec.vertices.sink.kafka
-      - path: spec.vertices.sink.blackhole
+      - path: spec.vertices.sink.serve
+      - path: spec.vertices.sink.sqs
+      - path: spec.vertices.sink.pulsar
       - path: spec.vertices.sink.udsink.container.image
       - path: spec.vertices.sink.udsink.container.volumeMounts
         includeSubfields: true
@@ -2734,6 +2735,35 @@ data:
         includeSubfields: true
       - path: spec.templates     # note: this one could be broken down further into just the fields that are at risk
         includeSubfields: true
+    progressive:
+      # Decision: Many of the fields inside of these source types and sink types are risky to change and could warrant doing Progressive Rollout
+      # There are too many different fields to go through each one and determine if it is, so for simplicity we do Progressive Rollout for all.
+      - path: spec.vertices.source.generator
+        includeSubfields: true
+      - path: spec.vertices.source.kafka
+        includeSubfields: true
+      - path: spec.vertices.source.http
+        includeSubfields: true
+      - path: spec.vertices.source.nats
+        includeSubfields: true
+      - path: spec.vertices.source.jetstream
+        includeSubfields: true
+      - path: spec.vertices.source.serving
+        includeSubfields: true
+      - path: spec.vertices.source.pulsar
+        includeSubfields: true
+      - path: spec.vertices.source.sqs
+        includeSubfields: true
+      
+      - path: spec.vertices.sink.kafka
+        includeSubfields: true
+      - path: spec.vertices.sink.serve
+        includeSubfields: true
+      - path: spec.vertices.sink.sqs
+        includeSubfields: true
+      - path: spec.vertices.sink.pulsar
+        includeSubfields: true
+      
   interstepbufferservice: |
     recreate:
       # Changing persistence settings and number of replicas needs to recreate both the ISBSvc and also the pipelines associated to it to 
@@ -2816,6 +2846,34 @@ data:
       - path: spec.source.udsource.container.envfrom
         includeSubfields: true
       - path: spec.volumes
+        includeSubfields: true
+
+      # Decision: Many of the fields inside of these source types and sink types are risky to change and could warrant doing Progressive Rollout
+      # There are too many different fields to go through each one and determine if it is, so for simplicity we do Progressive Rollout for all.
+      - path: spec.vertices.source.generator
+        includeSubfields: true
+      - path: spec.vertices.source.kafka
+        includeSubfields: true
+      - path: spec.vertices.source.http
+        includeSubfields: true
+      - path: spec.vertices.source.nats
+        includeSubfields: true
+      - path: spec.vertices.source.jetstream
+        includeSubfields: true
+      - path: spec.vertices.source.serving
+        includeSubfields: true
+      - path: spec.vertices.source.pulsar
+        includeSubfields: true
+      - path: spec.vertices.source.sqs
+        includeSubfields: true
+      
+      - path: spec.vertices.sink.kafka
+        includeSubfields: true
+      - path: spec.vertices.sink.serve
+        includeSubfields: true
+      - path: spec.vertices.sink.sqs
+        includeSubfields: true
+      - path: spec.vertices.sink.pulsar
         includeSubfields: true
   numaflowcontroller: |
     dataLoss:

--- a/config/manager/usde-config.yaml
+++ b/config/manager/usde-config.yaml
@@ -52,9 +52,10 @@ data:
         includeSubfields: true
       - path: spec.vertices.source.transformer.builtin
         includeSubfields: true
-      - path: spec.vertices.sink.log
       - path: spec.vertices.sink.kafka
-      - path: spec.vertices.sink.blackhole
+      - path: spec.vertices.sink.serve
+      - path: spec.vertices.sink.sqs
+      - path: spec.vertices.sink.pulsar
       - path: spec.vertices.sink.udsink.container.image
       - path: spec.vertices.sink.udsink.container.volumeMounts
         includeSubfields: true
@@ -88,6 +89,35 @@ data:
         includeSubfields: true
       - path: spec.templates     # note: this one could be broken down further into just the fields that are at risk
         includeSubfields: true
+    progressive:
+      # Decision: Many of the fields inside of these source types and sink types are risky to change and could warrant doing Progressive Rollout
+      # There are too many different fields to go through each one and determine if it is, so for simplicity we do Progressive Rollout for all.
+      - path: spec.vertices.source.generator
+        includeSubfields: true
+      - path: spec.vertices.source.kafka
+        includeSubfields: true
+      - path: spec.vertices.source.http
+        includeSubfields: true
+      - path: spec.vertices.source.nats
+        includeSubfields: true
+      - path: spec.vertices.source.jetstream
+        includeSubfields: true
+      - path: spec.vertices.source.serving
+        includeSubfields: true
+      - path: spec.vertices.source.pulsar
+        includeSubfields: true
+      - path: spec.vertices.source.sqs
+        includeSubfields: true
+      
+      - path: spec.vertices.sink.kafka
+        includeSubfields: true
+      - path: spec.vertices.sink.serve
+        includeSubfields: true
+      - path: spec.vertices.sink.sqs
+        includeSubfields: true
+      - path: spec.vertices.sink.pulsar
+        includeSubfields: true
+      
   interstepbufferservice: |
     recreate:
       # Changing persistence settings and number of replicas needs to recreate both the ISBSvc and also the pipelines associated to it to 
@@ -170,6 +200,34 @@ data:
       - path: spec.source.udsource.container.envfrom
         includeSubfields: true
       - path: spec.volumes
+        includeSubfields: true
+
+      # Decision: Many of the fields inside of these source types and sink types are risky to change and could warrant doing Progressive Rollout
+      # There are too many different fields to go through each one and determine if it is, so for simplicity we do Progressive Rollout for all.
+      - path: spec.vertices.source.generator
+        includeSubfields: true
+      - path: spec.vertices.source.kafka
+        includeSubfields: true
+      - path: spec.vertices.source.http
+        includeSubfields: true
+      - path: spec.vertices.source.nats
+        includeSubfields: true
+      - path: spec.vertices.source.jetstream
+        includeSubfields: true
+      - path: spec.vertices.source.serving
+        includeSubfields: true
+      - path: spec.vertices.source.pulsar
+        includeSubfields: true
+      - path: spec.vertices.source.sqs
+        includeSubfields: true
+      
+      - path: spec.vertices.sink.kafka
+        includeSubfields: true
+      - path: spec.vertices.sink.serve
+        includeSubfields: true
+      - path: spec.vertices.sink.sqs
+        includeSubfields: true
+      - path: spec.vertices.sink.pulsar
         includeSubfields: true
   numaflowcontroller: |
     dataLoss:

--- a/go.mod
+++ b/go.mod
@@ -108,7 +108,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/moby/spdystream v0.4.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,9 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/spdystream v0.4.0 h1:Vy79D6mHeJJjiPdFEL2yku1kl0chZpJfZcPpb16BRl8=
 github.com/moby/spdystream v0.4.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/hack/fix-configmap-formatting.py
+++ b/hack/fix-configmap-formatting.py
@@ -88,7 +88,7 @@ def main():
         
         # Scan backward to find the start of this ConfigMap
         configmap_start = None
-        for i in range(label_idx - 1, max(0, label_idx - 100), -1):
+        for i in range(label_idx - 1, -1, -1):
             if install_lines[i].strip().startswith('apiVersion:'):
                 configmap_start = i
                 break


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

I noticed we weren't triggering Progressive Rollout when changing SQS fields. This caused me to look at the numaflow pipeline/monovertex spec and see that more Sources and Sinks have been added since we wrote the USDE config. For simplicity, I ended up setting all of them to trigger Progressive when any subfield of them has changed. 

I also ended up fixing a Snyk issue (go.mod change), as well as a bug related to the script which reformats our ConfigMaps. 


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward (and forward) incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? What if we had to revert the change? What would happen? (not a showstopper but something to prepare for) -->

