### PR TITLE
fix: force gitops-engine to use BearerTokenFile rather than BearerToken (cached file) for authenticating to Kubernetes API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
 	k8s.io/code-generator v0.34.0
+	k8s.io/kubectl v0.34.0
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.22.4
 	sigs.k8s.io/controller-tools v0.16.4
@@ -177,7 +178,6 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-aggregator v0.34.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
-	k8s.io/kubectl v0.34.0 // indirect
 	k8s.io/kubernetes v1.34.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/util/kubernetes/kubectl.go
+++ b/internal/util/kubernetes/kubectl.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube"
 	"github.com/argoproj/argo-cd/gitops-engine/pkg/utils/tracing"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/util/openapi"
 
 	"github.com/numaproj/numaplane/internal/util/logger"
 )
@@ -17,6 +19,16 @@ func init() {
 	}
 }
 
+type kubectlCmd struct {
+	*kube.KubectlCmd
+}
+
+func (k *kubectlCmd) ManageResources(config *rest.Config, openAPISchema openapi.Resources) (kube.ResourceOperations, func(), error) {
+	return k.KubectlCmd.ManageResources(RestConfigForTempKubeconfig(config), openAPISchema)
+}
+
 func NewKubectl() kube.Kubectl {
-	return &kube.KubectlCmd{Tracer: tracer, Log: *logger.New().LogrLogger}
+	return &kubectlCmd{
+		KubectlCmd: &kube.KubectlCmd{Tracer: tracer, Log: *logger.New().LogrLogger},
+	}
 }

--- a/internal/util/kubernetes/restconfig.go
+++ b/internal/util/kubernetes/restconfig.go
@@ -1,0 +1,26 @@
+package kubernetes
+
+import (
+	"k8s.io/client-go/rest"
+)
+
+const inClusterServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+// RestConfigForTempKubeconfig returns a copy of config for gitops-engine's temp kubeconfig.
+//
+// gitops-engine WriteKubeConfig copies rest.Config.BearerToken into the kubeconfig as a static
+// token. client-go refreshes credentials from BearerTokenFile on each request, but kubectl
+// subprocesses use only what is written to the kubeconfig. After a projected service account
+// token rotates, the static token goes stale while the main controller client keeps working.
+//
+// When BearerTokenFile is set, drop the startup BearerToken snapshot so WriteKubeConfig falls
+// back to tokenFile in the generated kubeconfig (the standard in-cluster path for pods).
+func RestConfigForTempKubeconfig(config *rest.Config) *rest.Config {
+	if config == nil || config.BearerTokenFile == "" {
+		return config
+	}
+
+	copied := rest.CopyConfig(config)
+	copied.BearerToken = ""
+	return copied
+}

--- a/internal/util/kubernetes/restconfig_test.go
+++ b/internal/util/kubernetes/restconfig_test.go
@@ -1,0 +1,61 @@
+package kubernetes
+
+import (
+	"testing"
+
+	gitopskube "github.com/argoproj/argo-cd/gitops-engine/pkg/utils/kube"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestRestConfigForTempKubeconfig(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		assert.Nil(t, RestConfigForTempKubeconfig(nil))
+	})
+
+	t.Run("no token file", func(t *testing.T) {
+		cfg := &rest.Config{BearerToken: "static-token"}
+		assert.Equal(t, cfg, RestConfigForTempKubeconfig(cfg))
+	})
+
+	t.Run("token file clears stale bearer token", func(t *testing.T) {
+		cfg := &rest.Config{
+			Host:            "https://kubernetes.default.svc",
+			BearerToken:     "stale-token",
+			BearerTokenFile: inClusterServiceAccountTokenPath,
+		}
+
+		sanitized := RestConfigForTempKubeconfig(cfg)
+		require.NotSame(t, cfg, sanitized)
+		assert.Empty(t, sanitized.BearerToken)
+		assert.Equal(t, inClusterServiceAccountTokenPath, sanitized.BearerTokenFile)
+
+		kubeConfig := gitopskube.NewKubeConfig(sanitized, "")
+		authInfo := kubeConfig.AuthInfos[kubeConfig.CurrentContext]
+		assert.Empty(t, authInfo.Token)
+		assert.Equal(t, inClusterServiceAccountTokenPath, authInfo.TokenFile)
+	})
+
+	t.Run("original config unchanged", func(t *testing.T) {
+		cfg := &rest.Config{
+			BearerToken:     "stale-token",
+			BearerTokenFile: inClusterServiceAccountTokenPath,
+		}
+
+		_ = RestConfigForTempKubeconfig(cfg)
+		assert.Equal(t, "stale-token", cfg.BearerToken)
+	})
+
+	t.Run("static bearer token without file is written to kubeconfig", func(t *testing.T) {
+		cfg := &rest.Config{
+			Host:        "https://kubernetes.default.svc",
+			BearerToken: "static-token",
+		}
+
+		kubeConfig := gitopskube.NewKubeConfig(cfg, "")
+		authInfo := kubeConfig.AuthInfos[kubeConfig.CurrentContext]
+		assert.Equal(t, "static-token", authInfo.Token)
+		assert.Empty(t, authInfo.TokenFile)
+	})
+}


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

Fixes error failing to authenticate to Kubernetes API.

Issue appears to be seen when there is ServiceAccount token rotation happening on the cluster. 

**Background:** 
So, in Kubernetes, there is a token (associated with the ServiceAccount) provided by kubelet to every Pod for it to authenticate to Kubernetes API. This token rotates once an hour. It is provided by kubelet in the form of a file named `/var/run/secrets/kubernetes.io/serviceaccount/token`.
(When a pod starts, the kubelet automatically add a volume and mount so that it can update this file.)

In the gitops-engine code (from ArgoCD) which Numaplane uses, it caches the value of this file in memory when the Pod starts. So, when the token rotates after an hour, it's now using the old cached value.

The fix is to clear that cached value in the Kube restConfig which is passed to gitops-engine each time it does a sync so that it will be forced instead to look at the latest and greatest file value instead.

### Verification

e2e tests

### Backward (and forward) incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? What if we had to revert the change? What would happen? (not a showstopper but something to prepare for) -->

