### PR TITLE
fix: update numaplane-transformer-config.yaml to add missing references

### DIFF
--- a/config/kustomize/numaplane-transformer-config.yaml
+++ b/config/kustomize/numaplane-transformer-config.yaml
@@ -18,6 +18,10 @@ images:
     kind: PipelineRollout
     group: numaplane.numaproj.io
     version: v1alpha1
+  - path: spec/pipeline/spec/vertices/sink/onSuccess/udsink/container/image
+    kind: PipelineRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
   - path: spec/pipeline/spec/vertices/source/transformer/container/image
     kind: PipelineRollout
     group: numaplane.numaproj.io
@@ -46,6 +50,10 @@ images:
     kind: MonoVertexRollout
     group: numaplane.numaproj.io
     version: v1alpha1
+  - path: spec/monoVertex/spec/sink/onSuccess/udsink/container/image
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
   - path: spec/monoVertex/spec/udf/container/image
     kind: MonoVertexRollout
     group: numaplane.numaproj.io
@@ -70,6 +78,24 @@ nameReference:
         kind: MonoVertexRollout
         group: numaplane.numaproj.io
         version: v1alpha1
+  # A PipelineRollout references its ISBServiceRollout by name; interStepBufferServiceName must match the (possibly renamed) ISBServiceRollout name
+  - kind: ISBServiceRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+    fieldSpecs:
+      - path: spec/pipeline/spec/interStepBufferServiceName
+        kind: PipelineRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+  # A VerticalPodAutoscaler targets a MonoVertexRollout by name; targetRef/name must match the (possibly renamed) MonoVertexRollout name
+  - kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+    fieldSpecs:
+      - path: spec/targetRef/name
+        kind: VerticalPodAutoscaler
+        group: autoscaling.k8s.io
+        version: v1
   - kind: ConfigMap
     version: v1
     fieldSpecs:
@@ -142,6 +168,14 @@ nameReference:
         group: numaplane.numaproj.io
         version: v1alpha1
       - path: spec/pipeline/spec/vertices/sink/fallback/udsink/container/envFrom/configMapRef/name
+        kind: PipelineRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/pipeline/spec/vertices/sink/onSuccess/udsink/container/env/valueFrom/configMapKeyRef/name
+        kind: PipelineRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/pipeline/spec/vertices/sink/onSuccess/udsink/container/envFrom/configMapRef/name
         kind: PipelineRollout
         group: numaplane.numaproj.io
         version: v1alpha1
@@ -281,6 +315,14 @@ nameReference:
         kind: MonoVertexRollout
         group: numaplane.numaproj.io
         version: v1alpha1
+      - path: spec/monoVertex/spec/sink/onSuccess/udsink/container/env/valueFrom/configMapKeyRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/sink/onSuccess/udsink/container/envFrom/configMapRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
       - path: spec/monoVertex/spec/udf/container/env/valueFrom/configMapKeyRef/name
         kind: MonoVertexRollout
         group: numaplane.numaproj.io
@@ -393,6 +435,14 @@ nameReference:
         group: numaplane.numaproj.io
         version: v1alpha1
       - path: spec/pipeline/spec/vertices/sink/fallback/udsink/container/envFrom/secretRef/name
+        kind: PipelineRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/pipeline/spec/vertices/sink/onSuccess/udsink/container/env/valueFrom/secretKeyRef/name
+        kind: PipelineRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/pipeline/spec/vertices/sink/onSuccess/udsink/container/envFrom/secretRef/name
         kind: PipelineRollout
         group: numaplane.numaproj.io
         version: v1alpha1
@@ -549,6 +599,14 @@ nameReference:
         group: numaplane.numaproj.io
         version: v1alpha1
       - path: spec/monoVertex/spec/sink/fallback/udsink/container/envFrom/secretRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/sink/onSuccess/udsink/container/env/valueFrom/secretKeyRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/sink/onSuccess/udsink/container/envFrom/secretRef/name
         kind: MonoVertexRollout
         group: numaplane.numaproj.io
         version: v1alpha1
