### PR TITLE
fix: don't validate schema against OpenAPI for now due to authentication issue

### DIFF
--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -512,7 +512,11 @@ func (r *NumaflowControllerReconciler) sync(
 	opts := []gitopsSync.SyncOpt{
 		gitopsSync.WithLogr(*numaLogger.LogrLogger),
 		gitopsSync.WithOperationSettings(false, true, true, false),
-		gitopsSync.WithManifestValidation(true),
+		// Temporary: don't perform per-resource validation by hitting OpenAPI due to authentication issue.
+		// OpenAPI schema validation uses a temp kubeconfig in gitops-engine that can fail to
+		// authenticate to /openapi/v2 even when the controller's rest.Config works (e.g. after
+		// cluster auth changes). Equivalent to kubectl apply --validate=false.
+		gitopsSync.WithManifestValidation(false),
 		gitopsSync.WithPruneLast(false),
 		gitopsSync.WithResourceModificationChecker(true, diffResults),
 		gitopsSync.WithReplace(true),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

For some reason, Numaplane is failing to authenticate to Open API server. This is a workaround.


### Verification

<!-- TODO: Say how you tested your changes - manual and/or automated testing (can help for reviewers to see summary here in one place)  -->

### Backward (and forward) incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? What if we had to revert the change? What would happen? (not a showstopper but something to prepare for) -->

