### PR TITLE
fix: don't require NumaflowControllerRollout to start with 'numaflow-controller'

### DIFF
--- a/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
+++ b/config/crd/bases/numaplane.numaproj.io_numaflowcontrollerrollouts.yaml
@@ -176,9 +176,6 @@ spec:
                 type: string
             type: object
         type: object
-        x-kubernetes-validations:
-        - message: The metadata name must start with 'numaflow-controller'
-          rule: self.metadata.name.matches('^numaflow-controller.*')
     served: true
     storage: true
     subresources:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1155,9 +1155,6 @@ spec:
                 type: string
             type: object
         type: object
-        x-kubernetes-validations:
-        - message: The metadata name must start with 'numaflow-controller'
-          rule: self.metadata.name.matches('^numaflow-controller.*')
     served: true
     storage: true
     subresources:

--- a/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller_ginkgo_test.go
+++ b/internal/controller/numaflowcontrollerrollout/numaflowcontrollerrollout_controller_ginkgo_test.go
@@ -53,15 +53,6 @@ var _ = Describe("NumaflowControllerRollout Controller", Ordered, func() {
 			},
 		}
 
-		It("Should throw a CR validation error", func() {
-			By("Creating a NumaflowControllerRollout resource with an invalid name")
-			resource := numaflowControllerResource
-			resource.Name = "test-numaflow-controller"
-			err := ctlrcommon.TestK8sClient.Create(ctx, &resource)
-			Expect(err).NotTo(Succeed())
-			Expect(err.Error()).To(ContainSubstring("The metadata name must start with 'numaflow-controller'"))
-		})
-
 		It("Should throw duplicate resource error", func() {
 			By("Creating duplicate NumaflowControllerRollout resource with the same name")
 			resource := numaflowControllerResource

--- a/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
+++ b/pkg/apis/numaplane/v1alpha1/numaflowcontrollerrollout_types.go
@@ -44,7 +44,6 @@ type NumaflowControllerRolloutStatus struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:validation:XValidation:rule="self.metadata.name.matches('^numaflow-controller.*')",message="The metadata name must start with 'numaflow-controller'"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current phase"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.controller.version",description="The desired Numaflow Controller version"


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->

<!-- Does this PR fix an issue -->



### Modifications

If a user is using a `namePrefix` on their kustomization.yaml, then the NumaflowControllerRollout will not be named 'numaflow-controller'. We don't need this restriction on the CRD.


### Verification

Created a NumaflowControllerRollout with a name not prefixed by 'numaflow-controller'. Observed that this created a NumaflowController with the same name, and that the usual numaflow manifests were all deployed with their usual names. Created ISBServiceRollout and PipelineRollout. 

Then deleted PipelineRollout -> ISBServiceRollout -> NumaflowControllerRollout.

### Backward (and forward) incompatibilities

<!-- TODO: Considering the resources that have previously rolled out to clusters, do you see any issues related to this PR being able to correctly process them? Or is there any backward incompatibility for our CRDs? What if we had to revert the change? What would happen? (not a showstopper but something to prepare for) -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the name-format restriction for `NumaflowControllerRollout` resources, so valid custom resource names are no longer blocked by a prefix rule.
  * Updated the installed cluster configuration to match the new, less restrictive behavior.
  * Removed the related validation test that expected the old naming error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->