@@ -797,6 +855,18 @@ varReference:
     kind: PipelineRollout
     group: numaplane.numaproj.io
     version: v1alpha1
+  - path: spec/pipeline/spec/vertices/sink/onSuccess/udsink/container/args
+    kind: PipelineRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/pipeline/spec/vertices/sink/onSuccess/udsink/container/command
+    kind: PipelineRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/pipeline/spec/vertices/sink/onSuccess/udsink/container/env/value
+    kind: PipelineRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
   - path: spec/pipeline/spec/vertices/source/transformer/container/args
     kind: PipelineRollout
     group: numaplane.numaproj.io
@@ -893,6 +963,10 @@ varReference:
     kind: PipelineRollout
     group: numaplane.numaproj.io
     version: v1alpha1
+  - path: spec/pipeline/spec/vertices/sink/onSuccess/udsink/container/volumeMounts/mountPath
+    kind: PipelineRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
   - path: spec/pipeline/spec/vertices/source/transformer/container/volumeMounts/mountPath
     kind: PipelineRollout
     group: numaplane.numaproj.io
@@ -965,6 +1039,18 @@ varReference:
     kind: MonoVertexRollout
     group: numaplane.numaproj.io
     version: v1alpha1
+  - path: spec/monoVertex/spec/sink/onSuccess/udsink/container/args
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/sink/onSuccess/udsink/container/command
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/sink/onSuccess/udsink/container/env/value
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
   - path: spec/monoVertex/spec/udf/container/args
     kind: MonoVertexRollout
     group: numaplane.numaproj.io
@@ -994,6 +1080,10 @@ varReference:
     group: numaplane.numaproj.io
     version: v1alpha1
   - path: spec/monoVertex/spec/sink/fallback/udsink/container/volumeMounts/mountPath
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/sink/onSuccess/udsink/container/volumeMounts/mountPath
     kind: MonoVertexRollout
     group: numaplane.numaproj.io
     version: v1alpha1

--- a/config/kustomize/numaplane-transformer-config.yaml
+++ b/config/kustomize/numaplane-transformer-config.yaml
@@ -50,6 +50,10 @@ images:
     kind: MonoVertexRollout
     group: numaplane.numaproj.io
     version: v1alpha1
+  - path: spec/monoVertex/spec/sidecars/image
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
 
 # https://github.com/kubernetes-sigs/kustomize/blob/master/api/internal/konfig/builtinpluginconsts/namereference.go
 nameReference:
@@ -282,6 +286,38 @@ nameReference:
         group: numaplane.numaproj.io
         version: v1alpha1
       - path: spec/monoVertex/spec/udf/container/envFrom/configMapRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/volumes/configMap/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/volumes/projected/sources/configMap/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/containerTemplate/env/valueFrom/configMapKeyRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/containerTemplate/envFrom/configMapRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/initContainers/env/valueFrom/configMapKeyRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/initContainers/envFrom/configMapRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/sidecars/env/valueFrom/configMapKeyRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/sidecars/envFrom/configMapRef/name
         kind: MonoVertexRollout
         group: numaplane.numaproj.io
         version: v1alpha1
@@ -524,6 +560,42 @@ nameReference:
         kind: MonoVertexRollout
         group: numaplane.numaproj.io
         version: v1alpha1
+      - path: spec/monoVertex/spec/containerTemplate/env/valueFrom/secretKeyRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/containerTemplate/envFrom/secretRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/initContainers/env/valueFrom/secretKeyRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/initContainers/envFrom/secretRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/sidecars/env/valueFrom/secretKeyRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/sidecars/envFrom/secretRef/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/volumes/secret/secretName
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/volumes/projected/sources/secret/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/imagePullSecrets/name
+        kind: MonoVertexRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
   - kind: ServiceAccount
     version: v1
     fieldSpecs:
