### PR TITLE
fix: a force draining pipeline shouldn't switch its isbsvc

### DIFF
--- a/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
@@ -33,7 +33,7 @@ spec:
           source:
             # A self data generating source
             generator:
-              rpu: 5000
+              rpu: 500
               duration: 1s
         - name: cat
           scale: 

--- a/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
+++ b/config/samples/numaplane.numaproj.io_v1alpha1_pipelinerollout.yaml
@@ -33,7 +33,7 @@ spec:
           source:
             # A self data generating source
             generator:
-              rpu: 500
+              rpu: 5000
               duration: 1s
         - name: cat
           scale: 

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -191,9 +191,9 @@ const (
 	// (this only applies for recyclable pipelines)
 	AnnotationKeyMarkedForDeletion = KeyNumaplanePrefix + "marked-for-deletion"
 
-	// AnnotationKeyForceDrainFailureStartTime is annotated on a pipeline when it is marked as failed due to force drain
+	// AnnotationKeyDrainFailureStartTime is annotated on a recyclable pipeline when it is marked as failed while draining
 	// This is used to check for transient vs persistent failures to know if we can stop trying to drain
-	AnnotationKeyForceDrainFailureStartTime = KeyNumaplanePrefix + "force-drain-failure-start-time"
+	AnnotationKeyDrainFailureStartTime = KeyNumaplanePrefix + "drain-failure-start-time"
 
 	// AnnotationKeyRecyclableStartTime is annotated on a pipeline when it is marked as recyclable
 	AnnotationKeyRecyclableStartTime = KeyNumaplanePrefix + "recyclable-start-time"

--- a/internal/controller/common/rollout_controller.go
+++ b/internal/controller/common/rollout_controller.go
@@ -174,10 +174,7 @@ func MarkRecyclable(ctx context.Context, c client.Client, upgradeStateReason *co
 	if err != nil {
 		return err
 	}
-	// patch the annotation to mark the time when the resource was first marked as recyclable
-	// only set it if it's not already present: this function may be called on every reconciliation for an
-	// already-recyclable child (e.g. a pipeline whose isbsvc is recyclable), and re-stamping would reset the
-	// expiration clock used by isRecycledPipelineExpired, so the resource could never expire.
+
 	if childObject.GetAnnotations()[common.AnnotationKeyRecyclableStartTime] != "" {
 		return nil
 	}

--- a/internal/controller/common/rollout_controller.go
+++ b/internal/controller/common/rollout_controller.go
@@ -174,7 +174,13 @@ func MarkRecyclable(ctx context.Context, c client.Client, upgradeStateReason *co
 	if err != nil {
 		return err
 	}
-	// patch the annotation to mark the time when the resource was marked as recyclable
+	// patch the annotation to mark the time when the resource was first marked as recyclable
+	// only set it if it's not already present: this function may be called on every reconciliation for an
+	// already-recyclable child (e.g. a pipeline whose isbsvc is recyclable), and re-stamping would reset the
+	// expiration clock used by isRecycledPipelineExpired, so the resource could never expire.
+	if childObject.GetAnnotations()[common.AnnotationKeyRecyclableStartTime] != "" {
+		return nil
+	}
 	return kubernetes.SetAndPatchAnnotations(ctx, c, childObject, map[string]string{
 		common.AnnotationKeyRecyclableStartTime: time.Now().Format(time.RFC3339),
 	})

--- a/internal/controller/pipelinerollout/pipelinerollout_recycle.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_recycle.go
@@ -702,6 +702,8 @@ func markPipelineForceDrainStarted(ctx context.Context, c client.Client, pipelin
 	}); err != nil {
 		return err
 	}
+	// just in case a previous drain had a state in which the Pipeline was "failed", we clear that time so we can reuse the annotation from scratch
+	// if we need to
 	return clearDrainFailureStartTimeAnnotation(ctx, c, pipeline)
 }
 

--- a/internal/controller/pipelinerollout/pipelinerollout_recycle.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_recycle.go
@@ -311,7 +311,7 @@ func (r *PipelineRolloutReconciler) checkForFailedPipeline(ctx context.Context, 
 	// check if we've waited long enough
 	startTime, err := time.Parse(time.RFC3339, pipeline.GetAnnotations()[common.AnnotationKeyDrainFailureStartTime])
 	if err != nil {
-		return false, fmt.Errorf("failed to parse drain failure start time annotation %q on pipeline %s/%s: %w", startTime, pipeline.GetNamespace(), pipeline.GetName(), err)
+		return false, fmt.Errorf("failed to parse drain failure start time annotation %q on pipeline %s/%s: %w", pipeline.GetAnnotations()[common.AnnotationKeyDrainFailureStartTime], pipeline.GetNamespace(), pipeline.GetName(), err)
 	}
 	waitDurationSeconds := config.GetForceDrainFailureWaitDuration()
 	if int32(currentTime.Sub(startTime).Seconds()) < waitDurationSeconds {

--- a/internal/controller/pipelinerollout/pipelinerollout_recycle.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_recycle.go
@@ -136,7 +136,15 @@ func (r *PipelineRolloutReconciler) Recycle(
 			} // else implicitly fall through to force draining
 
 		} else if failed {
-			numaLogger.Debug("Pipeline is in Failed phase; will force drain") // fall through to force draining
+			nonTransientFailure, err := r.checkForFailedPipeline(ctx, pipeline)
+			if err != nil {
+				return false, fmt.Errorf("failed to check for failed pipeline %s/%s: %w", pipeline.GetNamespace(), pipeline.GetName(), err)
+			}
+			if !nonTransientFailure {
+				numaLogger.Debug("Pipeline is in Failed phase; waiting before force drain")
+				return false, nil
+			}
+			numaLogger.Debug("Pipeline has been in Failed phase for a period of time; will force drain") // fall through to force draining
 		} else {
 			return false, nil
 		}
@@ -274,8 +282,6 @@ func (r *PipelineRolloutReconciler) forceDrain(ctx context.Context,
 			currentVal, _ := kubernetes.GetAnnotation(pipeline, common.AnnotationKeyForceDrainSpecsCompleted)
 			err := kubernetes.SetAndPatchAnnotations(ctx, r.client, pipeline, map[string]string{
 				common.AnnotationKeyForceDrainSpecsCompleted: currentVal + promotedPipeline.GetName() + ",",
-				// reset this so we won't try to look at it on the next force drain attempt
-				common.AnnotationKeyForceDrainFailureStartTime: "",
 			})
 			return false, err
 		}
@@ -285,7 +291,7 @@ func (r *PipelineRolloutReconciler) forceDrain(ctx context.Context,
 }
 
 // check if the Pipeline has been in Failed state for long enough to consider it a permanent failure
-// if so, delete it; otherwise, return false to indicate we haven't deleted it yet.
+// if so, return true; otherwise, return false to indicate we should keep waiting.
 // decision: just use original failure start time in the case of Pipeline switching Failed->Running->Failed
 func (r *PipelineRolloutReconciler) checkForFailedPipeline(ctx context.Context, pipeline *unstructured.Unstructured) (bool, error) {
 
@@ -293,26 +299,26 @@ func (r *PipelineRolloutReconciler) checkForFailedPipeline(ctx context.Context, 
 	currentTime := time.Now()
 
 	// the first time we detect failure, mark the time
-	if pipeline.GetAnnotations()[common.AnnotationKeyForceDrainFailureStartTime] == "" {
+	if pipeline.GetAnnotations()[common.AnnotationKeyDrainFailureStartTime] == "" {
 		if err := kubernetes.SetAndPatchAnnotations(ctx, r.client, pipeline, map[string]string{
-			common.AnnotationKeyForceDrainFailureStartTime: currentTime.Format(time.RFC3339),
+			common.AnnotationKeyDrainFailureStartTime: currentTime.Format(time.RFC3339),
 		}); err != nil {
-			return false, fmt.Errorf("failed to set force drain failure start time annotation on pipeline %s/%s: %w", pipeline.GetNamespace(), pipeline.GetName(), err)
+			return false, fmt.Errorf("failed to set drain failure start time annotation on pipeline %s/%s: %w", pipeline.GetNamespace(), pipeline.GetName(), err)
 		}
 		return false, nil
 	}
 
 	// check if we've waited long enough
-	startTime, err := time.Parse(time.RFC3339, pipeline.GetAnnotations()[common.AnnotationKeyForceDrainFailureStartTime])
+	startTime, err := time.Parse(time.RFC3339, pipeline.GetAnnotations()[common.AnnotationKeyDrainFailureStartTime])
 	if err != nil {
-		return false, fmt.Errorf("failed to parse force drain failure start time annotation %q on pipeline %s/%s: %w", startTime, pipeline.GetNamespace(), pipeline.GetName(), err)
+		return false, fmt.Errorf("failed to parse drain failure start time annotation %q on pipeline %s/%s: %w", startTime, pipeline.GetNamespace(), pipeline.GetName(), err)
 	}
 	waitDurationSeconds := config.GetForceDrainFailureWaitDuration()
 	if int32(currentTime.Sub(startTime).Seconds()) < waitDurationSeconds {
-		numaLogger.WithValues("startTime", startTime, "currentTime", currentTime, "waitDuration", waitDurationSeconds).Debug("waiting longer before deleting failed pipeline during force drain")
+		numaLogger.WithValues("startTime", startTime, "currentTime", currentTime, "waitDuration", waitDurationSeconds).Debug("waiting longer before giving up on drain due to failed pipeline")
 		return false, nil
 	} else {
-		numaLogger.Infof("Pipeline has the promoted pipeline's spec and has failed, drain attempt is complete, pipeline definition: %v", kubernetes.GetLoggableResource(pipeline))
+		numaLogger.Infof("Pipeline has failed for long enough, giving up on current drain attempt, pipeline definition: %v", kubernetes.GetLoggableResource(pipeline))
 		return true, err
 	}
 }
@@ -672,6 +678,16 @@ func checkUserDesiresPause(ctx context.Context, pipelineRollout *apiv1.PipelineR
 	return false, nil
 }
 
+// clearDrainFailureStartTimeAnnotation resets the failure timer when starting a new force drain attempt, just in case it's set
+func clearDrainFailureStartTimeAnnotation(ctx context.Context, c client.Client, pipeline *unstructured.Unstructured) error {
+	if pipeline.GetAnnotations()[common.AnnotationKeyDrainFailureStartTime] == "" {
+		return nil
+	}
+	return kubernetes.SetAndPatchAnnotations(ctx, c, pipeline, map[string]string{
+		common.AnnotationKeyDrainFailureStartTime: "",
+	})
+}
+
 // update the Pipeline's annotation to mark that a new pipeline's spec has been used to update the pipeline
 func markPipelineForceDrainStarted(ctx context.Context, c client.Client, pipeline *unstructured.Unstructured, forceDrainSpecPipeline string) error {
 	// first check if it's already marked in which case we'll skip this
@@ -681,9 +697,12 @@ func markPipelineForceDrainStarted(ctx context.Context, c client.Client, pipelin
 	currentVal, _ := kubernetes.GetAnnotation(pipeline, common.AnnotationKeyForceDrainSpecsStarted)
 
 	// Patch in Kubernetes
-	return kubernetes.SetAndPatchAnnotations(ctx, c, pipeline, map[string]string{
+	if err := kubernetes.SetAndPatchAnnotations(ctx, c, pipeline, map[string]string{
 		common.AnnotationKeyForceDrainSpecsStarted: currentVal + forceDrainSpecPipeline + ",",
-	})
+	}); err != nil {
+		return err
+	}
+	return clearDrainFailureStartTimeAnnotation(ctx, c, pipeline)
 }
 
 // update the Pipeline's annotation to mark that a new pipeline's spec has been used to update the pipeline

--- a/internal/controller/pipelinerollout/pipelinerollout_recycle.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_recycle.go
@@ -340,22 +340,41 @@ func (r *PipelineRolloutReconciler) checkForPromotedPipelineForForceDrain(ctx co
 	}
 }
 
+// getForceAppliedSpec returns a copy of newPipeline with the transformations needed for force draining:
+// source vertices scaled to zero, ISBService name preserved from currentPipeline, and desiredPhase set to Running.
+func getForceAppliedSpec(ctx context.Context, currentPipeline, newPipelineSpec *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	forceAppliedPipelineSpec := newPipelineSpec.DeepCopy()
+
+	err := numaflowtypes.ScalePipelineDefSourceVerticesToZero(ctx, forceAppliedPipelineSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	// Preserve the current pipeline's ISBService name so we don't change it during force drain (a Pipeline cannot have its ISBService changed or it won't work)
+	currentISBSvcName, err := numaflowtypes.GetPipelineISBSVCName(currentPipeline)
+	if err != nil {
+		return nil, err
+	}
+	if err := numaflowtypes.PipelineWithISBServiceName(forceAppliedPipelineSpec, currentISBSvcName); err != nil {
+		return nil, err
+	}
+
+	// Set the desiredPhase to Running just in case it isn't (we need to take it out of Paused state if it's in it to give it a chance to pause again)
+	err = unstructured.SetNestedField(forceAppliedPipelineSpec.Object, string(numaflowv1.PipelinePhaseRunning), "spec", "lifecycle", "desiredPhase")
+	if err != nil {
+		return nil, err
+	}
+
+	return forceAppliedPipelineSpec, nil
+}
+
 // Update the pipeline to the new spec with min=max=0 initially and set to desiredPhase=Running
 // (it will be set to Paused later)
 // currentPipeline: the pipeline that will be updated
 // newPipeline: spec from the new pipeline which will be applied
 func forceApplySpecOnUndrainablePipeline(ctx context.Context, currentPipeline, newPipeline *unstructured.Unstructured, c client.Client) error {
 	numaLogger := logger.FromContext(ctx)
-	// take the newPipeline Spec, make a copy, and set any sources to min=max=0
-	newPipelineCopy := newPipeline.DeepCopy()
-	err := numaflowtypes.ScalePipelineDefSourceVerticesToZero(ctx, newPipelineCopy)
-	if err != nil {
-		return err
-	}
-
-	// Set the desiredPhase to Running just in case it isn't (we need to make to take it out of Paused state if it's in it to give it a chance to pause again)
-	// and set the "overridden-spec" annotation to indicate that we've applied over top the original
-	err = unstructured.SetNestedField(newPipelineCopy.Object, string(numaflowv1.PipelinePhaseRunning), "spec", "lifecycle", "desiredPhase")
+	forceAppliedPipeline, err := getForceAppliedSpec(ctx, currentPipeline, newPipeline)
 	if err != nil {
 		return err
 	}
@@ -365,7 +384,7 @@ func forceApplySpecOnUndrainablePipeline(ctx context.Context, currentPipeline, n
 	// Create a strategic merge patch by comparing the current pipeline with the new pipeline copy
 	// We need to extract just the fields we want to update: spec, metadata.annotations
 	patchData := map[string]interface{}{
-		"spec": newPipelineCopy.Object["spec"], // we assume we're the only ones who write to the Spec; therefore it's okay to copy the entire thing and use it knowing that nobody else has changed it
+		"spec": forceAppliedPipeline.Object["spec"], // we assume we're the only ones who write to the Spec; therefore it's okay to copy the entire thing and use it knowing that nobody else has changed it
 	}
 
 	// Convert patch data to JSON

--- a/internal/controller/pipelinerollout/pipelinerollout_recycle_test.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_recycle_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/numaproj/numaplane/internal/common"
 	ctlrcommon "github.com/numaproj/numaplane/internal/controller/common"
+	"github.com/numaproj/numaplane/internal/controller/common/numaflowtypes"
 	"github.com/numaproj/numaplane/internal/controller/config"
 	"github.com/numaproj/numaplane/internal/util"
 	"github.com/numaproj/numaplane/internal/util/kubernetes"
@@ -297,6 +298,154 @@ func Test_calculateScaleForRecycle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_getForceAppliedSpec(t *testing.T) {
+	ctx := context.Background()
+
+	zero := int32(0)
+
+	tests := []struct {
+		name                  string
+		currentPipelineISBSvc string
+		newPipelineISBSvc     string
+		newPipelineLifecycle  *numaflowv1.Lifecycle
+		expectError           bool
+		expectedISBSvcName    string
+	}{
+		{
+			name:                  "preserves current pipeline ISBService name",
+			currentPipelineISBSvc: "current-isbsvc",
+			newPipelineISBSvc:     "new-isbsvc",
+			newPipelineLifecycle:  &numaflowv1.Lifecycle{DesiredPhase: numaflowv1.PipelinePhasePaused},
+			expectedISBSvcName:    "current-isbsvc",
+		},
+		{
+			name:                  "uses default ISBService name when current pipeline has none set",
+			currentPipelineISBSvc: "",
+			newPipelineISBSvc:     "new-isbsvc",
+			newPipelineLifecycle:  &numaflowv1.Lifecycle{DesiredPhase: numaflowv1.PipelinePhaseRunning},
+			expectedISBSvcName:    "default",
+		},
+		{
+			name:                  "sets desiredPhase to Running when new pipeline lifecycle is unset",
+			currentPipelineISBSvc: "current-isbsvc",
+			newPipelineISBSvc:     "new-isbsvc",
+			newPipelineLifecycle:  nil,
+			expectedISBSvcName:    "current-isbsvc",
+		},
+		{
+			name:                  "sets desiredPhase to Running when new pipeline is already Running",
+			currentPipelineISBSvc: "shared-isbsvc",
+			newPipelineISBSvc:     "shared-isbsvc",
+			newPipelineLifecycle:  &numaflowv1.Lifecycle{DesiredPhase: numaflowv1.PipelinePhaseRunning},
+			expectedISBSvcName:    "shared-isbsvc",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			currentPipeline := pipelineUnstructuredForForceAppliedSpecTest(
+				"current", tc.currentPipelineISBSvc, &numaflowv1.Lifecycle{DesiredPhase: numaflowv1.PipelinePhasePaused},
+			)
+			newPipeline := pipelineUnstructuredForForceAppliedSpecTest(
+				"new", tc.newPipelineISBSvc, tc.newPipelineLifecycle,
+			)
+			newPipelineBefore := newPipeline.DeepCopy()
+
+			result, err := getForceAppliedSpec(ctx, currentPipeline, newPipeline)
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			isbsvcName, err := numaflowtypes.GetPipelineISBSVCName(result)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedISBSvcName, isbsvcName)
+
+			desiredPhase, err := numaflowtypes.GetPipelineDesiredPhase(result)
+			assert.NoError(t, err)
+			assert.Equal(t, string(numaflowv1.PipelinePhaseRunning), desiredPhase)
+
+			var pipelineSpec numaflowv1.Pipeline
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(result.Object, &pipelineSpec)
+			assert.NoError(t, err)
+
+			for _, vertex := range pipelineSpec.Spec.Vertices {
+				if vertex.Source != nil {
+					assert.NotNil(t, vertex.Scale.Min)
+					assert.NotNil(t, vertex.Scale.Max)
+					assert.Equal(t, zero, *vertex.Scale.Min)
+					assert.Equal(t, zero, *vertex.Scale.Max)
+				}
+			}
+
+			for _, vertex := range pipelineSpec.Spec.Vertices {
+				if vertex.Sink != nil {
+					assert.NotNil(t, vertex.Scale.Min)
+					assert.NotNil(t, vertex.Scale.Max)
+					assert.Equal(t, int32(2), *vertex.Scale.Min)
+					assert.Equal(t, int32(5), *vertex.Scale.Max)
+				}
+			}
+
+			assert.Equal(t, newPipelineBefore.Object, newPipeline.Object)
+		})
+	}
+}
+
+func pipelineUnstructuredForForceAppliedSpecTest(name, isbsvcName string, lifecycle *numaflowv1.Lifecycle) *unstructured.Unstructured {
+	vertices := []numaflowv1.AbstractVertex{
+		{
+			Name: "in",
+			Source: &numaflowv1.Source{
+				Generator: &numaflowv1.GeneratorSource{},
+			},
+			Scale: numaflowv1.Scale{
+				Min: int32Ptr(3),
+				Max: int32Ptr(6),
+			},
+		},
+		{
+			Name: "out",
+			Sink: &numaflowv1.Sink{
+				AbstractSink: numaflowv1.AbstractSink{
+					Log: &numaflowv1.Log{},
+				},
+			},
+			Scale: numaflowv1.Scale{
+				Min: int32Ptr(2),
+				Max: int32Ptr(5),
+			},
+		},
+	}
+
+	spec := numaflowv1.PipelineSpec{
+		InterStepBufferServiceName: isbsvcName,
+		Vertices:                   vertices,
+	}
+	if lifecycle != nil {
+		spec.Lifecycle = *lifecycle
+	}
+
+	pipeline := &numaflowv1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ctlrcommon.DefaultTestNamespace,
+		},
+		Spec: spec,
+	}
+
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(pipeline)
+	if err != nil {
+		panic(err)
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func int32Ptr(i int32) *int32 {
+	return &i
 }
 
 // Test_Recycle tests the Recycle function with various input scenarios

--- a/internal/controller/pipelinerollout/pipelinerollout_recycle_test.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_recycle_test.go
@@ -542,6 +542,8 @@ func Test_Recycle(t *testing.T) {
 		expectedVertexScaleDefinitions []apiv1.VertexScaleDefinition
 		// expected whether the force drain failure time annotation is set
 		expectForceDrainFailureTimeSet bool
+		// expected whether force drain has started (only asserts when true)
+		expectForceDrainStarted bool
 	}{
 		{
 			name:               "Delete/Recreate - should delete immediately",
@@ -550,6 +552,15 @@ func Test_Recycle(t *testing.T) {
 			pipelinePhase:      numaflowv1.PipelinePhaseRunning,
 			expectedDeleted:    true, // Delete recreate should delete immediately
 			expectedError:      false,
+		},
+		{
+			name:                              "Progressive Replace - original drain failed, wait before force drain",
+			upgradeStateReason:                string(common.LabelValueProgressiveReplaced),
+			requiresDrain:                     true,
+			desiredPhase:                      &paused,
+			pipelinePhase:                     failed,
+			isPromotedPipelineNew:             true,
+			expectForceDrainFailureTimeSet:    true,
 		},
 		{
 			name:                              "Progressive Replace - second attempt (force drain caused pipeline to have phase=Failed)",
@@ -827,7 +838,13 @@ func Test_Recycle(t *testing.T) {
 
 				// Verify if the force drain failure time annotation is set
 				if tc.expectForceDrainFailureTimeSet {
-					assert.Contains(t, updatedPipeline.Annotations, common.AnnotationKeyForceDrainFailureStartTime)
+					assert.Contains(t, updatedPipeline.Annotations, common.AnnotationKeyDrainFailureStartTime)
+				}
+
+				if tc.expectForceDrainStarted {
+					assert.Contains(t, updatedPipeline.Annotations, common.AnnotationKeyForceDrainSpecsStarted)
+				} else if tc.expectForceDrainFailureTimeSet && tc.initialForceDrainPipelinesStarted == "" {
+					assert.NotContains(t, updatedPipeline.Annotations, common.AnnotationKeyForceDrainSpecsStarted)
 				}
 
 				// Check if force-drain-specs-started annotation matches expected value
@@ -871,6 +888,33 @@ func Test_Recycle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_markPipelineForceDrainStarted_clearsForceDrainFailureStartTime(t *testing.T) {
+	ctx := context.Background()
+
+	pipeline := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "numaflow.numaproj.io/v1alpha1",
+			"kind":       "Pipeline",
+			"metadata": map[string]interface{}{
+				"name":      "test-pipeline",
+				"namespace": ctlrcommon.DefaultTestNamespace,
+			},
+		},
+	}
+	pipeline.SetGroupVersionKind(numaflowv1.PipelineGroupVersionKind)
+	pipeline.SetAnnotations(map[string]string{
+		common.AnnotationKeyDrainFailureStartTime: time.Now().Add(-2 * time.Hour).Format(time.RFC3339),
+	})
+
+	scheme := runtime.NewScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pipeline).Build()
+
+	err := markPipelineForceDrainStarted(ctx, fakeClient, pipeline, "promoted-pipeline-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "promoted-pipeline-1,", pipeline.GetAnnotations()[common.AnnotationKeyForceDrainSpecsStarted])
+	assert.Empty(t, pipeline.GetAnnotations()[common.AnnotationKeyDrainFailureStartTime])
 }
 
 func Test_checkForValueInCommaDelimitedAnnotation(t *testing.T) {

--- a/internal/controller/pipelinerollout/pipelinerollout_recycle_test.go
+++ b/internal/controller/pipelinerollout/pipelinerollout_recycle_test.go
@@ -542,8 +542,6 @@ func Test_Recycle(t *testing.T) {
 		expectedVertexScaleDefinitions []apiv1.VertexScaleDefinition
 		// expected whether the force drain failure time annotation is set
 		expectForceDrainFailureTimeSet bool
-		// expected whether force drain has started (only asserts when true)
-		expectForceDrainStarted bool
 	}{
 		{
 			name:               "Delete/Recreate - should delete immediately",
@@ -554,13 +552,13 @@ func Test_Recycle(t *testing.T) {
 			expectedError:      false,
 		},
 		{
-			name:                              "Progressive Replace - original drain failed, wait before force drain",
-			upgradeStateReason:                string(common.LabelValueProgressiveReplaced),
-			requiresDrain:                     true,
-			desiredPhase:                      &paused,
-			pipelinePhase:                     failed,
-			isPromotedPipelineNew:             true,
-			expectForceDrainFailureTimeSet:    true,
+			name:                           "Progressive Replace - original drain failed, wait before force drain",
+			upgradeStateReason:             string(common.LabelValueProgressiveReplaced),
+			requiresDrain:                  true,
+			desiredPhase:                   &paused,
+			pipelinePhase:                  failed,
+			isPromotedPipelineNew:          true,
+			expectForceDrainFailureTimeSet: true,
 		},
 		{
 			name:                              "Progressive Replace - second attempt (force drain caused pipeline to have phase=Failed)",
@@ -841,12 +839,6 @@ func Test_Recycle(t *testing.T) {
 					assert.Contains(t, updatedPipeline.Annotations, common.AnnotationKeyDrainFailureStartTime)
 				}
 
-				if tc.expectForceDrainStarted {
-					assert.Contains(t, updatedPipeline.Annotations, common.AnnotationKeyForceDrainSpecsStarted)
-				} else if tc.expectForceDrainFailureTimeSet && tc.initialForceDrainPipelinesStarted == "" {
-					assert.NotContains(t, updatedPipeline.Annotations, common.AnnotationKeyForceDrainSpecsStarted)
-				}
-
 				// Check if force-drain-specs-started annotation matches expected value
 				if tc.expectForceDrainPipelinesStarted != "" {
 					assert.Contains(t, updatedPipeline.Annotations, common.AnnotationKeyForceDrainSpecsStarted)
@@ -915,6 +907,73 @@ func Test_markPipelineForceDrainStarted_clearsForceDrainFailureStartTime(t *test
 	assert.NoError(t, err)
 	assert.Equal(t, "promoted-pipeline-1,", pipeline.GetAnnotations()[common.AnnotationKeyForceDrainSpecsStarted])
 	assert.Empty(t, pipeline.GetAnnotations()[common.AnnotationKeyDrainFailureStartTime])
+}
+
+func Test_checkForFailedPipeline(t *testing.T) {
+	ctx := context.Background()
+	waitDuration := time.Duration(config.GetForceDrainFailureWaitDuration()) * time.Second
+	withinWait := waitDuration - time.Second
+	pastWait := waitDuration + time.Second
+
+	tests := []struct {
+		name                      string
+		failureStartTimeAgo       *time.Duration // nil = no annotation (first failure detection)
+		expectNonTransientFailure bool
+		expectAnnotationSet       bool
+	}{
+		{
+			name:                "first failure sets start time and waits",
+			expectAnnotationSet: true,
+		},
+		{
+			name:                "failure within wait duration",
+			failureStartTimeAgo: &withinWait,
+		},
+		{
+			name:                      "failure past wait duration",
+			failureStartTimeAgo:       &pastWait,
+			expectNonTransientFailure: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pipeline := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "numaflow.numaproj.io/v1alpha1",
+					"kind":       "Pipeline",
+					"metadata": map[string]interface{}{
+						"name":      "test-pipeline",
+						"namespace": ctlrcommon.DefaultTestNamespace,
+					},
+				},
+			}
+			pipeline.SetGroupVersionKind(numaflowv1.PipelineGroupVersionKind)
+
+			if tc.failureStartTimeAgo != nil {
+				pipeline.SetAnnotations(map[string]string{
+					common.AnnotationKeyDrainFailureStartTime: time.Now().Add(-*tc.failureStartTimeAgo).Format(time.RFC3339),
+				})
+			}
+
+			scheme := runtime.NewScheme()
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pipeline).Build()
+			reconciler := &PipelineRolloutReconciler{
+				client:        fakeClient,
+				customMetrics: createTestMetrics(),
+				recorder:      record.NewFakeRecorder(100),
+			}
+
+			nonTransientFailure, err := reconciler.checkForFailedPipeline(ctx, pipeline)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectNonTransientFailure, nonTransientFailure)
+
+			if tc.expectAnnotationSet {
+				assert.NotEmpty(t, pipeline.GetAnnotations()[common.AnnotationKeyDrainFailureStartTime])
+			}
+		})
+	}
 }
 
 func Test_checkForValueInCommaDelimitedAnnotation(t *testing.T) {

--- a/tests/e2e/isbservice.go
+++ b/tests/e2e/isbservice.go
@@ -616,6 +616,37 @@ func VerifyISBServiceDeletion(isbsvcName string) {
 	}).WithTimeout(DefaultTestTimeout).Should(BeTrue(), fmt.Sprintf("The InterstepBufferService %s/%s should have been deleted but it was found.", Namespace, isbsvcName))
 }
 
+// VerifyISBServiceUpgradeState verifies that an InterstepBufferService has the expected upgrade state label and optionally the upgrade state reason label
+func VerifyISBServiceUpgradeState(namespace, isbsvcName, upgradeState string, upgradeStateReason *string) {
+	CheckEventually(fmt.Sprintf("verifying InterstepBufferService %s has upgrade state %s", isbsvcName, upgradeState), func() bool {
+		isbsvc, err := dynamicClient.Resource(GetGVRForISBService()).Namespace(namespace).Get(ctx, isbsvcName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		labels := isbsvc.GetLabels()
+		if labels == nil {
+			return false
+		}
+
+		// Check upgrade state label
+		actualUpgradeState, found := labels[common.LabelKeyUpgradeState]
+		if !found || actualUpgradeState != upgradeState {
+			return false
+		}
+
+		// If upgradeStateReason is provided, check it as well
+		if upgradeStateReason != nil {
+			actualUpgradeStateReason, found := labels[common.LabelKeyUpgradeStateReason]
+			if !found || actualUpgradeStateReason != *upgradeStateReason {
+				return false
+			}
+		}
+
+		return true
+	}).Should(BeTrue())
+}
+
 func VerifyISBServiceProgressiveFailure(isbsvcRolloutName string, promotedISBSvcName string, upgradingISBSvcName string) {
 	VerifyISBServiceRolloutProgressiveStatus(isbsvcRolloutName, promotedISBSvcName, upgradingISBSvcName, apiv1.AssessmentResultFailure)
 	VerifyISBServiceRolloutProgressiveCondition(isbsvcRolloutName, metav1.ConditionFalse)

--- a/tests/e2e/progressive-pipeline-e2e/pipeline_test.go
+++ b/tests/e2e/progressive-pipeline-e2e/pipeline_test.go
@@ -262,16 +262,22 @@ var _ = Describe("Progressive Pipeline and ISBService E2E", Serial, func() {
 		// Verify ISBServiceRollout Progressive Status
 		VerifyISBServiceProgressiveFailure(isbServiceRolloutName, GetInstanceName(isbServiceRolloutName, 3), GetInstanceName(isbServiceRolloutName, 4))
 
-		// Now put the isbsvc spec back to what it was before; this will cause the isbsvc and pipeline to both go back to just the "promoted" one
+		// Now put the isbsvc spec back to what it was before; this discontinues the progressive upgrade, so the
+		// "upgrading" isbsvc and pipeline both become "recyclable".
+		// Note: in this scenario the "upgrading" pipeline is permanently Failed (it's pinned to the failed "upgrading"
+		// isbsvc, which is stuck on the invalid Jetstream version), so it can never drain. Therefore it isn't deleted
+		// promptly; it remains "recyclable" until the maxRecyclableDurationMinutes expiry, which is well beyond this
+		// test's timeout. The "upgrading" isbsvc likewise can't be deleted while the pipeline still uses it. So rather
+		// than verify deletion, we verify both settle into the "recyclable" state.
 		UpdateISBService(isbServiceRolloutName, initialISBServiceSpec)
-		VerifyPipelineDeletion(GetInstanceName(pipelineRolloutName, 1))     // the "Upgrading" one
-		VerifyISBServiceDeletion(GetInstanceName(isbServiceRolloutName, 4)) // the "Upgrading" one
-		CheckConsistently("verifying just the original promoted Pipeline remains", func() bool {
+		VerifyPipelineUpgradeState(Namespace, GetInstanceName(pipelineRolloutName, 1), string(common.LabelValueUpgradeRecyclable), nil)     // the "Upgrading" one
+		VerifyISBServiceUpgradeState(Namespace, GetInstanceName(isbServiceRolloutName, 4), string(common.LabelValueUpgradeRecyclable), nil) // the "Upgrading" one
+		CheckConsistently("verifying trial Pipeline recycled", func() bool {
 			pipelineName, _ := GetPromotedPipelineName(Namespace, pipelineRolloutName)
 			return GetNumberOfNonRecyclableChildren(GetGVRForPipeline(), Namespace, pipelineRolloutName) == 1 && pipelineName == promotedPipelineName
 		}).Should(BeTrue())
 
-		CheckConsistently("verifying just the original promoted InterstepBufferService remains", func() bool {
+		CheckConsistently("verifying trial InterstepBufferService recycled", func() bool {
 			isbsvcName, _ := GetPromotedISBServiceName(Namespace, isbServiceRolloutName)
 			return GetNumberOfNonRecyclableChildren(GetGVRForISBService(), Namespace, isbServiceRolloutName) == 1 && isbsvcName == promotedISBSvc.GetName()
 		}).Should(BeTrue())


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->

Fixes #892 #929 

### Modifications

1. Make it so a Pipeline force draining won't ever switch to using a newer isbsvc (which will never work, since a Pipeline can't switch isbsvc) - it always remains on the original isbsvc for this reason
2. If a Pipeline is briefly in a "Failed" state while it's trying to drain (prior to force drain), give it some time before giving up. 
3. Make sure "recyclable-start-time" annotation is only set once, when resources enters recyclable state.



### Backward (and forward) incompatibilities

The annotation "force-drain-failure-start-time" changed its name - this would only affect Pipelines in the middle of transient failure, so should be unusual and not terribly consequential.

