### PR TITLE
fix: don't validate manifests first when syncing through gitops engine

### DIFF
--- a/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
+++ b/internal/controller/numaflowcontroller/numaflowcontroller_controller.go
@@ -512,7 +512,7 @@ func (r *NumaflowControllerReconciler) sync(
 	opts := []gitopsSync.SyncOpt{
 		gitopsSync.WithLogr(*numaLogger.LogrLogger),
 		gitopsSync.WithOperationSettings(false, true, true, false),
-		gitopsSync.WithManifestValidation(true),
+		gitopsSync.WithManifestValidation(false),
 		gitopsSync.WithPruneLast(false),
 		gitopsSync.WithResourceModificationChecker(true, diffResults),
 		gitopsSync.WithReplace(true),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

### Modifications

This is to fix the problem that despite upgrading kubectl to 0.34 [here](https://github.com/numaproj/numaplane/pull/998/changes#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6), we are still facing the error "Adding resource result, status: 'SyncFailed', phase: 'Failed', message: 'error validating data: failed to download openapi: the server has asked for the client to provide credentials'"