@@ -560,6 +632,10 @@ nameReference:
     fieldSpecs:
       - path: spec/pipeline/spec/vertices/volumes/persistentVolumeClaim/claimName
         kind: PipelineRollout
+        group: numaplane.numaproj.io
+        version: v1alpha1
+      - path: spec/monoVertex/spec/volumes/persistentVolumeClaim/claimName
+        kind: MonoVertexRollout
         group: numaplane.numaproj.io
         version: v1alpha1
   - kind: PriorityClass
@@ -841,7 +917,7 @@ varReference:
     kind: ISBServiceRollout
     group: numaplane.numaproj.io
     version: v1alpha1
-  - path: spec/monoVertex/spec/interStepBufferService/spec/source/transformer/container/args
+  - path: spec/monoVertex/spec/source/transformer/container/args
     kind: MonoVertexRollout
     group: numaplane.numaproj.io
     version: v1alpha1
@@ -902,6 +978,54 @@ varReference:
     group: numaplane.numaproj.io
     version: v1alpha1
   - path: spec/monoVertex/spec/udf/container/volumeMounts/mountPath
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/source/transformer/container/volumeMounts/mountPath
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/source/udsource/container/volumeMounts/mountPath
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/sink/udsink/container/volumeMounts/mountPath
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/sink/fallback/udsink/container/volumeMounts/mountPath
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/containerTemplate/env/value
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/initContainers/args
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/initContainers/command
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/initContainers/env/value
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/sidecars/args
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/sidecars/command
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/sidecars/env/value
+    kind: MonoVertexRollout
+    group: numaplane.numaproj.io
+    version: v1alpha1
+  - path: spec/monoVertex/spec/sidecars/volumeMounts/mountPath
     kind: MonoVertexRollout
     group: numaplane.numaproj.io
     version: v1alpha1

--- a/internal/common/numaplane_transformer_kustomize_test.go
+++ b/internal/common/numaplane_transformer_kustomize_test.go
@@ -33,7 +33,9 @@ import (
 // config/kustomize/numaplane-transformer-config.yaml is working with kustomize:
 //   - if user adds a nameSuffix or namePrefix, the AnalysisTemplate references in PipelineRollout and MonoVertexRollout must reflect that
 //   - if user adds a nameSuffix or namePrefix, ConfigMap/Secret references (including MonoVertexRollout volumes) must reflect that
-//   - if an image is renamed, the PipelineRollout / MonoVertexRollout image paths (including MonoVertexRollout sidecars) must reflect it.
+//   - if a referenced ISBServiceRollout is renamed, the PipelineRollout's interStepBufferServiceName must reflect that
+//   - if a targeted MonoVertexRollout is renamed, a VerticalPodAutoscaler's targetRef/name must reflect that
+//   - if an image is renamed, the PipelineRollout / MonoVertexRollout image paths (including MonoVertexRollout sidecars and onSuccess sinks) must reflect it.
 func TestNumaplaneTransformerConfigKustomizeBuild(t *testing.T) {
 	root := moduleRoot(t)
 	cfgPath := filepath.Join(root, "config", "kustomize", "numaplane-transformer-config.yaml")
@@ -59,6 +61,8 @@ resources:
 - monovertex-rollout.yaml
 - pipeline-rollout.yaml
 - analysis-template.yaml
+- isbservice-rollout.yaml
+- vpa.yaml
 
 images:
 - name: my-registry/pipeline-src
@@ -69,6 +73,9 @@ images:
   newTag: v2
 - name: my-registry/mvtx-sidecar
   newName: other-registry/mvtx-sidecar
+  newTag: v2
+- name: my-registry/mvtx-onsuccess
+  newName: other-registry/mvtx-onsuccess
   newTag: v2
 
 configMapGenerator:
@@ -100,6 +107,10 @@ spec:
         udsink:
           container:
             image: my-registry/mvtx-src:tag
+        onSuccess:
+          udsink:
+            container:
+              image: my-registry/mvtx-onsuccess:tag
       sidecars:
       - name: sidecar
         image: my-registry/mvtx-sidecar:tag
@@ -124,6 +135,7 @@ spec:
         clusterScope: false
   pipeline:
     spec:
+      interStepBufferServiceName: shared-isbsvc
       vertices:
       - name: in
         source:
@@ -132,6 +144,34 @@ spec:
               image: my-registry/pipeline-src:tag
 `
 	if err := os.WriteFile(filepath.Join(tmp, "pipeline-rollout.yaml"), []byte(pl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	isb := `apiVersion: numaplane.numaproj.io/v1alpha1
+kind: ISBServiceRollout
+metadata:
+  name: shared-isbsvc
+spec:
+  interStepBufferService:
+    spec:
+      jetstream:
+        version: latest
+`
+	if err := os.WriteFile(filepath.Join(tmp, "isbservice-rollout.yaml"), []byte(isb), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vpa := `apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: test-vpa
+spec:
+  targetRef:
+    apiVersion: numaplane.numaproj.io/v1alpha1
+    kind: MonoVertexRollout
+    name: test-mvtx
+`
+	if err := os.WriteFile(filepath.Join(tmp, "vpa.yaml"), []byte(vpa), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -162,6 +202,8 @@ spec:
 		"name: test-mvtx-kusttest",
 		"name: test-pipeline-kusttest",
 		"name: shared-analysis-template-kusttest",
+		"name: shared-isbsvc-kusttest",
+		"name: test-vpa-kusttest",
 	} {
 		if !strings.Contains(outputManifest, resourceName) {
 			t.Errorf("expected output to contain %q\n\n%s", resourceName, outputManifest)
@@ -174,6 +216,20 @@ spec:
 		t.Errorf("expected at least two occurrences of %q (MonoVertexRollout + PipelineRollout)\n\n%s", analysisTemplateRef, outputManifest)
 	}
 
+	// nameReference: PipelineRollout's interStepBufferServiceName follows the suffixed ISBServiceRollout name
+	// (spec/pipeline/spec/interStepBufferServiceName)
+	if !strings.Contains(outputManifest, "interStepBufferServiceName: shared-isbsvc-kusttest") {
+		t.Errorf("expected PipelineRollout interStepBufferServiceName to follow renamed ISBServiceRollout\n\n%s", outputManifest)
+	}
+
+	// nameReference: VerticalPodAutoscaler's targetRef/name follows the suffixed MonoVertexRollout name
+	// (spec/targetRef/name on VerticalPodAutoscaler). Match the targetRef block specifically so this
+	// isn't satisfied by the MonoVertexRollout's own (suffixed) metadata.name.
+	const vpaTargetRef = "targetRef:\n    apiVersion: numaplane.numaproj.io/v1alpha1\n    kind: MonoVertexRollout\n    name: test-mvtx-kusttest"
+	if !strings.Contains(outputManifest, vpaTargetRef) {
+		t.Errorf("expected VerticalPodAutoscaler targetRef to follow renamed MonoVertexRollout\n\n%s", outputManifest)
+	}
+
 	// images: transformer config paths for PipelineRollout / MonoVertexRollout
 	if !strings.Contains(outputManifest, "image: other-registry/pipeline-src:v2") {
 		t.Errorf("expected pipeline udsource image rewrite\n\n%s", outputManifest)
@@ -184,6 +240,10 @@ spec:
 	// MonoVertexRollout sidecar image rewrite (spec/monoVertex/spec/sidecars/image)
 	if !strings.Contains(outputManifest, "image: other-registry/mvtx-sidecar:v2") {
 		t.Errorf("expected MonoVertexRollout sidecar image rewrite\n\n%s", outputManifest)
+	}
+	// MonoVertexRollout onSuccess sink image rewrite (spec/monoVertex/spec/sink/onSuccess/udsink/container/image)
+	if !strings.Contains(outputManifest, "image: other-registry/mvtx-onsuccess:v2") {
+		t.Errorf("expected MonoVertexRollout onSuccess sink image rewrite\n\n%s", outputManifest)
 	}
 
 	// nameReference: MonoVertexRollout configMap volume ref follows the suffixed ConfigMap name

--- a/internal/common/numaplane_transformer_kustomize_test.go
+++ b/internal/common/numaplane_transformer_kustomize_test.go
@@ -32,7 +32,8 @@ import (
 // TestNumaplaneTransformerConfigKustomizeBuild ensures
 // config/kustomize/numaplane-transformer-config.yaml is working with kustomize:
 //   - if user adds a nameSuffix or namePrefix, the AnalysisTemplate references in PipelineRollout and MonoVertexRollout must reflect that
-//   - if an image is renamed, the PipelineRollout / MonoVertexRollout image paths must reflect it.
+//   - if user adds a nameSuffix or namePrefix, ConfigMap/Secret references (including MonoVertexRollout volumes) must reflect that
+//   - if an image is renamed, the PipelineRollout / MonoVertexRollout image paths (including MonoVertexRollout sidecars) must reflect it.
 func TestNumaplaneTransformerConfigKustomizeBuild(t *testing.T) {
 	root := moduleRoot(t)
 	cfgPath := filepath.Join(root, "config", "kustomize", "numaplane-transformer-config.yaml")
@@ -66,6 +67,14 @@ images:
 - name: my-registry/mvtx-src
   newName: other-registry/mvtx-src
   newTag: v2
+- name: my-registry/mvtx-sidecar
+  newName: other-registry/mvtx-sidecar
+  newTag: v2
+
+configMapGenerator:
+- name: mvtx-config
+  literals:
+  - foo=bar
 `
 	if err := os.WriteFile(filepath.Join(tmp, "kustomization.yaml"), []byte(kustomization), 0o644); err != nil {
 		t.Fatal(err)
@@ -91,6 +100,13 @@ spec:
         udsink:
           container:
             image: my-registry/mvtx-src:tag
+      sidecars:
+      - name: sidecar
+        image: my-registry/mvtx-sidecar:tag
+      volumes:
+      - name: cfg
+        configMap:
+          name: mvtx-config
 `
 	if err := os.WriteFile(filepath.Join(tmp, "monovertex-rollout.yaml"), []byte(mvr), 0o644); err != nil {
 		t.Fatal(err)
@@ -164,6 +180,17 @@ spec:
 	}
 	if strings.Count(outputManifest, "image: other-registry/mvtx-src:v2") < 2 {
 		t.Errorf("expected MonoVertexRollout udsource and udsink images rewritten (count >= 2)\n\n%s", outputManifest)
+	}
+	// MonoVertexRollout sidecar image rewrite (spec/monoVertex/spec/sidecars/image)
+	if !strings.Contains(outputManifest, "image: other-registry/mvtx-sidecar:v2") {
+		t.Errorf("expected MonoVertexRollout sidecar image rewrite\n\n%s", outputManifest)
+	}
+
+	// nameReference: MonoVertexRollout configMap volume ref follows the suffixed ConfigMap name
+	// (spec/monoVertex/spec/volumes/configMap/name). configMapGenerator appends a content hash,
+	// so match the prefix plus the nameSuffix.
+	if !strings.Contains(outputManifest, "name: mvtx-config-kusttest-") {
+		t.Errorf("expected MonoVertexRollout configMap volume reference to follow renamed ConfigMap\n\n%s", outputManifest)
 	}
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->


### Modifications

I asked Claude to find fields that were missing from the transformer config.

Since there a lot of fields to check manually, I instead performed this in two different steps:
1. Base the new config off of looking at the Numaflow CRDs in latest master
2. Base the new config off of looking at the numaflow-transformer-config.yaml in numaflow repo
Then compare the two and make sure they're the same. 


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward (and forward) incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? What if we had to revert the change? What would happen? (not a showstopper but something to prepare for) -->

